### PR TITLE
fix: make better-sqlite3 optional with node:sqlite fallback

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to this project
+# Contributing to Agent Dashboard
 
 Thanks for taking the time to contribute. Please read this guide before opening a PR or issue.
 
@@ -27,66 +27,59 @@ This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.
 
 ### Prerequisites
 
-- Node.js 20+
-- MongoDB 7+ (or Docker)
-- npm 10+
+- Node.js 18+ (22+ recommended for automatic SQLite fallback)
+- npm 9+
 
 ### Setup
 
 ```bash
-git clone https://github.com/<owner>/this project.git
-cd this project
-npm install
-cp .env.example apps/api/.env
-cp .env.example apps/web/.env.local
-# Fill in required values in both .env files
+git clone https://github.com/hoangsonww/Claude-Code-Agent-Monitor.git
+cd Claude-Code-Agent-Monitor
+npm run setup
 npm run dev
 ```
 
-The API runs on `http://localhost:4000` and the web app on `http://localhost:3000`.
+The Express server runs on `http://localhost:4820` and the Vite dev server on `http://localhost:5173`.
 
 ---
 
 ## Development Workflow
 
-The repo is a **Turborepo monorepo** with three packages:
+The repo has two packages:
 
-| Package                      | Path                    | Description            |
-| ---------------------------- | ----------------------- | ---------------------- |
-| `@this project/api`          | `apps/api`              | Express 4 REST API     |
-| `@this project/web`          | `apps/web`              | Next.js 14 frontend    |
-| `@this project/shared-types` | `packages/shared-types` | Zod schemas + TS types |
+| Package | Path | Description |
+| --- | --- | --- |
+| Server | `server/` | Express 4 REST API + WebSocket + SQLite |
+| Client | `client/` | React 18 + Vite + Tailwind CSS SPA |
 
 **Adding a new API endpoint:**
 
-1. Add Zod schema to `packages/shared-types/src/schemas/`
-2. Add route in `apps/api/src/routes/`
-3. Add controller in `apps/api/src/controllers/`
-4. Add service in `apps/api/src/services/`
+1. Add prepared statement(s) to `server/db.js` if new queries are needed
+2. Add route file in `server/routes/`
+3. Mount the router in `server/index.js`
 
 **Adding a new page:**
 
-1. Create `app/(dashboard)/<route>/page.tsx`
-2. Add sidebar link in `components/layout/sidebar.tsx`
-3. Create hooks in `hooks/use-<entity>.ts`
-4. Create components in `components/<entity>/`
+1. Create component in `client/src/pages/`
+2. Add route in `client/src/App.tsx`
+3. Add sidebar link in `client/src/components/Sidebar.tsx`
 
 ---
 
 ## Branching and Commits
 
-- Branch off `main`. Use a short, descriptive branch name:
+- Branch off `master`. Use a short, descriptive branch name:
   - `feat/budget-alerts`
-  - `fix/savings-rate-calculation`
-  - `docs/helm-readme`
-  - `chore/upgrade-mongoose`
+  - `fix/token-counting`
+  - `docs/setup-guide`
+  - `chore/upgrade-vite`
 
 - Commit messages should be concise and use the imperative mood:
-  - `add spending by day-of-week endpoint`
-  - `fix savings rate always returning zero`
-  - `update helm chart for production overlay`
+  - `add per-session cost breakdown endpoint`
+  - `fix stale session detection on resume`
+  - `update Dockerfile to node 22`
 
-- Do not commit directly to `main`.
+- Do not commit directly to `master`.
 
 ---
 
@@ -101,8 +94,7 @@ The repo is a **Turborepo monorepo** with three packages:
 **Before submitting:**
 
 ```bash
-npm run test       # all 330 tests must pass
-npm run lint       # TypeScript must compile clean
+npm test           # all server and client tests must pass
 npm run format     # run Prettier
 ```
 
@@ -110,27 +102,26 @@ npm run format     # run Prettier
 
 ## Testing
 
-Tests live in `__tests__/` directories next to their source:
+Tests live alongside their source:
 
 ```bash
-npm run test                                          # all packages
-npx turbo test --filter=@this project/api               # API only
-npx turbo test --filter=@this project/web               # web only
-npx turbo test --filter=@this project/shared-types      # schema tests only
+npm test                    # all packages
+npm run test:server         # server integration tests only
+npm run test:client         # client unit tests only
 ```
 
 **Rules:**
 
-- Write tests for every function added or modified.
-- API service tests use real Mongoose + an in-memory MongoDB server — do not mock the DB.
-- Web tests use Vitest + jsdom.
+- Write tests for every feature added or modified.
+- Server tests use a real SQLite database (temp file) — do not mock the DB.
+- Client tests use Vitest + jsdom.
 - All tests must pass before a PR can be merged.
 
 ---
 
 ## Reporting Bugs
 
-Use the [Bug Report](.github/ISSUE_TEMPLATE/bug_report.yml) issue template. Include:
+Open an issue and include:
 
 - Steps to reproduce
 - Expected vs. actual behavior
@@ -141,4 +132,4 @@ Use the [Bug Report](.github/ISSUE_TEMPLATE/bug_report.yml) issue template. Incl
 
 ## Requesting Features
 
-Use the [Feature Request](.github/ISSUE_TEMPLATE/feature_request.yml) issue template. Explain the problem you're solving, not just the solution you want.
+Open an issue. Explain the problem you're solving, not just the solution you want.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -43,17 +43,15 @@ body:
       label: Area
       description: Which part of the app is affected?
       options:
