### PR TITLE
Polish wiki sidebar interactions and enlarge Mermaid charts

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,6 +110,17 @@
           width 0.2s ease;
       }
 
+      .diagram-wrap .mermaid {
+        display: block;
+        width: 100%;
+      }
+
+      .diagram-wrap .mermaid svg {
+        width: 118%;
+        max-width: 118%;
+        height: auto;
+      }
+
       .sidebar-topbar {
         display: flex;
         align-items: center;
@@ -190,6 +201,11 @@
           padding: 32px 16px;
           margin-left: var(--sidebar-collapsed) !important;
           width: calc(100% - var(--sidebar-collapsed));
+        }
+
+        .diagram-wrap .mermaid svg {
+          width: 108%;
+          max-width: 108%;
         }
 
         body:not(.sidebar-collapsed) .sidebar {


### PR DESCRIPTION
This pull request updates the styling for Mermaid diagrams within the `.diagram-wrap` container in `index.html` to improve their display and responsiveness. The changes focus on ensuring diagrams use the full available width and scale appropriately, especially within different sidebar states.

Diagram styling improvements:

* Set `.diagram-wrap .mermaid` to `display: block` and `width: 100%` to ensure Mermaid diagrams fill the container width.
* Increased the width of `.diagram-wrap .mermaid svg` to 118% (and max-width to 118%) for general display, and to 108% when the sidebar is collapsed, making diagrams more readable and visually prominent. [[1]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R113-R123) [[2]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R206-R210)