### PR TITLE
Add Dockerfile and GHCR push to CI pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+node_modules/
+client/node_modules/
+client/dist/
+data/
+.git/
+.github/
+*.md
+!README.md
+images/
+wiki/
+index.html
+og-image.svg
+favicon.svg
+.prettierrc
+.prettierignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI / CD
+name: CI / CD Pipeline for Claude Code Agent Monitor
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI / CD
 
 on:
   push:
@@ -6,30 +6,40 @@ on:
   pull_request:
     branches: ["**"]
 
+env:
+  NODE_VERSION: "20"
+  IMAGE_NAME: claude-code-agent-monitor
+
 jobs:
+  # ────────────────────────────────────────────────────────────────
+  #  🧹 Format Check                                               #
+  # ────────────────────────────────────────────────────────────────
   format:
-    name: Check Formatting
+    name: "🧹 Check Formatting"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
       - name: Install root dependencies
         run: npm ci
       - name: Check formatting
         run: npm run format:check
 
+  # ────────────────────────────────────────────────────────────────
+  #  🧪 Tests                                                      #
+  # ────────────────────────────────────────────────────────────────
   test:
-    name: Run Tests
+    name: "🧪 Run Tests"
     runs-on: ubuntu-latest
     needs: format
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
       - name: Install root dependencies
         run: npm ci
@@ -40,15 +50,18 @@ jobs:
       - name: Run client tests
         run: npm run test:client
 
+  # ────────────────────────────────────────────────────────────────
+  #  🏗️ Build Client                                               #
+  # ────────────────────────────────────────────────────────────────
   build:
-    name: Build & Upload Artifact
+    name: "🏗️ Build & Upload Artifact"
     runs-on: ubuntu-latest
     needs: test
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
       - name: Install root dependencies
         run: npm ci
@@ -62,3 +75,47 @@ jobs:
           name: client-dist
           path: client/dist/
           retention-days: 7