-        - API (backend)
-        - Web (frontend)
-        - Authentication
-        - Transactions
-        - Budgets
-        - Goals
-        - Recurring / Bills
-        - Analytics
-        - Dashboard
+        - Server / API
+        - Client / UI
+        - WebSocket / Real-time
+        - Hook Integration
+        - Sessions / Agents
+        - Analytics / Tokens
+        - Settings / Pricing
+        - Database / SQLite
         - Docker / Deployment
-        - Helm / Kubernetes
         - Other
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -37,17 +37,15 @@ body:
       label: Area
       description: Which part of the app would this affect?
       options:
-        - API (backend)
-        - Web (frontend)
-        - Authentication
-        - Transactions
-        - Budgets
-        - Goals
-        - Recurring / Bills
-        - Analytics
-        - Dashboard
+        - Server / API
+        - Client / UI
+        - WebSocket / Real-time
+        - Hook Integration
+        - Sessions / Agents
+        - Analytics / Tokens
+        - Settings / Pricing
+        - Database / SQLite
         - Docker / Deployment
-        - Helm / Kubernetes
         - Other
     validations:
       required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,8 +29,8 @@
 - [ ] I have read the [contributing guidelines](../CONTRIBUTING.md)
 - [ ] My code follows the project's coding standards
 - [ ] I have added/updated tests that prove my fix or feature works
-- [ ] All new and existing tests pass (`npm run test`)
-- [ ] TypeScript compiles without errors (`npm run lint`)
+- [ ] All new and existing tests pass (`npm test`)
+- [ ] Code is formatted (`npm run format:check`)
 - [ ] I have updated documentation where necessary
 
 ## Screenshots

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -25,15 +25,13 @@ You should receive an acknowledgment within **48 hours**. We will work with you 
 
 The following are in scope:
 
-- Authentication and authorization flaws (JWT handling, session management)
-- Injection vulnerabilities (NoSQL injection, XSS, command injection)
-- Sensitive data exposure (credentials, tokens, PII leaks)
-- Broken access control (cross-user data access)
+- Injection vulnerabilities (SQL injection, XSS, command injection)
+- Sensitive data exposure (credentials, tokens, PII leaks in SQLite database)
+- Path traversal or file access issues (e.g. via hook handler or transcript paths)
 - Dependency vulnerabilities with a known exploit
 
 The following are **out of scope**:
 
-- Issues in third-party services (MongoDB Atlas, cloud providers)
 - Denial of service via rate limiting (we acknowledge this and plan to address it)
 - Self-hosted deployment misconfigurations
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: ["**"]
 
 env:
