### PR TITLE
fix: add comma formatting to cost displays in tooltips and full views

### DIFF
--- a/client/src/lib/format.ts
+++ b/client/src/lib/format.ts
@@ -77,3 +77,8 @@ export function fmtCost(n: number): string {
   if (n >= 1_000) return `$${(n / 1_000).toFixed(2)}K`;
   return `$${n.toFixed(2)}`;
 }
+
+/** Format dollar amounts with commas (for tooltips / full display). */
+export function fmtCostFull(n: number, decimals = 2): string {
+  return `$${n.toLocaleString(undefined, { minimumFractionDigits: decimals, maximumFractionDigits: decimals })}`;
+}

--- a/client/src/pages/Analytics.tsx
+++ b/client/src/pages/Analytics.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useCallback, useSyncExternalStore } from "react";
 import { RefreshCw, Download, Zap, Bot, FolderOpen, Cpu, DollarSign, Clock } from "lucide-react";
 import { api } from "../lib/api";
 import { eventBus } from "../lib/eventBus";
-import { fmt, fmtCost } from "../lib/format";
+import { fmt, fmtCost, fmtCostFull } from "../lib/format";
 import { Tip } from "../components/Tip";
 import type { Analytics as AnalyticsData, CostResult } from "../lib/types";
 
@@ -590,7 +590,7 @@ export function Analytics() {
         <StatPill
           label="Total Cost"
           value={costData ? fmtCost(costData.total_cost) : "$0.00"}
-          raw={costData ? `$${costData.total_cost.toFixed(2)}` : undefined}
+          raw={costData ? fmtCostFull(costData.total_cost) : undefined}
           sub={
             costData
               ? `${costData.breakdown.length} model${costData.breakdown.length !== 1 ? "s" : ""}`
@@ -785,14 +785,14 @@ export function Analytics() {
                         <div key={b.model} className="flex justify-between text-xs">
                           <span className="text-gray-400 font-mono truncate">{b.model}</span>
                           <span className="text-emerald-400 font-mono font-medium ml-2">
-                            <Tip raw={`$${b.cost.toFixed(2)}`}>{fmtCost(b.cost)}</Tip>
+                            <Tip raw={fmtCostFull(b.cost)}>{fmtCost(b.cost)}</Tip>
                           </span>
                         </div>
                       ))}
                     <div className="flex justify-between text-xs pt-2 border-t border-border">
                       <span className="text-gray-300 font-medium">Total</span>
                       <span className="text-emerald-400 font-mono font-semibold">
-                        <Tip raw={`$${costData.total_cost.toFixed(2)}`}>
+                        <Tip raw={fmtCostFull(costData.total_cost)}>
                           {fmtCost(costData.total_cost)}
                         </Tip>
                       </span>

--- a/client/src/pages/SessionDetail.tsx
+++ b/client/src/pages/SessionDetail.tsx
@@ -16,7 +16,7 @@ import { api } from "../lib/api";
 import { eventBus } from "../lib/eventBus";
 import { AgentCard } from "../components/AgentCard";
 import { SessionStatusBadge, AgentStatusBadge } from "../components/StatusBadge";
-import { formatDateTime, formatDuration, timeAgo } from "../lib/format";
+import { formatDateTime, formatDuration, fmtCostFull, timeAgo } from "../lib/format";
 import type { Session, Agent, DashboardEvent, SessionStatus, CostResult } from "../lib/types";
 
 export function SessionDetail() {
@@ -140,7 +140,8 @@ export function SessionDetail() {
             </span>
             {cost && cost.total_cost > 0 && (
               <span className="inline-flex items-center gap-1.5 text-xs font-medium text-emerald-400 bg-emerald-500/10 px-2 py-1 rounded">
-                <DollarSign className="w-3 h-3" />${cost.total_cost.toFixed(2)}
+                <DollarSign className="w-3 h-3" />
+                {fmtCostFull(cost.total_cost).slice(1)}
               </span>
             )}
           </div>
@@ -317,7 +318,7 @@ export function SessionDetail() {
                       {row.cache_write_tokens.toLocaleString()}
                     </td>
                     <td className="px-5 py-2.5 text-sm text-emerald-400 text-right font-mono font-medium">
-                      ${row.cost.toFixed(4)}
+                      {fmtCostFull(row.cost, 4)}
                     </td>
                   </tr>
                 ))}
@@ -326,7 +327,7 @@ export function SessionDetail() {
                     Total
                   </td>
                   <td className="px-5 py-2.5 text-sm text-emerald-400 text-right font-mono font-semibold">
-                    ${cost.total_cost.toFixed(4)}
+                    {fmtCostFull(cost.total_cost, 4)}
                   </td>
                 </tr>
               </tbody>


### PR DESCRIPTION
Costs like $1102.52 now display as $1,102.52 using toLocaleString. Added fmtCostFull() helper and replaced all raw .toFixed() cost formatting.