+
+  # ────────────────────────────────────────────────────────────────
+  #  🐳 Docker Build & Push to GHCR                                #
+  #   Only pushes on push to main/master (not PRs)                 #
+  # ────────────────────────────────────────────────────────────────
+  docker:
+    name: "🐳 Docker → GHCR"
+    runs-on: ubuntu-latest
+    needs: [test, build]
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,prefix=
+            type=ref,event=branch
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,3 +119,87 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  # ────────────────────────────────────────────────────────────────
+  #  🎉 Pipeline Summary                                            #
+  #   Runs after all jobs — reports final status to step summary    #
+  # ────────────────────────────────────────────────────────────────
+  pipeline-status:
+    name: "🎉 Pipeline Status"
+    if: always()
+    runs-on: ubuntu-latest
+    needs: [format, test, build, docker]
+    steps:
+      - name: Determine overall result
+        id: result
+        run: |
+          # Map each job result
+          FORMAT="${{ needs.format.result }}"
+          TEST="${{ needs.test.result }}"
+          BUILD="${{ needs.build.result }}"
+          DOCKER="${{ needs.docker.result }}"
+
+          echo "format=$FORMAT" >> "$GITHUB_OUTPUT"
+          echo "test=$TEST" >> "$GITHUB_OUTPUT"
+          echo "build=$BUILD" >> "$GITHUB_OUTPUT"
+          echo "docker=$DOCKER" >> "$GITHUB_OUTPUT"
+
+          # Overall: fail if any required job failed
+          if [[ "$FORMAT" == "failure" || "$TEST" == "failure" || "$BUILD" == "failure" || "$DOCKER" == "failure" ]]; then
+            echo "overall=failure" >> "$GITHUB_OUTPUT"
+          elif [[ "$FORMAT" == "cancelled" || "$TEST" == "cancelled" || "$BUILD" == "cancelled" || "$DOCKER" == "cancelled" ]]; then
+            echo "overall=cancelled" >> "$GITHUB_OUTPUT"
+          else
+            echo "overall=success" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Status icon helper
+        id: icons
+        run: |
+          icon() {
+            case "$1" in
+              success)   echo "✅" ;;
+              failure)   echo "❌" ;;
+              cancelled) echo "⚪" ;;
+              skipped)   echo "⏭️" ;;
+              *)         echo "❓" ;;
+            esac
+          }
+          echo "format=$(icon ${{ steps.result.outputs.format }})" >> "$GITHUB_OUTPUT"
+          echo "test=$(icon ${{ steps.result.outputs.test }})" >> "$GITHUB_OUTPUT"
+          echo "build=$(icon ${{ steps.result.outputs.build }})" >> "$GITHUB_OUTPUT"
+          echo "docker=$(icon ${{ steps.result.outputs.docker }})" >> "$GITHUB_OUTPUT"
+          echo "overall=$(icon ${{ steps.result.outputs.overall }})" >> "$GITHUB_OUTPUT"
+
+      - name: Write pipeline summary
+        run: |
+          PUSH_INFO=""
+          if [[ "${{ github.event_name }}" == "push" && ( "${{ github.ref }}" == "refs/heads/main" || "${{ github.ref }}" == "refs/heads/master" ) ]]; then
+            PUSH_INFO="| **Docker Image** | \`ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest\` |"
+          fi
+
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## ${{ steps.icons.outputs.overall }} CI / CD Pipeline — ${GITHUB_REF_NAME}
+
+          | Stage | Status | Job |
+          |-------|--------|-----|
+          | Formatting | ${{ steps.icons.outputs.format }} \`${{ steps.result.outputs.format }}\` | \`format\` |
+          | Tests | ${{ steps.icons.outputs.test }} \`${{ steps.result.outputs.test }}\` | \`test\` |
+          | Client Build | ${{ steps.icons.outputs.build }} \`${{ steps.result.outputs.build }}\` | \`build\` |
+          | Docker | ${{ steps.icons.outputs.docker }} \`${{ steps.result.outputs.docker }}\` | \`docker\` |
+
+          | Detail | Value |
+          |--------|-------|
+          | **Commit** | [\`${GITHUB_SHA::7}\`](${{ github.server_url }}/${{ github.repository }}/commit/${GITHUB_SHA}) |
+          | **Branch** | \`${GITHUB_REF_NAME}\` |
+          | **Trigger** | \`${{ github.event_name }}\` by \`${{ github.actor }}\` |
+          | **Runner** | \`ubuntu-latest\` · Node ${{ env.NODE_VERSION }} |
+          ${PUSH_INFO}
+          | **Completed** | $(date -u +"%Y-%m-%d %H:%M:%S UTC") |
+          EOF
+
+      - name: Fail pipeline if any job failed
+        if: steps.result.outputs.overall != 'success'
+        run: |
+          echo "::error::Pipeline finished with status: ${{ steps.result.outputs.overall }}"
+          exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# ── Stage 1: Install server production deps (with native build tools) ──
+FROM node:20-alpine AS server-deps
+RUN apk add --no-cache python3 make g++
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+# ── Stage 2: Build React client ───────────────────────────────────────
+FROM node:20-alpine AS client-build
+WORKDIR /app/client
+COPY client/package.json client/package-lock.json ./
+RUN npm ci
+COPY client/ ./
+RUN npm run build
+
+# ── Stage 3: Production runtime ───────────────────────────────────────
+FROM node:20-alpine
+WORKDIR /app
+
+COPY --from=server-deps /app/node_modules ./node_modules/
+COPY package.json ./
+COPY server/ ./server/
+COPY scripts/ ./scripts/
+COPY statusline/ ./statusline/
+COPY --from=client-build /app/client/dist ./client/dist/
+
+RUN mkdir -p data
+
+EXPOSE 4820
+
+ENV NODE_ENV=production
+
+CMD ["node", "server/index.js"]


### PR DESCRIPTION
- Multi-stage Dockerfile: build native deps, build client, slim runtime
- .dockerignore to keep context small
- CI docker job builds image on every push, pushes to GHCR on main/master
- Tags: commit SHA, branch name, latest (default branch only)
- GHA build cache for fast rebuilds

This pull request introduces improvements to the CI/CD pipeline and adds Docker support for the project. The changes include a new multi-stage `Dockerfile` for efficient builds, an updated `.dockerignore` for cleaner Docker images, and enhancements to the GitHub Actions workflow to support Docker builds and pushes to GitHub Container Registry (GHCR).

**CI/CD Pipeline and Docker Integration**

* Added a multi-stage `Dockerfile` to build both server and client, optimize dependencies, and prepare production runtime.
* Created a `.dockerignore` file to exclude unnecessary files and directories from Docker builds, reducing image size and build time.

**GitHub Actions Workflow Enhancements**

* Updated `.github/workflows/ci.yml` to include environment variables, improved job naming, and added themed sections for formatting, testing, and building. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL1-R42) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR53-R64)
* Added a new Docker job to the workflow for building and pushing Docker images to GHCR, triggered only on pushes to main/master branches.