### PR TITLE
feat: add subagent hierarchy visualization

### DIFF
--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -1,6 +1,17 @@
 import { useEffect, useState, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
-import { FolderOpen, Bot, Zap, DollarSign, Activity, ArrowRight, RefreshCw } from "lucide-react";
+import {
+  FolderOpen,
+  Bot,
+  Zap,
+  DollarSign,
+  Activity,
+  ArrowRight,
+  RefreshCw,
+  GitBranch,
+  ChevronDown,
+  ChevronRight,
+} from "lucide-react";
 import { api } from "../lib/api";
 import { eventBus } from "../lib/eventBus";
 import { StatCard } from "../components/StatCard";
@@ -16,6 +27,8 @@ export function Dashboard() {
   const [activeAgents, setActiveAgents] = useState<Agent[]>([]);
   const [recentEvents, setRecentEvents] = useState<DashboardEvent[]>([]);
   const [totalCost, setTotalCost] = useState<number | null>(null);
+  const [allSubagents, setAllSubagents] = useState<Agent[]>([]);
+  const [expandedAgents, setExpandedAgents] = useState<Set<string>>(new Set());
   const [error, setError] = useState<string | null>(null);
 
   const load = useCallback(async () => {
@@ -29,10 +42,23 @@ export function Dashboard() {
         api.pricing.totalCost(),
       ]);
       setStats(statsRes);
-      setActiveAgents([...workingRes.agents, ...connectedRes.agents, ...idleRes.agents]);
+      const active = [...workingRes.agents, ...connectedRes.agents, ...idleRes.agents];
+      setActiveAgents(active);
       setRecentEvents(eventsRes.events);
       setTotalCost(costRes.total_cost);
       setError(null);
+
+      // Fetch all subagents for each active main agent's session
+      const activeSessionIds = [
+        ...new Set(active.filter((a) => a.type === "main").map((a) => a.session_id)),
+      ];
+      const subagentResults = await Promise.all(
+        activeSessionIds.map((sid) => api.agents.list({ session_id: sid, limit: 100 }))
+      );
+      const subs = subagentResults
+        .flatMap((r) => r.agents)
+        .filter((a) => a.type === "subagent");
+      setAllSubagents(subs);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load data");
     }
@@ -43,6 +69,19 @@ export function Dashboard() {
     const interval = setInterval(load, 10000);
     return () => clearInterval(interval);
   }, [load]);
+
+  // Auto-expand agents with active subagents
+  useEffect(() => {
+    const parentsWithActive = new Set<string>();
+    for (const a of allSubagents) {
+      if (a.parent_agent_id && (a.status === "working" || a.status === "connected")) {
+        parentsWithActive.add(a.parent_agent_id);
+      }
+    }
+    if (parentsWithActive.size > 0) {
+      setExpandedAgents((prev) => new Set([...prev, ...parentsWithActive]));
+    }
+  }, [allSubagents]);
 
   useEffect(() => {
     return eventBus.subscribe((msg: WSMessage) => {
@@ -85,7 +124,7 @@ export function Dashboard() {
       </div>
 
       {/* Stats row */}
-      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
         <StatCard
           label="Total Sessions"
           value={stats ? fmt(stats.total_sessions) : "-"}
@@ -98,6 +137,13 @@ export function Dashboard() {
           value={stats?.active_agents ?? "-"}
           icon={Bot}
           accentColor="text-emerald-400"
+        />
+        <StatCard
+          label="Active Subagents"
+          value={allSubagents.filter((a) => a.status === "working" || a.status === "connected").length}
+          icon={GitBranch}
+          accentColor="text-violet-400"
+          trend={`${allSubagents.length} total`}
         />
         <StatCard
           label="Events Today"
@@ -142,10 +188,88 @@ export function Dashboard() {
               description="Agents will appear here when a Claude Code session is running."
             />
           ) : (
-            <div className="space-y-3">
-              {activeAgents.slice(0, 5).map((agent) => (
-                <AgentCard key={agent.id} agent={agent} />
-              ))}
+            <div className="space-y-2">
+              {activeAgents
+                .filter((a) => a.type === "main")
+                .slice(0, 5)
+                .map((main) => {
+                  const children = allSubagents.filter(
+                    (a) => a.parent_agent_id === main.id
+                  );
+                  const isExpanded = expandedAgents.has(main.id);
+                  const hasChildren = children.length > 0;
+                  const activeCount = children.filter(
+                    (c) => c.status === "working" || c.status === "connected"
+                  ).length;
+
+                  return (
+                    <div key={main.id}>
+                      <div className="flex items-center gap-1">
+                        {hasChildren ? (
+                          <button
+                            onClick={() =>
+                              setExpandedAgents((prev) => {
+                                const next = new Set(prev);
+                                if (next.has(main.id)) next.delete(main.id);
+                                else next.add(main.id);
+                                return next;
+                              })
+                            }
+                            className="p-1 text-gray-500 hover:text-gray-300 transition-colors"
+                          >
+                            {isExpanded ? (
+                              <ChevronDown className="w-4 h-4" />
+                            ) : (
+                              <ChevronRight className="w-4 h-4" />
+                            )}
+                          </button>
+                        ) : (
+                          <span className="w-6" />
+                        )}
+                        <div className="flex-1">
+                          <AgentCard agent={main} />
+                        </div>
+                      </div>
+
+                      {hasChildren && isExpanded && (
+                        <div className="ml-6 mt-1 space-y-1 border-l-2 border-violet-500/20 pl-3">
+                          {children.map((sub) => (
+                            <div key={sub.id} className="flex items-center gap-2">
+                              <GitBranch className="w-3 h-3 text-violet-400 flex-shrink-0" />
+                              <div className="flex-1">
+                                <AgentCard agent={sub} />
+                              </div>
+                            </div>
+                          ))}
+                        </div>
+                      )}
+
+                      {hasChildren && !isExpanded && (
+                        <button
+                          onClick={() =>
+                            setExpandedAgents((prev) => new Set([...prev, main.id]))
+                          }
+                          className="ml-7 mt-1 text-[11px] text-violet-400 hover:text-violet-300 transition-colors"
+                        >
+                          {children.length} subagent{children.length !== 1 ? "s" : ""}
+                          {activeCount > 0 && (
+                            <span className="text-emerald-400 ml-1">
+                              ({activeCount} active)
+                            </span>
+                          )}
+                        </button>
+                      )}
+                    </div>
+                  );
+                })}
+              {/* Show active subagents without a main agent in the active list */}
+              {activeAgents
+                .filter((a) => a.type === "subagent")
+                .map((agent) => (
+                  <div key={agent.id} className="ml-7">
+                    <AgentCard agent={agent} />
+                  </div>
+                ))}
             </div>
           )}
         </div>

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -55,9 +55,7 @@ export function Dashboard() {
       const subagentResults = await Promise.all(
         activeSessionIds.map((sid) => api.agents.list({ session_id: sid, limit: 100 }))
       );
-      const subs = subagentResults
-        .flatMap((r) => r.agents)
-        .filter((a) => a.type === "subagent");
+      const subs = subagentResults.flatMap((r) => r.agents).filter((a) => a.type === "subagent");
       setAllSubagents(subs);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load data");
@@ -140,7 +138,9 @@ export function Dashboard() {
         />
         <StatCard
           label="Active Subagents"
-          value={allSubagents.filter((a) => a.status === "working" || a.status === "connected").length}
+          value={
+            allSubagents.filter((a) => a.status === "working" || a.status === "connected").length
+          }
           icon={GitBranch}
           accentColor="text-violet-400"
           trend={`${allSubagents.length} total`}
@@ -193,9 +193,7 @@ export function Dashboard() {
                 .filter((a) => a.type === "main")
                 .slice(0, 5)
                 .map((main) => {
-                  const children = allSubagents.filter(
-                    (a) => a.parent_agent_id === main.id
-                  );
+                  const children = allSubagents.filter((a) => a.parent_agent_id === main.id);
                   const isExpanded = expandedAgents.has(main.id);
                   const hasChildren = children.length > 0;
                   const activeCount = children.filter(
@@ -224,7 +222,9 @@ export function Dashboard() {
                             )}
                           </button>
                         ) : (
-                          <span className="w-6" />
+                          <span className="flex items-center justify-center w-6">
+                            <span className="w-1.5 h-1.5 rounded-full bg-gray-600" />
+                          </span>
                         )}
                         <div className="flex-1">
                           <AgentCard agent={main} />
@@ -246,16 +246,12 @@ export function Dashboard() {
 
                       {hasChildren && !isExpanded && (
                         <button
-                          onClick={() =>
-                            setExpandedAgents((prev) => new Set([...prev, main.id]))
-                          }
+                          onClick={() => setExpandedAgents((prev) => new Set([...prev, main.id]))}
                           className="ml-7 mt-1 text-[11px] text-violet-400 hover:text-violet-300 transition-colors"
                         >
                           {children.length} subagent{children.length !== 1 ? "s" : ""}
                           {activeCount > 0 && (
-                            <span className="text-emerald-400 ml-1">
-                              ({activeCount} active)
-                            </span>
+                            <span className="text-emerald-400 ml-1">({activeCount} active)</span>
                           )}
                         </button>
                       )}

--- a/client/src/pages/SessionDetail.tsx
+++ b/client/src/pages/SessionDetail.tsx
@@ -213,7 +213,9 @@ export function SessionDetail() {
                               )}
                             </button>
                           ) : (
-                            <span className="w-6" />
+                            <span className="flex items-center justify-center w-6">
+                              <span className="w-1.5 h-1.5 rounded-full bg-gray-600" />
+                            </span>
                           )}
                           <div className="flex-1">
                             <AgentCard agent={main} />
@@ -237,9 +239,7 @@ export function SessionDetail() {
                         {/* Subagent count badge when collapsed */}
                         {hasChildren && !isExpanded && (
                           <button
-                            onClick={() =>
-                              setExpandedAgents((prev) => new Set([...prev, main.id]))
-                            }
+                            onClick={() => setExpandedAgents((prev) => new Set([...prev, main.id]))}
                             className="ml-7 mt-1 text-[11px] text-violet-400 hover:text-violet-300 transition-colors"
                           >
                             {children.length} subagent{children.length !== 1 ? "s" : ""}

--- a/client/src/pages/SessionDetail.tsx
+++ b/client/src/pages/SessionDetail.tsx
@@ -1,6 +1,17 @@
 import { useEffect, useState, useCallback } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { ArrowLeft, Bot, Clock, FolderOpen, Cpu, RefreshCw, DollarSign } from "lucide-react";
+import {
+  ArrowLeft,
+  Bot,
+  Clock,
+  FolderOpen,
+  Cpu,
+  RefreshCw,
+  DollarSign,
+  ChevronDown,
+  ChevronRight,
+  GitBranch,
+} from "lucide-react";
 import { api } from "../lib/api";
 import { eventBus } from "../lib/eventBus";
 import { AgentCard } from "../components/AgentCard";
@@ -17,6 +28,10 @@ export function SessionDetail() {
   const [cost, setCost] = useState<CostResult | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [expandedAgents, setExpandedAgents] = useState<Set<string>>(() => {
+    // Auto-expand on first render; useEffect below handles live updates
+    return new Set<string>();
+  });
 
   const load = useCallback(async () => {
     if (!id) return;
@@ -40,6 +55,23 @@ export function SessionDetail() {
   useEffect(() => {
     load();
   }, [load]);
+
+  // Auto-expand agents that have working subagents
+  useEffect(() => {
+    const parentsWithActiveChildren = new Set<string>();
+    for (const a of agents) {
+      if (
+        a.type === "subagent" &&
+        a.parent_agent_id &&
+        (a.status === "working" || a.status === "connected")
+      ) {
+        parentsWithActiveChildren.add(a.parent_agent_id);
+      }
+    }
+    if (parentsWithActiveChildren.size > 0) {
+      setExpandedAgents((prev) => new Set([...prev, ...parentsWithActiveChildren]));
+    }
+  }, [agents]);
 
   useEffect(() => {
     return eventBus.subscribe((msg) => {
@@ -133,10 +165,106 @@ export function SessionDetail() {
         {agents.length === 0 ? (
           <p className="text-sm text-gray-500">No agents recorded.</p>
         ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-            {agents.map((agent) => (
-              <AgentCard key={agent.id} agent={agent} />
-            ))}
+          <div className="space-y-2">
+            {(() => {
+              const mainAgents = agents.filter((a) => a.type === "main");
+              const subagentsByParent = new Map<string, Agent[]>();
+              for (const a of agents) {
+                if (a.type === "subagent" && a.parent_agent_id) {
+                  const list = subagentsByParent.get(a.parent_agent_id) || [];
+                  list.push(a);
+                  subagentsByParent.set(a.parent_agent_id, list);
+                }
+              }
+              // Subagents with no matching parent (orphans) get shown at top level
+              const orphans = agents.filter(
+                (a) =>
+                  a.type === "subagent" &&
+                  (!a.parent_agent_id || !mainAgents.some((m) => m.id === a.parent_agent_id))
+              );
+
+              return (
+                <>
+                  {mainAgents.map((main) => {
+                    const children = subagentsByParent.get(main.id) || [];
+                    const isExpanded = expandedAgents.has(main.id);
+                    const hasChildren = children.length > 0;
+
+                    return (
+                      <div key={main.id}>
+                        {/* Main agent row */}
+                        <div className="flex items-center gap-1">
+                          {hasChildren ? (
+                            <button
+                              onClick={() =>
+                                setExpandedAgents((prev) => {
+                                  const next = new Set(prev);
+                                  if (next.has(main.id)) next.delete(main.id);
+                                  else next.add(main.id);
+                                  return next;
+                                })
+                              }
+                              className="p-1 text-gray-500 hover:text-gray-300 transition-colors"
+                            >
+                              {isExpanded ? (
+                                <ChevronDown className="w-4 h-4" />
+                              ) : (
+                                <ChevronRight className="w-4 h-4" />
+                              )}
+                            </button>
+                          ) : (
+                            <span className="w-6" />
+                          )}
+                          <div className="flex-1">
+                            <AgentCard agent={main} />
+                          </div>
+                        </div>
+
+                        {/* Subagent children (collapsible) */}
+                        {hasChildren && isExpanded && (
+                          <div className="ml-6 mt-1 space-y-1 border-l-2 border-violet-500/20 pl-3">
+                            {children.map((sub) => (
+                              <div key={sub.id} className="flex items-center gap-2">
+                                <GitBranch className="w-3 h-3 text-violet-400 flex-shrink-0" />
+                                <div className="flex-1">
+                                  <AgentCard agent={sub} />
+                                </div>
+                              </div>
+                            ))}
+                          </div>
+                        )}
+
+                        {/* Subagent count badge when collapsed */}
+                        {hasChildren && !isExpanded && (
+                          <button
+                            onClick={() =>
+                              setExpandedAgents((prev) => new Set([...prev, main.id]))
+                            }
+                            className="ml-7 mt-1 text-[11px] text-violet-400 hover:text-violet-300 transition-colors"
+                          >
+                            {children.length} subagent{children.length !== 1 ? "s" : ""}
+                          </button>
+                        )}
+                      </div>
+                    );
+                  })}
+
+                  {/* Orphaned subagents */}
+                  {orphans.length > 0 && (
+                    <div className="mt-4">
+                      <p className="text-[11px] text-gray-500 mb-2 uppercase tracking-wider">
+                        Unparented Subagents
+                      </p>
+                      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+                        {orphans.map((agent) => (
+                          <AgentCard key={agent.id} agent={agent} />
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </>
+              );
+            })()}
           </div>
         )}
       </div>

--- a/scripts/import-history.js
+++ b/scripts/import-history.js
@@ -92,7 +92,11 @@ async function parseSessionFile(filePath) {
       if (Array.isArray(content)) {
         for (const block of content) {
           if (block.type === "tool_use" && block.name) {
-            toolUses.push({ name: block.name, timestamp: isoTs || firstTimestamp });
+            toolUses.push({
+              name: block.name,
+              timestamp: isoTs || firstTimestamp,
+              input: block.input || null,
+            });
           }
         }
       }
@@ -185,6 +189,66 @@ function importCompactions(dbModule, sessionId, mainAgentId, compactions) {
 }
 
 /**
+ * Create subagent records from Agent tool_use blocks found during import.
+ * Deduplicated by a deterministic ID derived from session + tool_use index.
+ * Returns the number of subagents created.
+ */
+function importSubagents(dbModule, sessionId, mainAgentId, toolUses) {
+  if (!toolUses || toolUses.length === 0) return 0;
+  const { stmts } = dbModule;
+  const insertEvent = dbModule.db.prepare(
+    "INSERT INTO events (session_id, agent_id, event_type, tool_name, summary, data, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)"
+  );
+
+  let created = 0;
+  let agentIndex = 0;
+
+  for (const tu of toolUses) {
+    if (tu.name !== "Agent" || !tu.input) continue;
+    const input = tu.input;
+    agentIndex++;
+
+    const subId = `${sessionId}-subagent-${agentIndex}`;
+    if (stmts.getAgent.get(subId)) continue;
+
+    const rawName =
+      input.description ||
+      input.subagent_type ||
+      (input.prompt ? input.prompt.split("\n")[0].slice(0, 60) : null) ||
+      "Subagent";
+    const subName = rawName.length > 60 ? rawName.slice(0, 57) + "..." : rawName;
+    const ts = tu.timestamp || new Date().toISOString();
+
+    stmts.insertAgent.run(
+      subId,
+      sessionId,
+      subName,
+      "subagent",
+      input.subagent_type || null,
+      "completed",
+      input.prompt ? input.prompt.slice(0, 500) : null,
+      mainAgentId,
+      null
+    );
+    dbModule.db
+      .prepare("UPDATE agents SET started_at = ?, ended_at = ?, updated_at = ? WHERE id = ?")
+      .run(ts, ts, ts, subId);
+
+    insertEvent.run(
+      sessionId,
+      subId,
+      "PreToolUse",
+      "Agent",
+      `Subagent spawned: ${subName} (imported)`,
+      JSON.stringify({ imported: true, subagent_type: input.subagent_type || null }),
+      ts
+    );
+    created++;
+  }
+  return created;
+}
+
+/**
  * Import a parsed session into the database.
  */
 function importSession(dbModule, session) {
@@ -263,6 +327,15 @@ function importSession(dbModule, session) {
       session.compactions
     );
     if (compactCount > 0) backfilled = true;
+
+    // Backfill subagent records from Agent tool_use blocks
+    const subagentCount = importSubagents(
+      dbModule,
+      session.sessionId,
+      mainAgentId,
+      session.toolUses
+    );
+    if (subagentCount > 0) backfilled = true;
 
     return backfilled ? { skipped: false, backfilled: true } : { skipped: true };
   }
@@ -390,6 +463,9 @@ function importSession(dbModule, session) {
 
   // Create compaction agents/events
   importCompactions(dbModule, session.sessionId, mainAgentId, session.compactions);
+
+  // Create subagent records from Agent tool_use blocks
+  importSubagents(dbModule, session.sessionId, mainAgentId, session.toolUses);
 
   for (const [tokenModel, tokens] of Object.entries(session.tokensByModel)) {
     if (tokens.input > 0 || tokens.output > 0 || tokens.cacheRead > 0 || tokens.cacheWrite > 0) {
@@ -601,5 +677,6 @@ module.exports = {
   importAllSessions,
   backfillCompactions,
   importCompactions,
+  importSubagents,
   findCompactionsInFile,
 };


### PR DESCRIPTION
## Summary

- **Collapsible parent/subagent tree UI** on both Dashboard and Session Detail pages — main agents show an expand/collapse chevron when they have subagents, with a violet branch connector line and `GitBranch` icons for child agents
- **"Active Subagents" stat card** on the Dashboard showing live count of working/connected subagents with total count trend
- **Auto-expand** agents that have actively working subagents, so you immediately see what's running
- **Subagent import from history** — `import-history.js` now extracts `Agent` tool_use blocks and creates proper subagent records (with backfill support for existing sessions), so historical sessions display the hierarchy too
- **Orphan handling** — subagents whose parent isn't in the current view are displayed in a separate "Unparented Subagents" section on the Session Detail page

## Motivation

When Claude Code spawns subagents (via the `Agent` tool), the monitor currently shows them as flat, disconnected entries. This makes it hard to understand which subagents belong to which main agent and what's actively running. This PR adds a tree-based hierarchy that mirrors the actual parent-child relationship.

## Files changed

| File | Change |
|------|--------|
| `client/src/pages/Dashboard.tsx` | Subagent fetching, tree UI, stat card, auto-expand |
| `client/src/pages/SessionDetail.tsx` | Hierarchical agent list with expand/collapse |
| `scripts/import-history.js` | `importSubagents()` function + backfill integration |

## Test plan

- [ ] Run `npm run dev` and verify Dashboard shows the "Active Subagents" stat card
- [ ] Start a Claude Code session that spawns subagents and verify they appear nested under the main agent
- [ ] Verify expand/collapse toggle works on both Dashboard and Session Detail
- [ ] Run `node scripts/import-history.js` on existing history and verify subagent records are created
- [ ] Verify re-running import is idempotent (no duplicate subagents)

🤖 Generated with [Claude Code](https://claude.com/claude-code)