-  NODE_VERSION: "20"
+  NODE_VERSION: "22"
   IMAGE_NAME: claude-code-agent-monitor
 
 jobs:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -210,7 +210,7 @@ sequenceDiagram
 ```mermaid
 graph TD
     INDEX[server/index.js<br/>Express app + HTTP server]
-    DB[server/db.js<br/>SQLite + prepared statements]
+    DB[server/db.js<br/>SQLite + prepared statements<br/>better-sqlite3 → node:sqlite fallback]
     WS[server/websocket.js<br/>WS server + broadcast]
     HOOKS[routes/hooks.js<br/>Hook event processing]
     SESSIONS[routes/sessions.js<br/>Session CRUD]
@@ -239,19 +239,20 @@ graph TD
 
 ### Server Components
 
-| Module                | Responsibility                                                                                                                                   |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `server/index.js`     | Express app setup, middleware, route mounting, static file serving in production, HTTP server creation. Runs a periodic maintenance sweep every 2 min (abandons stale sessions, scans active sessions' JSONL files for new compaction entries). Triggers legacy session import and compaction backfill on startup |
-| `server/db.js`        | SQLite connection with WAL mode, schema migration (CREATE TABLE IF NOT EXISTS + ALTER TABLE for column additions), all prepared statements as a reusable `stmts` object. Migrations use literal defaults for ALTER TABLE since SQLite does not support expressions like `strftime()` in column defaults added via ALTER TABLE |
-| `server/websocket.js` | WebSocket server on `/ws` path, 30s heartbeat with ping/pong dead connection detection, typed broadcast function                                 |
-| `routes/hooks.js`     | Core event processing inside a SQLite transaction. Auto-creates sessions/agents. Handles 7 hook types (SessionStart through SessionEnd) plus synthetic `Compaction` events. Manages agent state machine, session reactivation on resume, orphaned session cleanup (5+ min idle). Detects compaction via `isCompactSummary` in JSONL transcripts and creates compaction agents + events (deduplicated by uuid). Token baselines (`baseline_*` columns) preserve pre-compaction totals so no usage is lost across context compressions |
-| `routes/sessions.js`  | Standard CRUD with pagination. GET includes agent count via LEFT JOIN. POST is idempotent on session ID                                          |
-| `routes/agents.js`    | CRUD with status/session_id filtering. PATCH broadcasts `agent_updated`                                                                          |
-| `routes/events.js`    | Read-only event listing with session_id filter and pagination                                                                                    |
-| `routes/stats.js`     | Single aggregate query returning total/active counts + status distributions                                                                      |
-| `routes/analytics.js` | Extended analytics — token totals, tool usage counts, daily event/session trends, agent type distribution |
-| `routes/pricing.js`  | Model pricing CRUD (list/upsert/delete), per-session and global cost calculation with pattern-based model matching |
-| `routes/settings.js` | System info (DB size, hook status, server uptime), data export as JSON, session cleanup (abandon stale, purge old), clear all data, reset pricing, reinstall hooks |
+| Module                    | Responsibility                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+|---------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `server/index.js`         | Express app setup, middleware, route mounting, static file serving in production, HTTP server creation. Runs a periodic maintenance sweep every 2 min (abandons stale sessions, scans active sessions' JSONL files for new compaction entries). Triggers legacy session import and compaction backfill on startup                                                                                                                                                                                                                    |
+| `server/db.js`            | SQLite connection with WAL mode, schema migration (CREATE TABLE IF NOT EXISTS + ALTER TABLE for column additions), all prepared statements as a reusable `stmts` object. Tries `better-sqlite3` first, falls back to `node:sqlite` via `compat-sqlite.js`. Migrations use literal defaults for ALTER TABLE since SQLite does not support expressions like `strftime()` in column defaults added via ALTER TABLE                                                                                                                      |
+| `server/compat-sqlite.js` | Compatibility wrapper that gives Node.js built-in `node:sqlite` (`DatabaseSync`) the same API as `better-sqlite3` — pragma, transaction, prepare. Used as automatic fallback when the native module is unavailable (Node 22+)                                                                                                                                                                                                                                                                                                        |
+| `server/websocket.js`     | WebSocket server on `/ws` path, 30s heartbeat with ping/pong dead connection detection, typed broadcast function                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `routes/hooks.js`         | Core event processing inside a SQLite transaction. Auto-creates sessions/agents. Handles 7 hook types (SessionStart through SessionEnd) plus synthetic `Compaction` events. Manages agent state machine, session reactivation on resume, orphaned session cleanup (5+ min idle). Detects compaction via `isCompactSummary` in JSONL transcripts and creates compaction agents + events (deduplicated by uuid). Token baselines (`baseline_*` columns) preserve pre-compaction totals so no usage is lost across context compressions |
+| `routes/sessions.js`      | Standard CRUD with pagination. GET includes agent count via LEFT JOIN. POST is idempotent on session ID                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `routes/agents.js`        | CRUD with status/session_id filtering. PATCH broadcasts `agent_updated`                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `routes/events.js`        | Read-only event listing with session_id filter and pagination                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `routes/stats.js`         | Single aggregate query returning total/active counts + status distributions                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| `routes/analytics.js`     | Extended analytics — token totals, tool usage counts, daily event/session trends, agent type distribution                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| `routes/pricing.js`       | Model pricing CRUD (list/upsert/delete), per-session and global cost calculation with pattern-based model matching                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| `routes/settings.js`      | System info (DB size, hook status, server uptime), data export as JSON, session cleanup (abandon stale, purge old), clear all data, reset pricing, reinstall hooks                                                                                                                                                                                                                                                                                                                                                                   |
 
 ### Request Processing
 
@@ -602,15 +603,15 @@ flowchart TD
     START[Claude Code fires hook] --> STDIN[Read stdin to EOF]
     STDIN --> PARSE{Parse JSON?}
     PARSE -->|Success| POST["POST to 127.0.0.1:4820<br/>/api/hooks/event"]
-    PARSE -->|Failure| WRAP[Wrap raw input as<br/>{"raw": "..."}]
+    PARSE -->|Failure| WRAP["Wrap raw input as<br/>#123;raw: ...#125;"]
     WRAP --> POST
     POST --> RESP{Response?}
-    RESP -->|200| EXIT0[exit(0)]
-    RESP -->|Error| EXIT0_ERR[exit(0)]
+    RESP -->|200| EXIT0[exit = 0]
+    RESP -->|Error| EXIT0_ERR[exit = 0]
     RESP -->|Timeout 3s| DESTROY[Destroy request]
-    DESTROY --> EXIT0_TO[exit(0)]
+    DESTROY --> EXIT0_TO[exit = 0]
 
-    SAFETY[Safety net: setTimeout 5s] --> EXIT0_SAFETY[exit(0)]
+    SAFETY[Safety net: setTimeout 5s] --> EXIT0_SAFETY[exit = 0]
 
     style EXIT0 fill:#10b981,stroke:#34d399,color:#fff
     style EXIT0_ERR fill:#10b981,stroke:#34d399,color:#fff
@@ -908,9 +909,9 @@ A multi-stage `Dockerfile` builds the client and server into a single production
 ```mermaid
 graph LR
     subgraph "Multi-Stage Build"
-        S1["Stage 1: server-deps\nnode:20-alpine\nnpm ci --omit=dev\n+ python3/make/g++ for native modules"]
-        S2["Stage 2: client-build\nnode:20-alpine\nnpm ci + vite build"]
-        S3["Stage 3: runtime\nnode:20-alpine\nCopies node_modules + client/dist"]
+        S1["Stage 1: server-deps\nnode:22-alpine\nnpm ci --omit=dev"]
+        S2["Stage 2: client-build\nnode:22-alpine\nnpm ci + vite build"]
+        S3["Stage 3: runtime\nnode:22-alpine\nCopies node_modules + client/dist"]
         S1 --> S3
         S2 --> S3
     end
@@ -1010,7 +1011,7 @@ Claude Code invokes this command on each update, piping a JSON payload to stdin.
 
 | Technology                      | Why This Over Alternatives                                                                                                                      |
 | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| **SQLite** (via better-sqlite3) | Zero-config, embedded, no server process. WAL mode gives concurrent reads. Synchronous API is simpler than async alternatives for this use case |
