### PR TITLE
Implement scroll reveal effect for content blocks in script.js and styles.css

### DIFF
--- a/index.html
+++ b/index.html
@@ -2345,7 +2345,7 @@ npm run install-hooks</code></pre>
 
         const saved = localStorage.getItem(key);
         if (saved === null) {
-          applyCollapsed(false);
+          applyCollapsed(mobileQuery.matches);
         } else {
           applyCollapsed(saved === "1");
         }

--- a/wiki/script.js
+++ b/wiki/script.js
@@ -93,6 +93,64 @@ mermaid.initialize({
   sections.forEach((s) => observer.observe(s));
 })();
 
+/* ─── Scroll reveal for content blocks ──────────────────────────────────── */
+(function () {
+  const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+  const selectors = [
+    "#hero > *",
+    "main section > *",
+    "main section .feature-grid > *",
+    "main section .quick-start-grid > *",
+    "main section .stats-row > *",
+    "main section .pipeline > *",
+    "main section .route-list > *",
+    "main .wiki-footer > *",
+  ];
+
+  const targets = Array.from(document.querySelectorAll(selectors.join(","))).filter(
+    (element, index, collection) => collection.indexOf(element) === index
+  );
+  const targetSet = new Set(targets);
+
+  if (targets.length === 0) return;
+
+  const revealImmediately = () => {
+    targets.forEach((target) => target.classList.add("is-visible"));
+  };
+
+  targets.forEach((target) => {
+    target.classList.add("reveal-on-scroll");
+
+    const parent = target.parentElement;
+    if (!parent) return;
+
+    const revealSiblings = Array.from(parent.children).filter((child) => targetSet.has(child));
+    const revealIndex = revealSiblings.indexOf(target);
+    target.style.setProperty("--reveal-delay", `${Math.min(revealIndex * 70, 350)}ms`);
+  });
+
+  if (prefersReducedMotion.matches || !("IntersectionObserver" in window)) {
+    revealImmediately();
+    return;
+  }
+
+  const observer = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (!entry.isIntersecting) return;
+        entry.target.classList.add("is-visible");
+        observer.unobserve(entry.target);
+      });
+    },
+    {
+      rootMargin: "0px 0px -12% 0px",
+      threshold: 0.12,
+    }
+  );
+
+  targets.forEach((target) => observer.observe(target));
+})();
+
 /* ─── Sidebar search filter ──────────────────────────────────────────────── */
 (function () {
   const input = document.getElementById("sidebar-search");

--- a/wiki/style.css
+++ b/wiki/style.css
@@ -49,6 +49,25 @@ body {
   font-size: 15px;
 }
 
+/* ─── Scroll Reveal ─────────────────────────────────────────────────────── */
+.reveal-on-scroll {
+  --reveal-delay: 0ms;
+  opacity: 0;
+  transform: translate3d(0, 24px, 0) scale(0.985);
+  filter: blur(10px);
+  transition:
+    opacity 0.72s cubic-bezier(0.22, 1, 0.36, 1) var(--reveal-delay),
+    transform 0.72s cubic-bezier(0.22, 1, 0.36, 1) var(--reveal-delay),
+    filter 0.72s cubic-bezier(0.22, 1, 0.36, 1) var(--reveal-delay);
+  will-change: opacity, transform, filter;
+}
+
+.reveal-on-scroll.is-visible {
+  opacity: 1;
+  transform: translate3d(0, 0, 0) scale(1);
+  filter: blur(0);
+}
+
 /* ─── Layout ────────────────────────────────────────────────────────────── */
 .wiki-layout {
   display: flex;
@@ -933,6 +952,20 @@ tr:hover td {
   }
   .hero h1 {
     font-size: 32px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  .reveal-on-scroll {
+    opacity: 1;
+    transform: none;
+    filter: none;
+    transition: none;
+    will-change: auto;
   }
 }
 


### PR DESCRIPTION
This pull request introduces a new scroll reveal animation feature for content blocks in the wiki, enhancing the user experience with smooth entrance effects. The feature is implemented in both JavaScript and CSS, with accessibility considerations for users who prefer reduced motion. Additionally, a minor logic improvement is made to the collapsed state handling in `index.html`.

Scroll reveal animation feature:

* Added a scroll reveal animation for content blocks using the `.reveal-on-scroll` class, including staggered delays and blur effects, with transitions defined in `wiki/style.css`.
* Implemented scroll reveal logic in `wiki/script.js`, targeting various content sections and using `IntersectionObserver` for triggering animations as elements enter the viewport. The feature respects the user's reduced motion preference and falls back gracefully if unsupported.
* Provided accessibility support for reduced motion by disabling scroll reveal transitions and effects when the `prefers-reduced-motion: reduce` media query is active.

Minor logic improvement:

* Improved the initial collapsed state logic in `index.html` to use the mobile media query for better responsiveness.