### PR TITLE
Update wiki title, Open Graph metadata, and sidebar logo text

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsManagerConfiguration">
-    <option name="CHECK_CODE_SMELLS_BEFORE_PROJECT_COMMIT" value="false" />
-    <option name="CHECK_NEW_TODO" value="false" />
-    <option name="NON_MODAL_COMMIT_POSTPONE_SLOW_CHECKS" value="false" />
-  </component>
-</project>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="favicon.svg" />
-    <title>Agent Dashboard — Project Wiki</title>
+    <title>Claude Code Agent Monitor - Project Wiki</title>
     <meta
       name="description"
       content="Comprehensive technical wiki for Agent Dashboard — a real-time monitoring platform for Claude Code agent activity."
@@ -20,7 +20,7 @@
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Agent Dashboard" />
-    <meta property="og:title" content="Agent Dashboard — Project Wiki" />
+    <meta property="og:title" content="Claude Code Agent Monitor - Project Wiki" />
     <meta
       property="og:description"
       content="Comprehensive technical wiki for Agent Dashboard — a real-time monitoring platform for Claude Code agent activity."
@@ -36,7 +36,7 @@
 
     <!-- Twitter / X Card -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Agent Dashboard — Project Wiki" />
+    <meta name="twitter:title" content="Claude Code Agent Monitor - Project Wiki" />
     <meta
       name="twitter:description"
       content="Real-time monitoring platform for Claude Code agent activity. Sessions, Kanban board, analytics, WebSocket push."

--- a/index.html
+++ b/index.html
@@ -232,7 +232,7 @@
             <a href="#hero" class="sidebar-logo">
               <div class="logo-icon">⬡</div>
               <div class="logo-text">
-                Agent Dashboard
+                Claude Code Agent Monitor
                 <span class="logo-sub">Project Wiki</span>
               </div>
             </a>


### PR DESCRIPTION
This pull request updates the project branding throughout the `index.html` file, changing references from "Agent Dashboard" to "Claude Code Agent Monitor." These changes ensure consistency in how the project is presented across page titles, meta tags, and visible UI elements. Additionally, it removes the `.idea/misc.xml` configuration file.

Branding updates in `index.html`:

* Changed the page `<title>`, Open Graph `og:title`, Twitter card `twitter:title`, and sidebar logo text from "Agent Dashboard" to "Claude Code Agent Monitor" for consistent branding. [[1]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L7-R7) [[2]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L23-R23) [[3]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L39-R39) [[4]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L235-R235)

Project configuration:

* Removed `.idea/misc.xml`, cleaning up project-specific IDE configuration files.