+| **SQLite** (via `better-sqlite3` or built-in `node:sqlite`) | Zero-config, embedded, no server process. WAL mode gives concurrent reads. Synchronous API is simpler than async alternatives for this use case. Falls back to Node.js built-in `node:sqlite` when `better-sqlite3` cannot be compiled |
 | **Express**                     | Battle-tested, minimal, well-understood. Overkill would be Fastify for this scale; underkill would be raw `http` module                         |
 | **ws**                          | Fastest, most lightweight WebSocket library for Node. No Socket.IO overhead needed since we only push JSON messages                             |
 | **React 18**                    | Stable, widely known, strong TypeScript support. No need for Server Components or RSC given this is a client-rendered SPA                       |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
-# ── Stage 1: Install server production deps (with native build tools) ──
-FROM node:20-alpine AS server-deps
-RUN apk add --no-cache python3 make g++
+# ── Stage 1: Install server production deps ───────────────────────────
+FROM node:22-alpine AS server-deps
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci --omit=dev
 
 # ── Stage 2: Build React client ───────────────────────────────────────
-FROM node:20-alpine AS client-build
+FROM node:22-alpine AS client-build
 WORKDIR /app/client
 COPY client/package.json client/package-lock.json ./
 RUN npm ci
@@ -14,7 +13,7 @@ COPY client/ ./
 RUN npm run build
 
 # ── Stage 3: Production runtime ───────────────────────────────────────
-FROM node:20-alpine
+FROM node:22-alpine
 WORKDIR /app
 
 COPY --from=server-deps /app/node_modules ./node_modules/

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,7 +4,7 @@
 
 | Requirement | Version | Notes |
 |---|---|---|
-| Node.js | 18+ | Required for server and client |
+| Node.js | 18+ (22+ recommended) | Required for server and client |
 | npm | 9+ | Comes with Node.js |
 | Claude Code | 2.x+ | Required for hook integration |
 | Python | 3.6+ | Optional — statusline utility only |
@@ -163,6 +163,52 @@ podman run -d --name agent-monitor \
 <p align="center">
   <img src="images/settings.png" alt="Settings Overview" width="100%">
 </p>
