### PR TITLE
Calculate session costs in bulk and update response structure

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -8,7 +8,10 @@
       "Bash(node --test server/lib/__tests__/transcript-cache.test.js)",
       "Bash(node -e \"const r = require\\(''''./server/routes/hooks''''\\); console.log\\(''''router type:'''', typeof r\\); console.log\\(''''transcriptCache exists:'''', !!r.transcriptCache\\); console.log\\(''''transcriptCache has extract:'''', typeof r.transcriptCache?.extract\\);\")",
       "Bash(node -e \"const r = require\\(''''./server/routes/hooks''''\\); console.log\\(''''router type:'''', typeof r\\); console.log\\(''''transcriptCache exists:'''', Boolean\\(r.transcriptCache\\)\\); console.log\\(''''transcriptCache has extract:'''', typeof \\(r.transcriptCache && r.transcriptCache.extract\\)\\);\")",
-      "Bash(node -e \"const { transcriptCache } = require\\(''./server/routes/hooks''\\); console.log\\(''transcriptCache exists:'', Boolean\\(transcriptCache\\)\\); console.log\\(''has extract:'', typeof \\(transcriptCache && transcriptCache.extract\\)\\); console.log\\(''has extractCompactions:'', typeof \\(transcriptCache && transcriptCache.extractCompactions\\)\\); console.log\\(''has invalidate:'', typeof \\(transcriptCache && transcriptCache.invalidate\\)\\); console.log\\(''has stats:'', typeof \\(transcriptCache && transcriptCache.stats\\)\\);\")"
+      "Bash(node -e \"const { transcriptCache } = require\\(''./server/routes/hooks''\\); console.log\\(''transcriptCache exists:'', Boolean\\(transcriptCache\\)\\); console.log\\(''has extract:'', typeof \\(transcriptCache && transcriptCache.extract\\)\\); console.log\\(''has extractCompactions:'', typeof \\(transcriptCache && transcriptCache.extractCompactions\\)\\); console.log\\(''has invalidate:'', typeof \\(transcriptCache && transcriptCache.invalidate\\)\\); console.log\\(''has stats:'', typeof \\(transcriptCache && transcriptCache.stats\\)\\);\")",
+      "Bash(npx tsc:*)",
+      "Bash(npx --prefix client tsc --noEmit -p client/tsconfig.json)",
+      "Bash(node -e \":*)"
     ]
   }
 }

