### PR TITLE
Remove .claude from .gitignore and add settings.local.json

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm run:*)",
+      "Bash(cd client:*)",
+      "Bash(git add:*)",
+      "Bash(git:*)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,4 @@ client/tsconfig.tsbuildinfo
 *.db-wal
 *.db-shm
 .env
-.claude/
 .vs/


### PR DESCRIPTION
This pull request adds a new `.claude/settings.local.json` configuration file to define local permissions for running specific Bash commands. This change helps control which shell commands are allowed in the development environment.

Configuration changes:

* Added `.claude/settings.local.json` to specify allowed Bash commands, including `npm run:*`, `cd client:*`, and various `git` commands.