+
+---
+
+## Troubleshooting
+
+### `npm run setup` shows `better-sqlite3` errors
+
+This is expected and **non-fatal**. `better-sqlite3` is a native C++ module listed as an optional dependency. If prebuilt binaries are not available for your Node version or platform, npm will print gyp/compilation errors but still complete successfully.
+
+At runtime the server uses this fallback chain:
+
+1. **`better-sqlite3`** — used when prebuilt binaries are available (Node 18/20/22 on Windows x64, macOS arm64/x64, Linux x64/arm64)
+2. **`node:sqlite`** — Node.js built-in SQLite module, used automatically on Node 22+ when `better-sqlite3` is unavailable
+
+If you see an error box at startup saying *"SQLite backend not available"*, either:
+
+- **Upgrade to Node.js 22+** (recommended — zero native dependencies needed), or
+- **Install build tools** so `better-sqlite3` can compile from source:
+  - **Windows:** `npm install -g windows-build-tools` or install [Visual Studio Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) with the C++ workload
+  - **macOS:** `xcode-select --install`
+  - **Linux:** `sudo apt install python3 make g++` (Debian/Ubuntu) or equivalent
+
+  Then run: `npm rebuild better-sqlite3`
+
+### `npm run dev` fails immediately
+
+Ensure both server and client dependencies are installed:
+
+```bash
+npm run setup
+```
+
+If the error mentions a missing module like `express` or `react`, dependencies may be incomplete. Delete `node_modules` in both root and `client/`, then re-run setup:
+
+```bash
+rm -rf node_modules client/node_modules
+npm run setup
+```
+
+### Server starts but client shows a blank page
+
+The Vite dev server and Express server run on different ports. Make sure both are running (`npm run dev` starts both). Open **http://localhost:5173**, not `http://localhost:4820`, during development.
+
+### No sessions appearing after starting Claude Code
+
+See [SETUP.md — Troubleshooting](./SETUP.md#troubleshooting) for detailed hook debugging steps.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A professional dashboard to track and visualize your Claude Code agent sessions,
 ![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS-3.4-06B6D4?style=flat-square&logo=tailwindcss&logoColor=white)
 ![SQLite](https://img.shields.io/badge/SQLite-3-003B57?style=flat-square&logo=sqlite&logoColor=white)
 ![WebSocket](https://img.shields.io/badge/WebSocket-RFC_6455-010101?style=flat-square&logo=socketdotio&logoColor=white)
-![better--sqlite3](https://img.shields.io/badge/better--sqlite3-11.7-003B57?style=flat-square&logo=sqlite&logoColor=white)
+![better--sqlite3](https://img.shields.io/badge/better--sqlite3-11.7_(optional)-003B57?style=flat-square&logo=sqlite&logoColor=white)
 ![React Router](https://img.shields.io/badge/React_Router-6.28-CA4245?style=flat-square&logo=reactrouter&logoColor=white)
 ![Lucide](https://img.shields.io/badge/Lucide_Icons-0.474-F56565?style=flat-square&logo=lucide&logoColor=white)
 ![PostCSS](https://img.shields.io/badge/PostCSS-8.5-DD3A0A?style=flat-square&logo=postcss&logoColor=white)
@@ -159,7 +159,7 @@ The dashboard offers a comprehensive set of features to monitor and analyze your
 
 ### Prerequisites
 
-- **Node.js** >= 18.0.0
+- **Node.js** >= 18.0.0 (22+ recommended)
 - **npm** >= 9.0.0
 
 ### 1. Install
@@ -533,7 +533,7 @@ Additionally, any `Notification` hook event from Claude Code triggers a browser 
 
 ## Data Storage
 
-- **Engine:** SQLite 3 via `better-sqlite3`
+- **Engine:** SQLite 3 via `better-sqlite3` (optional) or Node.js built-in `node:sqlite`
 - **Location:** `data/dashboard.db`
 - **Journal mode:** WAL (concurrent reads during writes)
 - **Reset:** Delete `data/dashboard.db` to clear all data
@@ -739,9 +739,10 @@ agent-dashboard/
 |       |-- agents.js            # Agent CRUD
 |       |-- events.js            # Event listing
 |       |-- stats.js             # Aggregate statistics
-|       |-- analytics.js        # Token, tool, and trend analytics
-|       |-- pricing.js            # Model pricing CRUD and cost calculation
-|       +-- settings.js           # System info, data management, export, cleanup
+|       |-- analytics.js         # Token, tool, and trend analytics
+|       |-- pricing.js           # Model pricing CRUD and cost calculation
+|       +-- settings.js          # System info, data management, export, cleanup
+|   +-- compat-sqlite.js         # node:sqlite compatibility wrapper (fallback for better-sqlite3)
 |-- client/
 |   |-- package.json             # Client dependencies
 |   |-- index.html               # HTML entry point
@@ -758,7 +759,7 @@ agent-dashboard/
 |       |   |-- format.ts        # Date/time formatting utilities
 |       |   +-- eventBus.ts      # Pub/sub for WebSocket distribution
 |       |-- hooks/
-|       |   |-- useWebSocket.ts  # Auto-reconnecting WebSocket hook
+|       |   |-- useWebSocket.ts     # Auto-reconnecting WebSocket hook
 |       |   +-- useNotifications.ts # Browser notification triggers from WebSocket events
 |       |-- components/
 |       |   |-- Layout.tsx       # Shell with sidebar + outlet
@@ -768,12 +769,12 @@ agent-dashboard/
 |       |   |-- StatusBadge.tsx  # Color-coded status pills
 |       |   +-- EmptyState.tsx   # Placeholder for empty lists
 |       +-- pages/
-|           |-- Dashboard.tsx    # Overview page
-|           |-- KanbanBoard.tsx  # Agent status columns
-|           |-- Sessions.tsx     # Sessions table
-|           |-- SessionDetail.tsx # Single session deep dive
-|           |-- ActivityFeed.tsx # Real-time event stream
-|           |-- Analytics.tsx   # Token usage, heatmap, trends
+|           |-- Dashboard.tsx      # Overview page
+|           |-- KanbanBoard.tsx    # Agent status columns
+|           |-- Sessions.tsx       # Sessions table
+|           |-- SessionDetail.tsx  # Single session deep dive
+|           |-- ActivityFeed.tsx   # Real-time event stream
+|           |-- Analytics.tsx      # Token usage, heatmap, trends
 |           |-- Settings.tsx       # Model pricing, notifications, hooks, export, cleanup
 |           +-- NotFound.tsx       # 404 catch-all page
 |-- scripts/
@@ -795,7 +796,7 @@ agent-dashboard/
 
 | Problem                           | Solution                                                                                                                                                         |
 | --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `better-sqlite3` fails to install | Ensure you have Node.js >= 18. On Windows, you may need the [Visual Studio Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) C++ workload |
+| `better-sqlite3` fails to install | This is non-fatal — the server falls back to Node.js built-in `node:sqlite` automatically (Node 22+). On older Node versions, install Python 3 and C++ build tools, then run `npm rebuild better-sqlite3` |
 | Hooks not firing                  | Run `npm run install-hooks` and restart Claude Code. Verify hooks exist in `~/.claude/settings.json`                                                             |
 | Dashboard shows no data           | Ensure the server is running (`npm run dev`) before starting a Claude Code session. Check `http://localhost:4820/api/health`                                     |
 | WebSocket disconnected            | The client auto-reconnects every 2 seconds. Check that port 4820 is not blocked by a firewall                                                                    |

--- a/SETUP.md
+++ b/SETUP.md
@@ -166,6 +166,34 @@ See [statusline/README.md](./statusline/README.md) for installation instructions
 
 ## Troubleshooting
 
+### `better-sqlite3` errors during `npm install` / `npm run setup`
+
+These warnings are **harmless**. `better-sqlite3` is an optional dependency — if it cannot compile, npm skips it and the server falls back to Node.js built-in `node:sqlite` (available on Node 22+).
+
+You do **not** need Python, Visual Studio Build Tools, or any C++ compiler to run this project on Node 22+.
+
+If you are on Node 18 or 20 and `better-sqlite3` prebuilds are not available for your platform, you have two options:
+
+1. **Upgrade to Node.js 22+** — the built-in `node:sqlite` fallback requires no native compilation at all
+2. **Install build tools** and run `npm rebuild better-sqlite3`:
+   - **Windows:** install [Visual Studio Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) with the C++ workload
+   - **macOS:** `xcode-select --install`
+   - **Linux:** `sudo apt install python3 make g++` (Debian/Ubuntu)
+
+### "SQLite backend not available" error on startup
+
+This means neither `better-sqlite3` nor `node:sqlite` could be loaded. The most common cause is running Node.js < 22 without `better-sqlite3` prebuilds. Upgrade to Node.js 22+ to resolve this.
+
+### Database is locked / busy errors
+
+The SQLite database uses WAL mode with a 5-second busy timeout. If you see lock errors:
+
+- Ensure only one dashboard server instance is running
+- Check for zombie `node server/index.js` processes: `ps aux | grep server/index`
+- Delete `data/dashboard.db-wal` and `data/dashboard.db-shm` if the server was killed uncleanly, then restart
+
+---
+
 ### No sessions appearing after starting Claude Code
 
 **Check 1 — Is the server running?**
@@ -238,3 +266,36 @@ And make sure Claude Code posts hooks to the new port:
 CLAUDE_DASHBOARD_PORT=4821 claude
 # or edit scripts/hook-handler.js and change the default port
 ```
+
+---
+
+### Docker / Podman container starts but no sessions appear
+
+**Check 1 — Is the container healthy?**
+
+```bash
+curl http://localhost:4820/api/health
+# Expected: {"status":"ok","timestamp":"..."}
+```
+
+**Check 2 — Did you install hooks on the host?**
+
+Hooks run on the host machine, not inside the container. After the container is up:
+
+```bash
+npm run install-hooks
+```
+
+**Check 3 — Are hooks pointing to the right port?**
+
+Open `~/.claude/settings.json` and verify the hook commands reference `localhost:4820` (or whatever port the container is mapped to). If you changed the port mapping, update hooks accordingly.
+
+---
+
+### Docker build fails during `npm ci`
+
+If the build fails in Stage 1 with `better-sqlite3` errors, this is expected and should not block the build — `better-sqlite3` is an optional dependency. If the build still fails:
+
+- Ensure you are using the latest Dockerfile (it should use `node:22-alpine` and **not** install `python3`, `make`, or `g++`)
+- Run `docker build --no-cache -t agent-monitor .` to force a clean rebuild
+- Check that `package.json` has `better-sqlite3` under `optionalDependencies`, not `dependencies`

--- a/docs/superpowers/plans/2026-03-16-remove-native-sqlite-dependency.md
+++ b/docs/superpowers/plans/2026-03-16-remove-native-sqlite-dependency.md
@@ -1,0 +1,240 @@
+# Remove Native SQLite Dependency — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `better-sqlite3` (native C++ module requiring Python/build tools) with a compatibility layer over Node.js built-in `node:sqlite`, so `npm install` succeeds on any machine without native compilation tools.
+
+**Architecture:** Create `server/compat-sqlite.js` — a thin wrapper that gives `DatabaseSync` (from `node:sqlite`) the same API as `better-sqlite3`. Move `better-sqlite3` to `optionalDependencies` so it's preferred when prebuilds are available but doesn't block install. The `server/db.js` loader tries `better-sqlite3` first, falls back to the compat wrapper. Update minimum Node version to 22.
+
+**Tech Stack:** Node.js `node:sqlite` (DatabaseSync), existing Express/WS server
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `server/compat-sqlite.js` | **Create** | Wrapper class: DatabaseSync → better-sqlite3 API |
+| `server/db.js` | **Modify** (line 1) | Try better-sqlite3, fallback to compat wrapper |
+| `scripts/clear-data.js` | **Modify** (line 8) | Same fallback import |
+| `package.json` | **Modify** | Move better-sqlite3 to optionalDependencies, bump engines to >=22 |
+| `server/__tests__/api.test.js` | **Modify** (lines 952-959) | Fix `db.pragma()` calls to work with both backends |
+
+---
+
+## Chunk 1: Core Implementation
+
+### Task 1: Create `server/compat-sqlite.js`
+
+**Files:**
+- Create: `server/compat-sqlite.js`
+
+- [ ] **Step 1: Write the compat wrapper**
+
+The wrapper must bridge these API differences:
+
+| better-sqlite3 | node:sqlite (DatabaseSync) |
+|----------------|---------------------------|
+| `new Database(path)` | `new DatabaseSync(path)` |
+| `db.pragma("key = value")` | `db.exec("PRAGMA key = value")` |
+| `db.pragma("key")` → value | `db.prepare("PRAGMA key").get()` → `{key: value}` |
+| `db.pragma("key", { simple: true })` → value | same as above, extract single value |
+| `db.transaction(fn)` → wrapper fn | manual `BEGIN`/`COMMIT`/`ROLLBACK` |
+| `db.prepare(sql)` → stmt with `.run()`, `.get()`, `.all()` | identical API |
+| `db.exec(sql)` | identical |
+| `db.close()` | identical |
+
+```js
+// server/compat-sqlite.js
+const { DatabaseSync } = require("node:sqlite");
+
+class Database {
+  constructor(filePath) {
+    this._db = new DatabaseSync(filePath);
+  }
+
+  exec(sql) {
+    this._db.exec(sql);
+    return this;
+  }
+
+  pragma(str, options) {
+    if (str.includes("=")) {
+      this._db.exec(`PRAGMA ${str}`);
+      return undefined;
+    }
+    const row = this._db.prepare(`PRAGMA ${str}`).get();
+    if (!row) return undefined;
+    const keys = Object.keys(row);
+    if (options?.simple || keys.length === 1) return row[keys[0]];
+    return row;
+  }
+
+  prepare(sql) {
+    return this._db.prepare(sql);
+  }
+
+  transaction(fn) {
+    const db = this._db;
+    const wrapper = (...args) => {
+      db.exec("BEGIN");
+      try {
+        const result = fn(...args);
+        db.exec("COMMIT");
+        return result;
+      } catch (err) {
+        db.exec("ROLLBACK");
+        throw err;
+      }
+    };
+    return wrapper;
+  }
+
+  close() {
+    this._db.close();
+  }
+}
+
+module.exports = Database;
+```
+
+- [ ] **Step 2: Verify the wrapper works standalone**
+
+Run: `node -e "const DB = require('./server/compat-sqlite'); const db = new DB(':memory:'); db.pragma('journal_mode = WAL'); db.exec('CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)'); const s = db.prepare('INSERT INTO t (v) VALUES (?)'); console.log(s.run('hi')); console.log(db.prepare('SELECT * FROM t').all()); const tx = db.transaction((items) => { for (const i of items) s.run(i); }); tx(['a','b','c']); console.log(db.prepare('SELECT COUNT(*) as c FROM t').get()); db.close(); console.log('OK')"`
+
+Expected: `OK` printed at the end with correct query results.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/compat-sqlite.js
+git commit -m "feat: add node:sqlite compat wrapper for better-sqlite3 API"
+```
+
+---
+
+### Task 2: Update `server/db.js` to use fallback import
+
+**Files:**
+- Modify: `server/db.js:1`
+
+- [ ] **Step 1: Replace the import**
+
+Change line 1 from:
+```js
+const Database = require("better-sqlite3");
+```
+To:
+```js
+let Database;
+try {
+  Database = require("better-sqlite3");
+} catch {
+  Database = require("./compat-sqlite");
+}
+```
+
+- [ ] **Step 2: Verify server starts**
+
+Run: `node -e "process.env.DASHBOARD_DB_PATH = require('path').join(require('os').tmpdir(), 'test-fallback-' + Date.now() + '.db'); const { db, stmts } = require('./server/db'); console.log('stmts keys:', Object.keys(stmts).length); stmts.insertSession.run('test-1', 'Test', 'active', null, null, null); console.log(stmts.getSession.get('test-1')); db.close(); console.log('OK')"`
+
+Expected: Prints statement count (39), session row, and `OK`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/db.js
+git commit -m "feat: fallback to node:sqlite when better-sqlite3 unavailable"
+```
+
+---
+
+### Task 3: Update `scripts/clear-data.js` to use fallback import
+
+**Files:**
+- Modify: `scripts/clear-data.js:8`
+
+- [ ] **Step 1: Replace the import**
+
+Change line 8 from:
+```js
+const Database = require("better-sqlite3");
+```
+To:
+```js
+let Database;
+try {
+  Database = require("better-sqlite3");
+} catch {
+  Database = require("../server/compat-sqlite");
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add scripts/clear-data.js
+git commit -m "fix: use fallback sqlite import in clear-data script"
+```
+
+---
+
+### Task 4: Update `package.json`
+
+**Files:**
+- Modify: `package.json`
+
+- [ ] **Step 1: Move better-sqlite3 to optionalDependencies, bump engines**
+
+Move `"better-sqlite3": "^11.7.0"` from `dependencies` to `optionalDependencies`.
+Change engines from `"node": ">=18.0.0"` to `"node": ">=22.0.0"`.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add package.json
+git commit -m "chore: make better-sqlite3 optional, require Node >= 22"
+```
+
+---
+
+### Task 5: Fix test pragma calls
+
+**Files:**
+- Modify: `server/__tests__/api.test.js:952-959`
+
+- [ ] **Step 1: Fix pragma calls in Database Integrity tests**
+
+The tests call `db.pragma("journal_mode", { simple: true })` and `db.pragma("foreign_keys", { simple: true })`. The compat wrapper supports `{ simple: true }`, so these should work as-is. However, WAL mode isn't available for in-memory databases (returns "memory"). The test creates a file-based DB via `TEST_DB`, so WAL should work.
+
+No change needed — verify by running tests.
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `node --test server/__tests__/api.test.js`
+
+Expected: All tests pass.
+
+- [ ] **Step 3: Run setup to verify npm install succeeds without Python**
+
+Run: `npm run setup`
+
+Expected: Install succeeds (better-sqlite3 may warn but won't fail since it's optional).
+
+---
+
+### Task 6: Update documentation
+
+**Files:**
+- Modify: `SETUP.md` (if it mentions better-sqlite3 or Python requirements)
+
+- [ ] **Step 1: Check and update SETUP.md**
+
+Remove any mentions of Python or build tools as requirements. Note that Node >= 22 is required.
+
+- [ ] **Step 2: Commit all remaining changes**
+
+```bash
+git add -A
+git commit -m "docs: update setup requirements for native-free SQLite"
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "agent-dashboard",
       "version": "1.0.0",
       "dependencies": {
-        "better-sqlite3": "^11.7.0",
         "cors": "^2.8.5",
         "express": "^4.21.2",
         "uuid": "^11.1.0",
@@ -20,6 +19,9 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "better-sqlite3": "^11.7.0"
       }
     },
     "node_modules/accepts": {
@@ -85,7 +87,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/better-sqlite3": {
       "version": "11.10.0",
@@ -93,6 +96,7 @@
       "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -103,6 +107,7 @@
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
@@ -112,6 +117,7 @@
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -161,6 +167,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -238,7 +245,8 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -367,6 +375,7 @@
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -382,6 +391,7 @@
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -410,6 +420,7 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "license": "Apache-2.0",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -455,6 +466,7 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -519,6 +531,7 @@
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
       "license": "(MIT OR WTFPL)",
+      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -573,7 +586,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/finalhandler": {
       "version": "1.3.2",
@@ -615,7 +629,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -677,7 +692,8 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -775,7 +791,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/inherits": {
       "version": "2.0.4",
@@ -787,7 +804,8 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -882,6 +900,7 @@
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=10"
       },
@@ -894,6 +913,7 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "license": "MIT",
+      "optional": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -902,7 +922,8 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/ms": {
       "version": "2.0.0",
@@ -914,7 +935,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -930,6 +952,7 @@
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz",
       "integrity": "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -975,6 +998,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -1000,6 +1024,7 @@
       "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
       "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
@@ -1055,6 +1080,7 @@
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -1104,6 +1130,7 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -1119,6 +1146,7 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -1179,6 +1207,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
+      "optional": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -1340,7 +1369,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/simple-get": {
       "version": "4.0.1",
@@ -1361,6 +1391,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
@@ -1381,6 +1412,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -1418,6 +1450,7 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1443,6 +1476,7 @@
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
       "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -1455,6 +1489,7 @@
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -1497,6 +1532,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -1530,7 +1566,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -1585,7 +1622,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/ws": {
       "version": "8.19.0",

--- a/package.json
+++ b/package.json
@@ -21,11 +21,13 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
-    "better-sqlite3": "^11.7.0",
     "cors": "^2.8.5",
     "express": "^4.21.2",
     "uuid": "^11.1.0",
     "ws": "^8.18.0"
+  },
+  "optionalDependencies": {
+    "better-sqlite3": "^11.7.0"
   },
   "devDependencies": {
     "concurrently": "^9.1.2",

--- a/scripts/clear-data.js
+++ b/scripts/clear-data.js
@@ -5,7 +5,19 @@
  * Useful for removing seed/demo data before using the real dashboard.
  */
 
-const Database = require("better-sqlite3");
+let Database;
+try {
+  Database = require("better-sqlite3");
+} catch {
+  try {
+    Database = require("../server/compat-sqlite");
+  } catch {
+    console.error(
+      "Error: No SQLite backend available. Upgrade to Node.js 22+ or install build tools."
+    );
+    process.exit(1);
+  }
+}
 const path = require("path");
 
 const DB_PATH = process.env.DASHBOARD_DB_PATH || path.join(__dirname, "..", "data", "dashboard.db");

--- a/server/compat-sqlite.js
+++ b/server/compat-sqlite.js
@@ -1,0 +1,60 @@
+/**
+ * Compatibility wrapper around Node.js built-in node:sqlite (DatabaseSync).
+ * Provides a better-sqlite3-compatible API so the rest of the codebase
+ * works without the native module.
+ *
+ * Available on Node.js >= 22.5.0 (node:sqlite is experimental).
+ * On older Node versions, require() will throw and the caller should
+ * handle the error (e.g. show an informative message).
+ */
+
+const { DatabaseSync } = require("node:sqlite");
+
+class Database {
+  constructor(filePath) {
+    this._db = new DatabaseSync(filePath);
+  }
+
+  exec(sql) {
+    this._db.exec(sql);
+    return this;
+  }
+
+  pragma(str, options) {
+    if (str.includes("=")) {
+      this._db.exec(`PRAGMA ${str}`);
+      return undefined;
+    }
+    const row = this._db.prepare(`PRAGMA ${str}`).get();
+    if (!row) return undefined;
+    const keys = Object.keys(row);
+    if (options?.simple || keys.length === 1) return row[keys[0]];
+    return row;
+  }
+
+  prepare(sql) {
+    return this._db.prepare(sql);
+  }
+
+  transaction(fn) {
+    const db = this._db;
+    const wrapper = (...args) => {
+      db.exec("BEGIN");
+      try {
+        const result = fn(...args);
+        db.exec("COMMIT");
+        return result;
+      } catch (err) {
+        db.exec("ROLLBACK");
+        throw err;
+      }
+    };
+    return wrapper;
+  }
+
+  close() {
+    this._db.close();
+  }
+}
+
+module.exports = Database;

--- a/server/db.js
+++ b/server/db.js
@@ -1,4 +1,27 @@
-const Database = require("better-sqlite3");
+let Database;
+try {
+  Database = require("better-sqlite3");
+} catch {
+  try {
+    Database = require("./compat-sqlite");
+  } catch {
+    console.error(
+      "\n" +
+        "╔══════════════════════════════════════════════════════════════╗\n" +
+        "║  SQLite backend not available                               ║\n" +
+        "║                                                             ║\n" +
+        "║  better-sqlite3 could not be loaded (native module) and     ║\n" +
+        "║  node:sqlite is not available (requires Node.js >= 22).     ║\n" +
+        "║                                                             ║\n" +
+        "║  Fix options (pick one):                                    ║\n" +
+        "║    1. Upgrade to Node.js 22+ (recommended)                  ║\n" +
+        "║    2. Install Python 3 + C++ build tools, then              ║\n" +
+        "║       run: npm rebuild better-sqlite3                       ║\n" +
+        "╚══════════════════════════════════════════════════════════════╝\n"
+    );
+    process.exit(1);
+  }
+}
 const path = require("path");
 const fs = require("fs");
 


### PR DESCRIPTION
Move better-sqlite3 from dependencies to optionalDependencies so npm install never fails due to missing Python or C++ build tools. At runtime the server tries better-sqlite3 first, then falls back to Node.js built-in node:sqlite (Node 22+), with a clear error message if neither is available.

- Add server/compat-sqlite.js: thin wrapper giving node:sqlite the same API as better-sqlite3 (pragma, transaction, prepare)
- Update server/db.js and scripts/clear-data.js with fallback chain
- Update Dockerfile to node:22-alpine, remove python3/make/g++
- Update CI to Node 22
- Update all docs (README, INSTALL, SETUP, ARCHITECTURE, CONTRIBUTING, SECURITY, issue templates) to reflect changes and add SQLite/Docker troubleshooting sections
- Rewrite CONTRIBUTING.md to match actual project structure

