### PR TITLE
docs: document subagent hierarchy visualization feature

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -309,15 +309,15 @@ graph TD
     LAYOUT --> SIDEBAR
     LAYOUT --> DASH & KANBAN & SESS & DETAIL & ACTIVITY & ANALYTICS_P & SETTINGS_P & NOTFOUND
 
-    DASH --> SC1["StatCard x4"]
-    DASH --> AC1["AgentCard[]"]
+    DASH --> SC1["StatCard x5<br/>(sessions/agents/subagents/events/cost)"]
+    DASH --> AC1["AgentCard[]<br/>with collapsible subagent hierarchy"]
     DASH --> EV1["Event rows"]
 
     KANBAN --> COL["Column x5<br/>(idle/connected/<br/>working/completed/error)"]
     COL --> AC2["AgentCard[]"]
 
     SESS --> TABLE["Session Table<br/>with filters"]
-    DETAIL --> AC3["AgentCard grid"]
+    DETAIL --> AC3["AgentCard hierarchy<br/>parent → children tree"]
     DETAIL --> TL["Event Timeline"]
     ACTIVITY --> FEED["Streaming<br/>Event List"]
 
@@ -406,7 +406,7 @@ graph LR
 
 | Route           | Page          | Data Sources                                           |
 | --------------- | ------------- | ------------------------------------------------------ |
-| `/`             | Dashboard     | `GET /api/stats`, `GET /api/agents`, `GET /api/events` |
+| `/`             | Dashboard     | `GET /api/stats`, `GET /api/agents`, `GET /api/events`, `GET /api/agents?session_id={sid}` (subagent hierarchy) |
 | `/kanban`       | KanbanBoard   | `GET /api/agents?status={each}` per-status (no limit)  |
 | `/sessions`     | Sessions      | `GET /api/sessions`                                    |
 | `/sessions/:id` | SessionDetail | `GET /api/sessions/:id` (includes agents + events)     |

--- a/README.md
+++ b/README.md
@@ -134,15 +134,16 @@ The dashboard offers a comprehensive set of features to monitor and analyze your
 
 | Feature               | Description                                                                  |
 | --------------------- | ---------------------------------------------------------------------------- |
-| **Dashboard**         | Overview stats, active agent cards, recent activity feed                     |
+| **Dashboard**         | Overview stats, active agent cards with collapsible subagent hierarchy, recent activity feed |
 | **Kanban Board**      | 5-column agent status board with paginated columns, per-status fetching (no artificial limits) |
 | **Sessions**          | Searchable, filterable, paginated table of all Claude Code sessions          |
-| **Session Detail**    | Per-session agent cards and full event timeline                              |
+| **Session Detail**    | Per-session agent hierarchy tree (parent/child) and full event timeline      |
 | **Activity Feed**     | Real-time streaming event log with pause/resume and pagination               |
 | **Analytics**         | Token usage, tool frequency, activity heatmap, session trends, live/offline connection indicator |
 | **Live Updates**      | WebSocket push -- no polling, instant UI updates                             |
 | **Auto-Discovery**    | Sessions and agents are created automatically from hook events               |
 | **History Import**    | Automatically imports legacy sessions from `~/.claude/` on server startup    |
+| **Subagent Hierarchy** | Collapsible parent-child agent tree on Dashboard and Session Detail. Agents with subagents show expand/collapse chevrons; leaf agents show a dot indicator. Auto-expands when subagents are active |
 | **Background Agents** | Correctly tracks backgrounded subagents without premature completion         |
 | **Cost Tracking**     | Per-model cost estimation with configurable pricing rules and per-session breakdowns. Compaction-aware token accounting preserves totals across context compressions |
 | **Notifications**     | Browser notifications for session starts, completions, errors, and subagent spawns. Configurable per-event toggles with permission management |

--- a/index.html
+++ b/index.html
@@ -539,8 +539,8 @@
               <div class="feature-icon ic-indigo">⬡</div>
               <h3>Live Dashboard</h3>
               <p>
-                Overview stats, active agent cards, and recent activity feed — all updating in
-                real-time via WebSocket.
+                Overview stats, active agent cards with collapsible subagent hierarchy, and recent
+                activity feed — all updating in real-time via WebSocket.
               </p>
             </div>
             <div class="feature-card">
@@ -563,8 +563,8 @@
               <div class="feature-icon ic-violet">◎</div>
               <h3>Session Detail</h3>
               <p>
-                Per-session agent grid and full chronological event timeline with tool names and
-                summaries.
+                Per-session agent hierarchy tree (parent/child with expand/collapse) and full
+                chronological event timeline with tool names and summaries.
               </p>
             </div>
             <div class="feature-card">
@@ -609,10 +609,12 @@
             </div>
             <div class="feature-card">
               <div class="feature-icon ic-violet">⊜</div>
-              <h3>Background Agents</h3>
+              <h3>Subagent Hierarchy</h3>
               <p>
-                Correctly tracks backgrounded subagents without premature completion. Sessions stay
-                active until the last subagent finishes.
+                Collapsible parent-child agent tree on Dashboard and Session Detail. Agents with
+                subagents show expand/collapse chevrons; leaf agents show a dot indicator.
+                Auto-expands when subagents are active. Correctly tracks backgrounded subagents
+                without premature completion.
               </p>
             </div>
             <div class="feature-card">


### PR DESCRIPTION
Update docs to reflect the collapsible parent-child agent tree added to Dashboard and Session Detail pages:

- README: update Dashboard, Session Detail, and add Subagent Hierarchy feature row in the features table
- ARCHITECTURE: update route table data sources, component tree diagram (StatCard count, hierarchy labels)
- index.html wiki: update Live Dashboard and Session Detail feature cards, rename Background Agents card to Subagent Hierarchy with expanded description

