### PR TITLE
Remove forceful issue templates from documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,0 @@
-blank_issues_enabled: false
-contact_links:
-  - name: Security Vulnerability
-    url: https://github.com/hoangsonww/WealthWise-Personal-Finance-App/security/advisories/new
-    about: Please report security vulnerabilities privately via GitHub Security Advisories — do not open a public issue.


### PR DESCRIPTION
This pull request makes a small change to the issue template configuration by removing the security vulnerability contact link and disabling blank issues.

* Removed the security vulnerability contact link and disabled blank issues in `.github/ISSUE_TEMPLATE/config.yml`.