### PR TITLE
Fix cross-platform compatibility for npm start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev:server": "node --watch server/index.js",
     "dev:client": "cd client && npm run dev",
     "build": "cd client && npm run build",
-    "start": "NODE_ENV=production node server/index.js",
+    "start": "node server/index.js",
     "setup": "npm install && cd client && npm install",
     "install-hooks": "node scripts/install-hooks.js",
     "seed": "node scripts/seed.js",

--- a/server/index.js
+++ b/server/index.js
@@ -1,3 +1,5 @@
+if (!process.env.NODE_ENV) process.env.NODE_ENV = "production";
+
 const express = require("express");
 const cors = require("cors");
 const path = require("path");


### PR DESCRIPTION
Move NODE_ENV assignment from shell command (Unix-only syntax) into server/index.js so the start script works on Windows, Linux, and macOS without needing cross-env or similar dependencies.

