### PR TITLE
docs: add Makefile coverage to README, ARCHITECTURE, INSTALL, and SETUP

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1214,3 +1214,24 @@ Claude Code invokes this command on each update, piping a JSON payload to stdin.
 | **React Router 6**              | Standard routing for React SPAs. Layout routes with `<Outlet>` give clean shell composition                                                     |
 | **Lucide React**                | Tree-shakeable icon library. Only imports what's used (~20 icons)                                                                               |
 | **TypeScript Strict**           | Catches null/undefined bugs at compile time. `noUncheckedIndexedAccess` prevents array bounds issues                                            |
+
+---
+
+## Build & Run Targets
+
+A root `Makefile` mirrors every npm script for developers who prefer `make`. Run `make help` for the full list.
+
+```
+make setup          Install all dependencies (root + client + MCP)
+make dev            Start server + client in watch mode
+make build          Build the React client for production
+make start          Start the production server
+make test           Run all tests (server + client)
+make format         Format all files with Prettier
+make mcp-build      Compile MCP TypeScript → JavaScript
+make mcp-typecheck  Type-check MCP source without emitting
+make docker-up      Start via docker-compose
+make docker-down    Stop docker-compose stack
+```
+
+See `Makefile` for the complete set of 30 targets covering setup, dev, testing, formatting, MCP, data management, Codex extensions, and Docker/Podman workflows.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -43,6 +43,8 @@
 - [Performance Characteristics](#performance-characteristics)
 - [Deployment Modes](#deployment-modes)
 - [Statusline Utility](#statusline-utility)
+- [Technology Choices](#technology-choices)
+- [Build & Run Targets](#build--run-targets)
 
 ---
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -34,6 +34,12 @@ npm install
 cd client && npm install
 ```
 
+Or via Makefile (also installs MCP dependencies):
+
+```bash
+make setup
+```
+
 ---
 
 ## Step 3 — Start the dashboard

--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ npm run dev
 npm run build && npm start
 ```
 
+> **Makefile alternative** — all commands are also available via `make`. Run `make help` to see every target, or use shortcuts like `make dev`, `make build`, `make test`, etc.
+
 ### 4. Open
 
 | Mode        | URL                     |

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ A professional dashboard to track and visualize your Claude Code agent sessions,
 ![Python](https://img.shields.io/badge/Python-%3E%3D3.6-3776AB?style=flat-square&logo=python&logoColor=white)
 ![Docker](https://img.shields.io/badge/Docker-20.10-2496ED?style=flat-square&logo=docker&logoColor=white)
 ![Vitest](https://img.shields.io/badge/Vitest-1.0-646CFF?style=flat-square&logo=vitest&logoColor=white)
+![React Testing Library](https://img.shields.io/badge/React_Testing_Library-13.0-FF5733?style=flat-square&logo=testinglibrary&logoColor=white)
+![Make](https://img.shields.io/badge/Make-4.3-000000?style=flat-square&logo=make&logoColor=white)
 ![GitHub Actions](https://img.shields.io/badge/GitHub_Actions-automated_builds-2088FF?style=flat-square&logo=githubactions&logoColor=white)
 ![MIT License](https://img.shields.io/badge/License-MIT-yellow?style=flat-square)
 
@@ -173,7 +175,8 @@ npm run dev
 npm run build && npm start
 ```
 
-> **Makefile alternative** — all commands are also available via `make`. Run `make help` to see every target, or use shortcuts like `make dev`, `make build`, `make test`, etc.
+> [!TIP]
+> **Makefile alternative** — all commands are also available via `make` if you have it installed on your system. Run `make help` to see every target, or use shortcuts like `make dev`, `make build`, `make test`, etc.
 
 ### 4. Open
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -206,6 +206,37 @@ npm run seed
 
 ---
 
+## Makefile targets
+
+All npm scripts are mirrored as `make` targets for convenience. Run `make help` to list them:
+
+```bash
+make help
+```
+
+Commonly used targets:
+
+| Make target | Equivalent npm command | Description |
+|---|---|---|
+| `make setup` | `npm run setup` + MCP install | Install all dependencies (root + client + MCP) |
+| `make dev` | `npm run dev` | Start server + client in watch mode |
+| `make build` | `npm run build` | Build the React client for production |
+| `make start` | `npm start` | Start the production server |
+| `make prod` | `npm run build && npm start` | Build then start in one step |
+| `make test` | `npm test` | Run all tests (server + client) |
+| `make test-server` | `npm run test:server` | Run server tests only |
+| `make test-client` | `npm run test:client` | Run client tests only |
+| `make format` | `npm run format` | Format all files with Prettier |
+| `make format-check` | `npm run format:check` | Check formatting without writing |
+| `make mcp-build` | `npm run mcp:build` | Compile MCP TypeScript |
+| `make mcp-typecheck` | `npm run mcp:typecheck` | Type-check MCP source |
+| `make seed` | `npm run seed` | Load demo data |
+| `make clear-data` | `npm run clear-data` | Delete all data rows |
+| `make docker-up` | `docker compose up -d` | Start via docker-compose |
+| `make docker-down` | `docker compose down` | Stop docker-compose stack |
+
+---
+
 ## Statusline (optional)
 
 The `statusline/` directory contains a standalone terminal statusline for Claude Code showing model, working directory, git branch, context window usage, and token counts. It is independent of the web dashboard.


### PR DESCRIPTION
This pull request updates project documentation to highlight the new `Makefile` and its developer workflow. The changes clarify that all npm scripts are now mirrored as `make` targets, making it easier for developers who prefer using `make`. The documentation now provides clear instructions, usage examples, and tables mapping common `make` targets to their npm equivalents.

**Documentation updates for Makefile-based workflows:**

* Added a new "Build & Run Targets" section in `ARCHITECTURE.md` describing the root `Makefile`, listing common targets, and referencing the full set of 30 available commands.
* Updated `INSTALL.md` to mention `make setup` as an alternative to manually running npm install, especially for installing MCP dependencies.
* Added a note in `README.md` that all commands are available as `make` targets, with instructions to run `make help` for a full list and examples of common shortcuts.
* Added a detailed table in `SETUP.md` mapping each `make` target to its npm equivalent and describing its purpose, making it easier for developers to understand and use the new workflow.