--- a/client/src/lib/types.ts
+++ b/client/src/lib/types.ts
@@ -13,6 +13,7 @@ export interface Session {
   metadata: string | null;
   agent_count?: number;
   last_activity?: string;
+  cost?: number;
 }
 
 export interface Agent {

--- a/client/src/pages/Sessions.tsx
+++ b/client/src/pages/Sessions.tsx
@@ -23,7 +23,6 @@ export function Sessions() {
   const [sessions, setSessions] = useState<Session[]>([]);
   const [filter, setFilter] = useState("");
   const [search, setSearch] = useState("");
-  const [sessionCosts, setSessionCosts] = useState<Record<string, number>>({});
   const [loading, setLoading] = useState(true);
   const [page, setPage] = useState(0);
 
@@ -33,21 +32,6 @@ export function Sessions() {
       if (filter) params.status = filter;
       const sessionsRes = await api.sessions.list(params);
       setSessions(sessionsRes.sessions);
-      // Fetch individual session costs in background
-      const costs: Record<string, number> = {};
-      const batchSize = 10;
-      for (let i = 0; i < sessionsRes.sessions.length; i += batchSize) {
-        const batch = sessionsRes.sessions.slice(i, i + batchSize);
-        const results = await Promise.all(
-          batch.map((s) =>
-            api.pricing.sessionCost(s.id).catch(() => ({ total_cost: 0, breakdown: [] }))
-          )
-        );
-        batch.forEach((s, j) => {
-          if (results[j]) costs[s.id] = results[j].total_cost;
-        });
-      }
-      setSessionCosts(costs);
     } finally {
       setLoading(false);
     }
@@ -206,10 +190,7 @@ export function Sessions() {
                       {session.agent_count ?? "-"}
                     </td>
                     <td className="px-5 py-4 text-sm text-gray-400 font-mono">
-                      {(() => {
-                        const c = sessionCosts[session.id];
-                        return c != null && c > 0 ? fmtCost(c) : "-";
-                      })()}
+                      {session.cost != null && session.cost > 0 ? fmtCost(session.cost) : "-"}
                     </td>
                     <td className="px-5 py-4 text-[11px] text-gray-500 font-mono">
                       {session.cwd ? truncate(session.cwd, 30) : "-"}

--- a/server/routes/pricing.js
+++ b/server/routes/pricing.js
@@ -116,3 +116,4 @@ router.get("/cost/:sessionId", (req, res) => {
 });
 
 module.exports = router;
+module.exports.calculateCost = calculateCost;

--- a/server/routes/sessions.js
+++ b/server/routes/sessions.js
@@ -1,6 +1,7 @@
 const { Router } = require("express");
-const { stmts } = require("../db");
+const { stmts, db } = require("../db");
 const { broadcast } = require("../websocket");
+const { calculateCost } = require("./pricing");
 
 const router = Router();
 
@@ -12,6 +13,38 @@ router.get("/", (req, res) => {
   const rows = status
     ? stmts.listSessionsByStatus.all(status, limit, offset)
     : stmts.listSessions.all(limit, offset);
+
+  // Bulk-compute costs for all returned sessions in a single pass
+  if (rows.length > 0) {
+    const ids = rows.map((r) => r.id);
+    const placeholders = ids.map(() => "?").join(",");
+    const allTokens = db
+      .prepare(
+        `SELECT session_id, model,
+          input_tokens + baseline_input as input_tokens,
+          output_tokens + baseline_output as output_tokens,
+          cache_read_tokens + baseline_cache_read as cache_read_tokens,
+          cache_write_tokens + baseline_cache_write as cache_write_tokens
+        FROM token_usage WHERE session_id IN (${placeholders})`
+      )
+      .all(...ids);
+
+    const rules = stmts.listPricing.all();
+    const tokensBySession = {};
+    for (const t of allTokens) {
+      if (!tokensBySession[t.session_id]) tokensBySession[t.session_id] = [];
+      tokensBySession[t.session_id].push(t);
+    }
+
+    for (const row of rows) {
+      const sessionTokens = tokensBySession[row.id];
+      if (sessionTokens) {
+        row.cost = calculateCost(sessionTokens, rules).total_cost;
+      } else {
+        row.cost = 0;
+      }
+    }
+  }
 
   res.json({ sessions: rows, limit, offset });
 });


### PR DESCRIPTION
This pull request improves how session costs are displayed in the sessions list by computing and including the cost for each session directly in the backend API response, rather than fetching them individually on the frontend. This results in a more efficient and responsive UI. Additionally, some minor test and export adjustments are included.

**Backend changes (session cost computation):**
* The `/sessions` API endpoint now bulk-computes costs for all returned sessions in a single query, adds a `cost` property to each session, and sends it in the response. This eliminates the need for the frontend to fetch costs for each session individually.
* The `calculateCost` function is now exported from `server/routes/pricing.js` so it can be used in other modules.

**Frontend changes (sessions list):**
* The `Session` type in `client/src/lib/types.ts` now includes an optional `cost` field to receive the new backend property.
* The logic for fetching and tracking session costs individually in the frontend (`Sessions.tsx`) has been removed, and the table now directly displays the `cost` property from each session. [[1]](diffhunk://#diff-edae0d6602b9ebb2bf8590379f4375305c3a0635a7b1c1d884b8c88dbb1775ddL26) [[2]](diffhunk://#diff-edae0d6602b9ebb2bf8590379f4375305c3a0635a7b1c1d884b8c88dbb1775ddL36-L50) [[3]](diffhunk://#diff-edae0d6602b9ebb2bf8590379f4375305c3a0635a7b1c1d884b8c88dbb1775ddL209-R193)

**Testing and configuration:**
* Additional bash commands were added to `.claude/settings.local.json` for running TypeScript checks and other scripts, improving local testing and validation.