### PR TITLE
feat: add Coralogix full-stack observability to deployment infrastructure

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -32,6 +32,8 @@ Architectural overview and technical reference for the Agent Dashboard system, c
 ![Prometheus](https://img.shields.io/badge/Prometheus-2.x-E6522C?style=flat-square&logo=prometheus&logoColor=white)
 ![Grafana](https://img.shields.io/badge/Grafana-10.x-F46800?style=flat-square&logo=grafana&logoColor=white)
 ![Nginx](https://img.shields.io/badge/Nginx-Ingress-009639?style=flat-square&logo=nginx&logoColor=white)
+![Coralogix](https://img.shields.io/badge/Coralogix-Observability-1a1a2e?style=flat-square&logo=coralogix&logoColor=white)
+![OpenTelemetry](https://img.shields.io/badge/OpenTelemetry-Collector-4f46e5?style=flat-square&logo=opentelemetry&logoColor=white)
 ![AWS](https://img.shields.io/badge/AWS-ECS%20%7C%20RDS-232F3E?style=flat-square&logo=task&logoColor=white)
 ![Google Cloud](https://img.shields.io/badge/Google_Cloud-GKE%20%7C%20SQL-4285F4?style=flat-square&logo=googlecloud&logoColor=white)
 ![Azure](https://img.shields.io/badge/Azure-AKS%20%7C%20SQL-0078D4?style=flat-square&logo=cloudflare&logoColor=white)
@@ -1247,17 +1249,20 @@ graph TB
     LB["Load Balancer<br/>TLS 1.3 · WebSocket<br/>Weighted Routing"]
     PV["Persistent Storage<br/>Encrypted NFS"]
     MON["Monitoring<br/>Prometheus · Grafana<br/>13 Alert Rules"]
+    OTEL["OTel Collector<br/>Coralogix"]
   end
 
   LB -->|"Active"| BLUE
   LB -.->|"Standby"| GREEN
   BLUE & GREEN --> PV
   MON -->|"Scrape"| BLUE & GREEN
+  BLUE & GREEN -->|"logs + metrics + traces"| OTEL
 
   style BLUE fill:#2563eb,color:#fff
   style GREEN fill:#16a34a,color:#fff
   style LB fill:#7c3aed,color:#fff
   style CI fill:#2088ff,color:#fff
+  style OTEL fill:#4f46e5,color:#fff
 ```
 
 | Capability | Details |
@@ -1267,7 +1272,7 @@ graph TB
 | **Release Strategies** | Rolling update, blue-green (instant switchover), canary (automated analysis) |
 | **Environments** | Dev, staging, production with per-environment configuration |
 | **CI/CD** | GitHub Actions and GitLab CI pipelines with Trivy security scanning |
-| **Observability** | Prometheus scraping, 13 alert rules, Grafana dashboard (16 panels), Alertmanager routing |
+| **Observability** | Prometheus scraping, 13 alert rules, Grafana dashboard (16 panels), Alertmanager routing, Coralogix full-stack observability (logs, metrics, traces, SLO tracking) via OpenTelemetry Collector |
 | **Operations** | Scripts for deploy, rollback, blue-green switch, database backup/restore, teardown |
 | **Security** | Restricted PSS, network policies, TLS enforcement, OIDC auth, no long-lived credentials |
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -32,7 +32,7 @@ Architectural overview and technical reference for the Agent Dashboard system, c
 ![Prometheus](https://img.shields.io/badge/Prometheus-2.x-E6522C?style=flat-square&logo=prometheus&logoColor=white)
 ![Grafana](https://img.shields.io/badge/Grafana-10.x-F46800?style=flat-square&logo=grafana&logoColor=white)
 ![Nginx](https://img.shields.io/badge/Nginx-Ingress-009639?style=flat-square&logo=nginx&logoColor=white)
-![Coralogix](https://img.shields.io/badge/Coralogix-Observability-1a1a2e?style=flat-square&logo=coralogix&logoColor=white)
+![Coralogix](https://img.shields.io/badge/Coralogix-Observability-1a1a2e?style=flat-square&logo=datadog&logoColor=white)
 ![OpenTelemetry](https://img.shields.io/badge/OpenTelemetry-Collector-4f46e5?style=flat-square&logo=opentelemetry&logoColor=white)
 ![AWS](https://img.shields.io/badge/AWS-ECS%20%7C%20RDS-232F3E?style=flat-square&logo=task&logoColor=white)
 ![Google Cloud](https://img.shields.io/badge/Google_Cloud-GKE%20%7C%20SQL-4285F4?style=flat-square&logo=googlecloud&logoColor=white)

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -39,6 +39,8 @@ graph TB
     PROM[Prometheus]
     GRAF[Grafana]
     ALERT[Alertmanager]
+    CX[Coralogix]
+    OTEL[OTel Collector]
   end
 
   U --> LB
@@ -48,6 +50,8 @@ graph TB
   B1 & B2 & B3 --> PV
   PROM -->|Scrape| B1 & B2 & B3
   PROM --> ALERT
+  OTEL -->|Ship logs, metrics, traces| CX
+  B1 & B2 & B3 --> OTEL
   GRAF --> PROM
 ```
 
@@ -717,12 +721,17 @@ cp deployments/ci/gitlab-ci/.gitlab-ci.yml .
 ```mermaid
 graph TB
   App[Agent Monitor<br/>Pods] -->|"/metrics"| Prom[Prometheus<br/>Scraping & Storage]
+  App -->|"logs + metrics"| OTEL[OTel Collector<br/>DaemonSet]
   Prom --> Graf[Grafana<br/>Dashboards]
   Prom --> AM[Alertmanager<br/>Routing & Notifications]
+  OTEL -->|"OTLP gRPC"| CX[Coralogix<br/>Full-Stack Observability]
 
   AM --> Slack[Slack]
   AM --> PD[PagerDuty]
   AM --> Email[Email]
+  CX --> CXA[Coralogix Alerts]
+  CXA --> PD
+  CXA --> Slack
 
   subgraph "Grafana Dashboard"
     P1[Request Rate]
@@ -733,11 +742,22 @@ graph TB
     P6[SQLite Operations]
   end
 
+  subgraph "Coralogix Dashboard"
+    C1[Log Analytics / DataPrime]
+    C2[Metrics + Recording Rules]
+    C3[SLO Tracking + Error Budget]
+    C4[Distributed Tracing]
+  end
+
   Graf --- P1 & P2 & P3 & P4 & P5 & P6
+  CX --- C1 & C2 & C3 & C4
 
   style Prom fill:#e6522c,color:#fff
   style Graf fill:#f46800,color:#fff
   style AM fill:#e6522c,color:#fff
+  style CX fill:#1a1a2e,color:#fff
+  style OTEL fill:#4f46e5,color:#fff
+  style CXA fill:#dc2626,color:#fff
 ```
 
 ### Setup
@@ -755,6 +775,15 @@ kubectl apply -f deployments/monitoring/prometheus/rules/agent-monitor.rules.yam
 
 # Apply Alertmanager config
 # Merge deployments/monitoring/alertmanager/alertmanager.yaml into your Alertmanager config
+
+# Deploy Coralogix OTel Collector (optional – full-stack observability)
+helm repo add coralogix https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
+kubectl create secret generic coralogix-keys \
+  --namespace agent-monitor \
+  --from-literal=PRIVATE_KEY=<YOUR_CORALOGIX_KEY>
+helm install coralogix-otel coralogix/opentelemetry \
+  --namespace agent-monitor \
+  -f deployments/monitoring/coralogix/values.yaml
 ```
 
 ### Alert Rules
@@ -784,6 +813,17 @@ The pre-built dashboard (`agent-monitor.json`) includes 16 panels across 6 rows:
 - **Database** — Query duration, row counts, WAL checkpoint time
 - **Resources** — CPU, memory, network I/O, filesystem usage
 - **Deployment** — Pod status, restart count, HPA scaling events
+
+### Coralogix Dashboard
+
+The Coralogix custom dashboard (`monitoring/coralogix/dashboards.yaml`) provides 18 panels across 6 rows with SLO tracking:
+
+- **Overview** — Active sessions, request rate, WebSocket connections
+- **HTTP Performance** — Latency P50/P95/P99, error rate with thresholds, status code distribution
+- **Application Logs** — Error log stream via DataPrime, log volume by severity, hook event throughput
+- **Infrastructure** — CPU, memory, pod status gauges
+- **Database & Storage** — SQLite query duration, PV usage gauge, network I/O
+- **SLO Tracking** — Availability SLO (99.9% target), latency SLO (P95 < 500ms), error budget remaining
 
 ---
 
@@ -858,6 +898,11 @@ deployments/
 │       └── canary/              # Canary with analysis
 ├── monitoring/
 │   ├── alertmanager/            # Alert routing config
+│   ├── coralogix/               # Coralogix full-stack observability
+│   │   ├── values.yaml          # OTel Collector Helm values
+│   │   ├── alerts.yaml          # Alert definitions
+│   │   ├── dashboards.yaml      # Custom dashboard (18 panels)
+│   │   └── coralogix-terraform.tf  # Terraform-managed resources
 │   ├── grafana/
 │   │   ├── dashboards/          # Pre-built dashboard JSON
 │   │   └── datasources.yaml

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ A professional dashboard to track and visualize your Claude Code agent sessions,
 ![Prometheus](https://img.shields.io/badge/Prometheus-2.x-E6522C?style=flat-square&logo=prometheus&logoColor=white)
 ![Grafana](https://img.shields.io/badge/Grafana-10.x-F46800?style=flat-square&logo=grafana&logoColor=white)
 ![Nginx](https://img.shields.io/badge/Nginx-Ingress-009639?style=flat-square&logo=nginx&logoColor=white)
+![Coralogix](https://img.shields.io/badge/Coralogix-Observability-1a1a2e?style=flat-square&logo=coralogix&logoColor=white)
+![OpenTelemetry](https://img.shields.io/badge/OpenTelemetry-Collector-4f46e5?style=flat-square&logo=opentelemetry&logoColor=white)
 ![AWS](https://img.shields.io/badge/AWS-ECS%20%7C%20RDS-232F3E?style=flat-square&logo=task&logoColor=white)
 ![Google Cloud](https://img.shields.io/badge/Google_Cloud-GKE%20%7C%20SQL-4285F4?style=flat-square&logo=googlecloud&logoColor=white)
 ![Azure](https://img.shields.io/badge/Azure-AKS%20%7C%20SQL-0078D4?style=flat-square&logo=cloudflare&logoColor=white)
@@ -1012,8 +1014,14 @@ graph TB
     CAN["Canary + Analysis"]
   end
 
+  subgraph "Observability"
+    PROM["📊 Prometheus + Grafana"]
+    CX["📡 Coralogix<br/>Logs · Metrics · Traces · SLOs"]
+  end
+
   HELM & KUST --> ROLL & BG & CAN
   TF --> AWS & GCP & AZ & OCI
+  ROLL & BG & CAN --> PROM & CX
 
   style HELM fill:#0f1689,color:#fff
   style KUST fill:#326ce5,color:#fff
@@ -1022,6 +1030,8 @@ graph TB
   style GCP fill:#4285f4,color:#fff
   style AZ fill:#0078d4,color:#fff
   style OCI fill:#f80000,color:#fff
+  style PROM fill:#e6522c,color:#fff
+  style CX fill:#1a1a2e,color:#fff
 ```
 
 ```bash
@@ -1041,7 +1051,7 @@ terraform init && terraform apply -var-file=../../environments/production/terraf
 ./deployments/scripts/deploy.sh --env production --method helm --strategy blue-green
 ```
 
-The deployment stack includes CI/CD pipelines (GitHub Actions + GitLab CI), comprehensive monitoring (Prometheus, Grafana, Alertmanager with 13 alert rules), operational scripts (deploy, rollback, blue-green switch, backup/restore, teardown), and a full security posture (Restricted Pod Security Standard, TLS 1.3, network policies, Trivy scanning).
+The deployment stack includes CI/CD pipelines (GitHub Actions + GitLab CI), comprehensive monitoring (Prometheus, Grafana, Alertmanager with 13 alert rules, Coralogix full-stack observability with OpenTelemetry Collector for logs, metrics, traces, and SLO tracking), operational scripts (deploy, rollback, blue-green switch, backup/restore, teardown), and a full security posture (Restricted Pod Security Standard, TLS 1.3, network policies, Trivy scanning).
 
 > [!NOTE]
 > 📘 **Full deployment guide:** See [DEPLOYMENT.md](DEPLOYMENT.md) for step-by-step instructions, architecture diagrams, and operational workflows.
@@ -1157,7 +1167,7 @@ agent-dashboard/
 |   |   +-- strategies/          # Blue-green and canary deployment strategies
 |   |-- helm/agent-monitor/      # Helm chart with 12 templates and 4 value sets
 |   |-- scripts/                 # Operational scripts (deploy, rollback, backup, teardown)
-|   |-- monitoring/              # Prometheus rules, Grafana dashboards, Alertmanager config
+|   |-- monitoring/              # Prometheus, Grafana, Alertmanager, Coralogix (OTel Collector)
 |   +-- ci/                      # CI/CD pipelines (GitHub Actions, GitLab CI)
 |-- .codex/
 |   |-- config.toml              # Codex runtime configuration

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A professional dashboard to track and visualize your Claude Code agent sessions,
 ![Prometheus](https://img.shields.io/badge/Prometheus-2.x-E6522C?style=flat-square&logo=prometheus&logoColor=white)
 ![Grafana](https://img.shields.io/badge/Grafana-10.x-F46800?style=flat-square&logo=grafana&logoColor=white)
 ![Nginx](https://img.shields.io/badge/Nginx-Ingress-009639?style=flat-square&logo=nginx&logoColor=white)
-![Coralogix](https://img.shields.io/badge/Coralogix-Observability-1a1a2e?style=flat-square&logo=coralogix&logoColor=white)
+![Coralogix](https://img.shields.io/badge/Coralogix-Observability-1a1a2e?style=flat-square&logo=datadog&logoColor=white)
 ![OpenTelemetry](https://img.shields.io/badge/OpenTelemetry-Collector-4f46e5?style=flat-square&logo=opentelemetry&logoColor=white)
 ![AWS](https://img.shields.io/badge/AWS-ECS%20%7C%20RDS-232F3E?style=flat-square&logo=task&logoColor=white)
 ![Google Cloud](https://img.shields.io/badge/Google_Cloud-GKE%20%7C%20SQL-4285F4?style=flat-square&logo=googlecloud&logoColor=white)

--- a/deployments/README.md
+++ b/deployments/README.md
@@ -30,7 +30,7 @@ graph TB
     end
 
     subgraph "Observability"
-      MON["monitoring/<br/>Prometheus · Grafana · Alertmanager<br/>13 rules · 16 panels"]
+      MON["monitoring/<br/>Prometheus · Grafana · Alertmanager · Coralogix<br/>13 rules · 16 panels · OTel Collector"]
     end
   end
 
@@ -103,7 +103,8 @@ deployments/
 ├── monitoring/                 # Observability stack configs
 │   ├── prometheus/             # Scrape config + alert rules
 │   ├── grafana/                # Dashboards + datasources
-│   └── alertmanager/           # Alert routing (Slack, PagerDuty, email)
+│   ├── alertmanager/           # Alert routing (Slack, PagerDuty, email)
+│   └── coralogix/              # Full-stack observability (logs, metrics, traces, SLOs)
 └── ci/                         # CI/CD pipeline definitions
     ├── github-actions/         # GitHub Actions workflows
     └── gitlab-ci/              # GitLab CI pipeline
@@ -134,6 +135,7 @@ graph TB
         PV["Persistent Volume<br/>(EFS / Filestore / Azure Files / FSS)"]
         SECRETS["Secret Store<br/>(Vault / Secrets Manager)"]
         MON["Monitoring<br/>(Prometheus / Grafana)"]
+        OTEL["OTel Collector<br/>(Coralogix)"]
     end
 
     USER -->|HTTPS + WSS| LB
@@ -146,6 +148,8 @@ graph TB
     G_MCP -->|localhost:4820| G1
     MON -->|scrape /api/health| Blue
     MON -->|scrape /api/health| Green
+    Blue -->|logs + metrics| OTEL
+    Green -->|logs + metrics| OTEL
 
     style Blue fill:#2563eb,stroke:#3b82f6,color:#fff
     style Green fill:#16a34a,stroke:#22c55e,color:#fff
@@ -297,19 +301,26 @@ The monitoring stack provides:
 - **Prometheus** scrape configuration and alert rules
 - **Grafana** dashboard with request rate, latency, errors, WebSocket connections, resource usage
 - **Alertmanager** routing to Slack, PagerDuty, and email
+- **Coralogix** full-stack observability with log analytics (DataPrime), metrics, distributed tracing, SLO tracking, and error budget management via OpenTelemetry Collector
 
 ```mermaid
 graph LR
     APP["agent-monitor pods"] -->|metrics| PROM["Prometheus"]
+    APP -->|"logs + metrics"| OTEL["OTel Collector"]
     PROM -->|query| GRAF["Grafana Dashboards"]
     PROM -->|evaluate rules| AM["Alertmanager"]
+    OTEL -->|"OTLP gRPC"| CX["Coralogix"]
     AM -->|critical| PD["PagerDuty"]
     AM -->|warning| SLACK["Slack"]
     AM -->|info| EMAIL["Email"]
+    CX -->|alerts| PD
+    CX -->|alerts| SLACK
 
     style PROM fill:#e6522c,stroke:#e6522c,color:#fff
     style GRAF fill:#f46800,stroke:#f46800,color:#fff
     style AM fill:#e6522c,stroke:#e6522c,color:#fff
+    style CX fill:#1a1a2e,stroke:#1a1a2e,color:#fff
+    style OTEL fill:#4f46e5,stroke:#4f46e5,color:#fff
 ```
 
 Deploy the monitoring stack:
@@ -324,6 +335,15 @@ kubectl apply -f ./deployments/monitoring/prometheus/rules/
 # Apply Alertmanager config
 kubectl create secret generic alertmanager-config \
   --from-file=./deployments/monitoring/alertmanager/alertmanager.yaml
+
+# Deploy Coralogix OTel Collector (optional)
+helm repo add coralogix https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
+kubectl create secret generic coralogix-keys \
+  --namespace agent-monitor \
+  --from-literal=PRIVATE_KEY=<YOUR_CORALOGIX_KEY>
+helm install coralogix-otel coralogix/opentelemetry \
+  --namespace agent-monitor \
+  -f ./deployments/monitoring/coralogix/values.yaml
 ```
 
 ## CI/CD
@@ -427,7 +447,7 @@ Provisions the application load balancer with TLS termination and WebSocket supp
 
 ### monitoring/
 
-Provisions cloud-native monitoring and alerting.
+Provisions cloud-native monitoring and alerting, with optional Coralogix full-stack observability.
 
 | Provider | Metrics | Alarms | Logs |
 |----------|---------|--------|------|
@@ -435,6 +455,7 @@ Provisions cloud-native monitoring and alerting.
 | GCP | Cloud Monitoring | Notification Channel | Cloud Logging |
 | Azure | Azure Monitor | Action Group | Log Analytics |
 | OCI | OCI Monitoring | Notification Topic | OCI Logging |
+| Coralogix | PromQL + Recording Rules | Coralogix Alerts → PagerDuty/Slack | DataPrime Log Analytics |
 
 ### Root Variables
 

--- a/deployments/monitoring/coralogix/README.md
+++ b/deployments/monitoring/coralogix/README.md
@@ -1,0 +1,140 @@
+# Coralogix Integration
+
+Full-stack observability for Claude Code Agent Monitor via [Coralogix](https://coralogix.com) — logs, metrics, traces, and SLO tracking through a single platform.
+
+## Architecture
+
+```mermaid
+graph TB
+  subgraph "Kubernetes Cluster"
+    APP["Agent Monitor Pods"]
+    MCP["MCP Sidecar"]
+    OTEL["OTel Collector<br/>(DaemonSet)"]
+  end
+
+  APP -->|"metrics + logs"| OTEL
+  MCP -->|"metrics + logs"| OTEL
+
+  OTEL -->|"OTLP (gRPC)"| CX["Coralogix Platform"]
+
+  subgraph "Coralogix"
+    CX --> LOGS["Log Analytics<br/>DataPrime Queries"]
+    CX --> MET["Metrics<br/>PromQL + Recording Rules"]
+    CX --> TRACE["Distributed Tracing"]
+    CX --> ALERT["Alert Engine"]
+    CX --> DASH["Custom Dashboards"]
+    CX --> SLO["SLO Management"]
+  end
+
+  ALERT -->|"Critical"| PD["PagerDuty"]
+  ALERT -->|"Warning"| SLACK["Slack"]
+
+  style OTEL fill:#4f46e5,color:#fff
+  style CX fill:#1a1a2e,color:#fff
+  style LOGS fill:#7c3aed,color:#fff
+  style MET fill:#e6522c,color:#fff
+  style TRACE fill:#059669,color:#fff
+  style ALERT fill:#dc2626,color:#fff
+  style DASH fill:#f46800,color:#fff
+  style SLO fill:#0ea5e9,color:#fff
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `values.yaml` | Helm values for Coralogix OpenTelemetry Collector |
+| `alerts.yaml` | Alert definitions (mirrors Prometheus/Alertmanager rules) |
+| `dashboards.yaml` | Custom dashboard with 6 rows, 18 panels, SLO tracking |
+| `coralogix-terraform.tf` | Terraform-managed alerts, parsing rules, recording rules |
+
+## Quick Start
+
+### 1. Add the Helm Repository
+
+```bash
+helm repo add coralogix https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
+helm repo update
+```
+
+### 2. Create the API Key Secret
+
+```bash
+kubectl create secret generic coralogix-keys \
+  --namespace agent-monitor \
+  --from-literal=PRIVATE_KEY=<YOUR_CORALOGIX_SEND_YOUR_DATA_KEY>
+```
+
+### 3. Deploy the OTel Collector
+
+```bash
+helm install coralogix-otel coralogix/opentelemetry \
+  --namespace agent-monitor \
+  -f deployments/monitoring/coralogix/values.yaml
+```
+
+### 4. Import the Dashboard
+
+Upload `dashboards.yaml` via the Coralogix UI:
+
+**Dashboards → Custom Dashboards → Import**
+
+### 5. (Optional) Terraform-managed Alerts
+
+```bash
+cd deployments/monitoring/coralogix
+export CORALOGIX_API_KEY="<your-key>"
+export CORALOGIX_ENV="coralogix.com"
+terraform init
+terraform apply
+```
+
+## What Gets Collected
+
+| Signal | Source | Destination |
+|--------|--------|-------------|
+| **Logs** | Pod stdout/stderr (JSON structured) | Coralogix Log Analytics |
+| **Metrics** | Prometheus scrape (`/api/health`) | Coralogix Metrics |
+| **K8s Metrics** | kubelet, cAdvisor, host metrics | Coralogix Metrics |
+| **Traces** | OTLP from application (if instrumented) | Coralogix Tracing |
+
+## Alert Parity
+
+All 10 Prometheus/Alertmanager rules are replicated in Coralogix:
+
+| Alert | Severity | Prometheus | Coralogix |
+|-------|----------|:----------:|:---------:|
+| Instance Down | Critical | ✓ | ✓ |
+| High Error Rate | Critical | ✓ | ✓ |
+| Pod Restart Loop | Critical | ✓ | ✓ |
+| PV Nearly Full | Critical | ✓ | ✓ |
+| High Latency | Warning | ✓ | ✓ |
+| WebSocket Spike | Warning | ✓ | ✓ |
+| High Memory | Warning | ✓ | ✓ |
+| High CPU | Warning | ✓ | ✓ |
+| HPA Maxed Out | Warning | ✓ | ✓ |
+| Slow DB Queries | Warning | ✓ | ✓ |
+
+## Dashboard Panels
+
+The custom dashboard provides 18 panels across 6 rows:
+
+1. **Overview** — Active sessions, request rate, WebSocket connections
+2. **HTTP Performance** — Latency distribution, error rate, status codes
+3. **Application Logs** — Error log stream (DataPrime), log volume by severity, hook throughput
+4. **Infrastructure** — CPU, memory, pod status
+5. **Database & Storage** — SQLite query duration, PV usage, network I/O
+6. **SLO Tracking** — Availability SLO (99.9%), latency SLO (P95 < 500ms), error budget burn
+
+## Coralogix Regions
+
+Set `global.domain` in `values.yaml` to match your Coralogix region:
+
+| Region | Domain |
+|--------|--------|
+| US1 | `coralogix.us` |
+| US2 | `cx498.coralogix.com` |
+| EU1 | `coralogix.com` |
+| EU2 | `eu2.coralogix.com` |
+| AP1 (India) | `coralogix.in` |
+| AP2 (Singapore) | `coralogix.sg` |

--- a/deployments/monitoring/coralogix/alerts.yaml
+++ b/deployments/monitoring/coralogix/alerts.yaml
@@ -1,0 +1,194 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Coralogix Alert Definitions for Claude Code Agent Monitor
+#
+# These alerts can be imported via the Coralogix Alerts API or Terraform
+# provider (coralogix/coralogix). They mirror the Prometheus/Alertmanager
+# rules in ../prometheus/rules/ for consistency across observability stacks.
+#
+# API import:
+#   curl -X POST "https://api.coralogix.com/api/v1/external/alerts" \
+#     -H "Authorization: Bearer $CORALOGIX_API_KEY" \
+#     -H "Content-Type: application/json" \
+#     -d @deployments/monitoring/coralogix/alerts.yaml
+#
+# Terraform:
+#   See the coralogix_alert resources in coralogix-terraform.tf
+# ─────────────────────────────────────────────────────────────────────────────
+
+alerts:
+  # ── Critical ───────────────────────────────────────────────────────────────
+
+  - name: "Agent Monitor Down"
+    description: "No metrics received from agent-monitor pods for > 2 minutes"
+    severity: critical
+    type: metric
+    condition:
+      metric_name: "up"
+      filter:
+        job: "agent-monitor"
+      threshold: 1
+      comparison: less_than
+      for_duration: "2m"
+      of_last: "5m"
+    notifications:
+      - integration: pagerduty
+      - integration: slack
+        channel: "#agent-monitor-critical"
+    labels:
+      service: agent-monitor
+      team: platform
+
+  - name: "High Error Rate"
+    description: "5xx error rate exceeds 5% of total requests for 5 minutes"
+    severity: critical
+    type: ratio
+    condition:
+      numerator:
+        query: 'http_requests_total{job="agent-monitor", status=~"5.."}'
+      denominator:
+        query: 'http_requests_total{job="agent-monitor"}'
+      threshold: 0.05
+      comparison: greater_than
+      for_duration: "5m"
+    notifications:
+      - integration: pagerduty
+      - integration: slack
+        channel: "#agent-monitor-critical"
+    labels:
+      service: agent-monitor
+
+  - name: "Pod Restart Loop"
+    description: "Agent Monitor pod has restarted > 5 times in 15 minutes"
+    severity: critical
+    type: metric
+    condition:
+      query: 'increase(kube_pod_container_status_restarts_total{namespace=~"agent-monitor.*", container="agent-monitor"}[15m])'
+      threshold: 5
+      comparison: greater_than
+      for_duration: "1m"
+    notifications:
+      - integration: pagerduty
+      - integration: slack
+        channel: "#agent-monitor-critical"
+    labels:
+      service: agent-monitor
+
+  - name: "Persistent Volume Nearly Full"
+    description: "SQLite persistent volume is > 90% full"
+    severity: critical
+    type: metric
+    condition:
+      query: '(kubelet_volume_stats_used_bytes{namespace=~"agent-monitor.*"} / kubelet_volume_stats_capacity_bytes{namespace=~"agent-monitor.*"}) * 100'
+      threshold: 90
+      comparison: greater_than
+      for_duration: "5m"
+    notifications:
+      - integration: pagerduty
+      - integration: slack
+        channel: "#agent-monitor-critical"
+    labels:
+      service: agent-monitor
+
+  # ── Warning ────────────────────────────────────────────────────────────────
+
+  - name: "High Latency"
+    description: "P95 request latency exceeds 2 seconds for 5 minutes"
+    severity: warning
+    type: metric
+    condition:
+      query: 'histogram_quantile(0.95, rate(http_request_duration_seconds_bucket{job="agent-monitor"}[5m]))'
+      threshold: 2
+      comparison: greater_than
+      for_duration: "5m"
+    notifications:
+      - integration: slack
+        channel: "#agent-monitor-alerts"
+    labels:
+      service: agent-monitor
+
+  - name: "WebSocket Connection Spike"
+    description: "Active WebSocket connections exceed 1000"
+    severity: warning
+    type: metric
+    condition:
+      metric_name: "websocket_connections_active"
+      filter:
+        job: "agent-monitor"
+      threshold: 1000
+      comparison: greater_than
+      for_duration: "2m"
+    notifications:
+      - integration: slack
+        channel: "#agent-monitor-alerts"
+    labels:
+      service: agent-monitor
+
+  - name: "High Memory Usage"
+    description: "Container memory usage exceeds 85% of limit"
+    severity: warning
+    type: metric
+    condition:
+      query: '(container_memory_working_set_bytes{namespace=~"agent-monitor.*", container="agent-monitor"} / container_spec_memory_limit_bytes{namespace=~"agent-monitor.*", container="agent-monitor"}) * 100'
+      threshold: 85
+      comparison: greater_than
+      for_duration: "5m"
+    notifications:
+      - integration: slack
+        channel: "#agent-monitor-alerts"
+    labels:
+      service: agent-monitor
+
+  - name: "High CPU Usage"
+    description: "Container CPU usage exceeds 80% for 10 minutes"
+    severity: warning
+    type: metric
+    condition:
+      query: '(rate(container_cpu_usage_seconds_total{namespace=~"agent-monitor.*", container="agent-monitor"}[5m]) / container_spec_cpu_quota{namespace=~"agent-monitor.*", container="agent-monitor"} * 100000)'
+      threshold: 80
+      comparison: greater_than
+      for_duration: "10m"
+    notifications:
+      - integration: slack
+        channel: "#agent-monitor-alerts"
+    labels:
+      service: agent-monitor
+
+  - name: "HPA Maxed Out"
+    description: "HPA replicas at max for 15 minutes — may need capacity increase"
+    severity: warning
+    type: metric
+    condition:
+      query: 'kube_horizontalpodautoscaler_status_current_replicas{namespace=~"agent-monitor.*"} == kube_horizontalpodautoscaler_spec_max_replicas{namespace=~"agent-monitor.*"}'
+      threshold: 1
+      comparison: greater_than_or_equal
+      for_duration: "15m"
+    notifications:
+      - integration: slack
+        channel: "#agent-monitor-alerts"
+    labels:
+      service: agent-monitor
+
+  - name: "Slow Database Queries"
+    description: "SQLite query duration exceeds 1 second"
+    severity: warning
+    type: metric
+    condition:
+      metric_name: "sqlite_query_duration_seconds"
+      filter:
+        job: "agent-monitor"
+      threshold: 1
+      comparison: greater_than
+      for_duration: "5m"
+    notifications:
+      - integration: slack
+        channel: "#agent-monitor-alerts"
+    labels:
+      service: agent-monitor
+
+# ── Notification integrations ────────────────────────────────────────────────
+# Configure these in Coralogix UI: Settings → Integrations → Outbound Webhooks
+#
+# Required integrations:
+#   - pagerduty: PagerDuty Events API v2 routing key
+#   - slack: Slack webhook for #agent-monitor-critical and #agent-monitor-alerts
+#   - email: (optional) Email notification group

--- a/deployments/monitoring/coralogix/coralogix-terraform.tf
+++ b/deployments/monitoring/coralogix/coralogix-terraform.tf
@@ -1,0 +1,353 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Coralogix Terraform Integration for Claude Code Agent Monitor
+#
+# Provisions Coralogix resources via the official Terraform provider:
+#   - Alert rules (mirroring Prometheus/Alertmanager rules)
+#   - Log parsing rules for structured JSON ingestion
+#   - Recording rules for pre-aggregated SLO metrics
+#   - Dashboard provisioning
+#
+# Usage:
+#   export CORALOGIX_API_KEY="<your-send-your-data-key>"
+#   export CORALOGIX_ENV="<your-coralogix-domain>"  # e.g. coralogix.com
+#   terraform init
+#   terraform plan
+#   terraform apply
+#
+# Requires: hashicorp/terraform >= 1.5, coralogix/coralogix >= 1.10
+# ─────────────────────────────────────────────────────────────────────────────
+
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    coralogix = {
+      source  = "coralogix/coralogix"
+      version = "~> 1.10"
+    }
+  }
+}
+
+provider "coralogix" {
+  # API key and environment are sourced from:
+  #   CORALOGIX_API_KEY  – Send-Your-Data API key
+  #   CORALOGIX_ENV      – Domain (e.g. coralogix.com, eu2.coralogix.com)
+}
+
+# ── Variables ────────────────────────────────────────────────────────────────
+
+variable "environment" {
+  description = "Deployment environment (dev, staging, production)"
+  type        = string
+  default     = "production"
+  validation {
+    condition     = contains(["dev", "staging", "production"], var.environment)
+    error_message = "environment must be one of: dev, staging, production."
+  }
+}
+
+variable "notification_group_id" {
+  description = "Coralogix notification group ID for alert routing"
+  type        = string
+  default     = ""
+}
+
+variable "pagerduty_webhook_id" {
+  description = "Coralogix outbound webhook ID for PagerDuty integration"
+  type        = string
+  default     = ""
+}
+
+variable "slack_webhook_id" {
+  description = "Coralogix outbound webhook ID for Slack integration"
+  type        = string
+  default     = ""
+}
+
+locals {
+  app_name    = "agent-monitor"
+  subsystem   = "kubernetes"
+  alert_prefix = "[Agent Monitor]"
+}
+
+# ── Parsing Rules ────────────────────────────────────────────────────────────
+# Structured JSON log parsing for agent-monitor application logs
+
+resource "coralogix_rules_group" "agent_monitor_parsing" {
+  name         = "${local.alert_prefix} Log Parsing"
+  description  = "Parse structured JSON logs from Agent Monitor pods"
+  enabled      = true
+  order        = 1
+
+  rule_subgroups {
+    rules {
+      name        = "JSON Extract"
+      description = "Extract structured fields from JSON application logs"
+      source_field = "text"
+      enabled     = true
+
+      parse_json_field {
+        destination_field = "json"
+        keep_source_field = false
+        keep_destination_field = true
+      }
+    }
+  }
+
+  rule_subgroups {
+    rules {
+      name        = "Severity Mapping"
+      description = "Map log level field to Coralogix severity"
+      source_field = "json.level"
+      enabled     = true
+
+      extract {
+        regexp = "(?P<severity>debug|info|warn|error|fatal)"
+      }
+    }
+  }
+}
+
+# ── Recording Rules ──────────────────────────────────────────────────────────
+# Pre-aggregate SLO metrics for efficient dashboard queries
+
+resource "coralogix_recording_rule_group_set" "slo_metrics" {
+  name = "${local.alert_prefix} SLO Recording Rules"
+
+  groups {
+    name     = "agent_monitor_slo"
+    interval = 60 # seconds
+
+    rules {
+      record = "agent_monitor:http_availability:ratio_rate5m"
+      expr   = <<-EOT
+        1 - (
+          sum(rate(http_requests_total{job="agent-monitor", status=~"5.."}[5m]))
+          /
+          sum(rate(http_requests_total{job="agent-monitor"}[5m]))
+        )
+      EOT
+      labels = {
+        service     = local.app_name
+        environment = var.environment
+      }
+    }
+
+    rules {
+      record = "agent_monitor:http_latency_p95:seconds_rate5m"
+      expr   = <<-EOT
+        histogram_quantile(0.95,
+          sum(rate(http_request_duration_seconds_bucket{job="agent-monitor"}[5m])) by (le)
+        )
+      EOT
+      labels = {
+        service     = local.app_name
+        environment = var.environment
+      }
+    }
+
+    rules {
+      record = "agent_monitor:websocket_connections:total"
+      expr   = <<-EOT
+        sum(websocket_connections_active{job="agent-monitor"})
+      EOT
+      labels = {
+        service     = local.app_name
+        environment = var.environment
+      }
+    }
+  }
+}
+
+# ── Alert Rules ──────────────────────────────────────────────────────────────
+
+resource "coralogix_alert" "instance_down" {
+  name        = "${local.alert_prefix} Instance Down"
+  description = "No metrics received from agent-monitor pods for > 2 minutes"
+  severity    = "Critical"
+  enabled     = true
+
+  metric {
+    promql {
+      text      = "up{job=\"agent-monitor\"} == 0"
+      condition = "more_than"
+      threshold = 0
+    }
+    duration = "2m"
+  }
+
+  notifications_group {
+    dynamic "notification" {
+      for_each = var.pagerduty_webhook_id != "" ? [1] : []
+      content {
+        integration_id = var.pagerduty_webhook_id
+      }
+    }
+    dynamic "notification" {
+      for_each = var.slack_webhook_id != "" ? [1] : []
+      content {
+        integration_id = var.slack_webhook_id
+      }
+    }
+  }
+
+  labels = {
+    service     = local.app_name
+    environment = var.environment
+    team        = "platform"
+  }
+}
+
+resource "coralogix_alert" "high_error_rate" {
+  name        = "${local.alert_prefix} High Error Rate"
+  description = "5xx error rate exceeds 5% of total requests for 5 minutes"
+  severity    = "Critical"
+  enabled     = true
+
+  metric {
+    promql {
+      text = <<-EOT
+        (
+          sum(rate(http_requests_total{job="agent-monitor", status=~"5.."}[5m]))
+          /
+          sum(rate(http_requests_total{job="agent-monitor"}[5m]))
+        ) * 100 > 5
+      EOT
+      condition = "more_than"
+      threshold = 5
+    }
+    duration = "5m"
+  }
+
+  notifications_group {
+    dynamic "notification" {
+      for_each = var.pagerduty_webhook_id != "" ? [1] : []
+      content {
+        integration_id = var.pagerduty_webhook_id
+      }
+    }
+  }
+
+  labels = {
+    service     = local.app_name
+    environment = var.environment
+  }
+}
+
+resource "coralogix_alert" "high_latency" {
+  name        = "${local.alert_prefix} High Latency"
+  description = "P95 request latency exceeds 2 seconds for 5 minutes"
+  severity    = "Warning"
+  enabled     = true
+
+  metric {
+    promql {
+      text      = "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{job=\"agent-monitor\"}[5m])) by (le)) > 2"
+      condition = "more_than"
+      threshold = 2
+    }
+    duration = "5m"
+  }
+
+  notifications_group {
+    dynamic "notification" {
+      for_each = var.slack_webhook_id != "" ? [1] : []
+      content {
+        integration_id = var.slack_webhook_id
+      }
+    }
+  }
+
+  labels = {
+    service     = local.app_name
+    environment = var.environment
+  }
+}
+
+resource "coralogix_alert" "high_memory" {
+  name        = "${local.alert_prefix} High Memory Usage"
+  description = "Container memory usage exceeds 85% of limit"
+  severity    = "Warning"
+  enabled     = true
+
+  metric {
+    promql {
+      text = <<-EOT
+        (
+          container_memory_working_set_bytes{namespace=~"agent-monitor.*", container="agent-monitor"}
+          /
+          container_spec_memory_limit_bytes{namespace=~"agent-monitor.*", container="agent-monitor"}
+        ) * 100 > 85
+      EOT
+      condition = "more_than"
+      threshold = 85
+    }
+    duration = "5m"
+  }
+
+  notifications_group {
+    dynamic "notification" {
+      for_each = var.slack_webhook_id != "" ? [1] : []
+      content {
+        integration_id = var.slack_webhook_id
+      }
+    }
+  }
+
+  labels = {
+    service     = local.app_name
+    environment = var.environment
+  }
+}
+
+resource "coralogix_alert" "pod_restart_loop" {
+  name        = "${local.alert_prefix} Pod Restart Loop"
+  description = "Agent Monitor pod has restarted > 5 times in 15 minutes"
+  severity    = "Critical"
+  enabled     = true
+
+  metric {
+    promql {
+      text      = "increase(kube_pod_container_status_restarts_total{namespace=~\"agent-monitor.*\", container=\"agent-monitor\"}[15m]) > 5"
+      condition = "more_than"
+      threshold = 5
+    }
+    duration = "1m"
+  }
+
+  notifications_group {
+    dynamic "notification" {
+      for_each = var.pagerduty_webhook_id != "" ? [1] : []
+      content {
+        integration_id = var.pagerduty_webhook_id
+      }
+    }
+  }
+
+  labels = {
+    service     = local.app_name
+    environment = var.environment
+  }
+}
+
+# ── Outputs ──────────────────────────────────────────────────────────────────
+
+output "parsing_rule_group_id" {
+  description = "ID of the Coralogix parsing rule group"
+  value       = coralogix_rules_group.agent_monitor_parsing.id
+}
+
+output "recording_rule_set_id" {
+  description = "ID of the Coralogix recording rule group set"
+  value       = coralogix_recording_rule_group_set.slo_metrics.id
+}
+
+output "alert_ids" {
+  description = "IDs of all provisioned Coralogix alerts"
+  value = {
+    instance_down   = coralogix_alert.instance_down.id
+    high_error_rate = coralogix_alert.high_error_rate.id
+    high_latency    = coralogix_alert.high_latency.id
+    high_memory     = coralogix_alert.high_memory.id
+    pod_restart     = coralogix_alert.pod_restart_loop.id
+  }
+}

--- a/deployments/monitoring/coralogix/dashboards.yaml
+++ b/deployments/monitoring/coralogix/dashboards.yaml
@@ -1,0 +1,245 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Coralogix Custom Dashboard – Agent Monitor
+#
+# Import via Coralogix UI: Dashboards → Custom Dashboards → Import
+# Or via API:
+#   curl -X POST "https://api.coralogix.com/api/v1/external/grafana/api/dashboards/db" \
+#     -H "Authorization: Bearer $CORALOGIX_API_KEY" \
+#     -H "Content-Type: application/json" \
+#     -d @dashboards.yaml
+#
+# This dashboard mirrors the Grafana dashboard (../grafana/dashboards/) while
+# leveraging Coralogix-native features: DataPrime queries, log correlation,
+# distributed tracing waterfall, and Apdex scoring.
+# ─────────────────────────────────────────────────────────────────────────────
+
+dashboard:
+  name: "Agent Monitor – Operations"
+  description: "Claude Code Agent Monitor: real-time operations, SLOs, and infrastructure health"
+  folder: "Agent Monitor"
+  tags:
+    - agent-monitor
+    - operations
+    - sre
+
+  # ── Row 1: Overview ──────────────────────────────────────────────────────
+  rows:
+    - name: "Overview"
+      panels:
+        - title: "Active Sessions"
+          type: line-chart
+          query:
+            type: metrics
+            promql: 'agent_monitor_active_sessions'
+            legend: "{{namespace}}"
+          span: 4
+
+        - title: "Request Rate (req/s)"
+          type: line-chart
+          query:
+            type: metrics
+            promql: 'sum(rate(http_requests_total{job="agent-monitor"}[5m]))'
+            legend: "Requests/sec"
+          span: 4
+
+        - title: "WebSocket Connections"
+          type: line-chart
+          query:
+            type: metrics
+            promql: 'websocket_connections_active{job="agent-monitor"}'
+            legend: "{{pod}}"
+          span: 4
+
+    # ── Row 2: HTTP Performance ────────────────────────────────────────────
+    - name: "HTTP Performance"
+      panels:
+        - title: "Latency Distribution (P50 / P95 / P99)"
+          type: line-chart
+          query:
+            type: metrics
+            promql: |
+              histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket{job="agent-monitor"}[5m])) by (le))
+              histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{job="agent-monitor"}[5m])) by (le))
+              histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{job="agent-monitor"}[5m])) by (le))
+          span: 6
+
+        - title: "Error Rate (%)"
+          type: line-chart
+          query:
+            type: metrics
+            promql: |
+              sum(rate(http_requests_total{job="agent-monitor", status=~"5.."}[5m]))
+              /
+              sum(rate(http_requests_total{job="agent-monitor"}[5m])) * 100
+            legend: "5xx %"
+          thresholds:
+            - value: 1
+              color: yellow
+            - value: 5
+              color: red
+          span: 3
+
+        - title: "Status Code Distribution"
+          type: bar-chart
+          query:
+            type: metrics
+            promql: 'sum by (status) (increase(http_requests_total{job="agent-monitor"}[1h]))'
+          span: 3
+
+    # ── Row 3: Logs (DataPrime) ────────────────────────────────────────────
+    - name: "Application Logs"
+      panels:
+        - title: "Error Logs"
+          type: dataprime
+          query: |
+            source logs
+            | filter $d.cx.application.name == 'agent-monitor'
+            | filter $d.severity == 'ERROR' || $d.severity == 'FATAL'
+            | select $m.timestamp, $d.k8s.pod.name, $d.message
+            | order by $m.timestamp desc
+            | limit 100
+          span: 6
+
+        - title: "Log Volume by Severity"
+          type: bar-chart
+          query:
+            type: dataprime
+            expression: |
+              source logs
+              | filter $d.cx.application.name == 'agent-monitor'
+              | count_group_by $d.severity as count
+          span: 3
+
+        - title: "Hook Event Throughput"
+          type: line-chart
+          query:
+            type: dataprime
+            expression: |
+              source logs
+              | filter $d.cx.application.name == 'agent-monitor'
+              | filter $d.message matches 'hook.*event'
+              | count_per_time 1m as throughput
+          span: 3
+
+    # ── Row 4: Infrastructure ──────────────────────────────────────────────
+    - name: "Infrastructure"
+      panels:
+        - title: "CPU Usage (%)"
+          type: line-chart
+          query:
+            type: metrics
+            promql: |
+              rate(container_cpu_usage_seconds_total{
+                namespace=~"agent-monitor.*",
+                container="agent-monitor"
+              }[5m]) * 100
+            legend: "{{pod}}"
+          span: 4
+
+        - title: "Memory Usage (MiB)"
+          type: line-chart
+          query:
+            type: metrics
+            promql: |
+              container_memory_working_set_bytes{
+                namespace=~"agent-monitor.*",
+                container="agent-monitor"
+              } / 1024 / 1024
+            legend: "{{pod}}"
+          span: 4
+
+        - title: "Pod Status"
+          type: gauge
+          query:
+            type: metrics
+            promql: |
+              count by (phase) (
+                kube_pod_status_phase{namespace=~"agent-monitor.*"}
+              )
+          span: 4
+
+    # ── Row 5: Database & Storage ──────────────────────────────────────────
+    - name: "Database & Storage"
+      panels:
+        - title: "SQLite Query Duration (ms)"
+          type: line-chart
+          query:
+            type: metrics
+            promql: 'sqlite_query_duration_seconds{job="agent-monitor"} * 1000'
+          span: 4
+
+        - title: "PV Usage (%)"
+          type: gauge
+          query:
+            type: metrics
+            promql: |
+              (kubelet_volume_stats_used_bytes{namespace=~"agent-monitor.*"}
+              / kubelet_volume_stats_capacity_bytes{namespace=~"agent-monitor.*"}) * 100
+          thresholds:
+            - value: 70
+              color: yellow
+            - value: 90
+              color: red
+          span: 4
+
+        - title: "Network I/O (bytes/s)"
+          type: line-chart
+          query:
+            type: metrics
+            promql: |
+              sum by (pod) (rate(container_network_receive_bytes_total{namespace=~"agent-monitor.*"}[5m]))
+              sum by (pod) (rate(container_network_transmit_bytes_total{namespace=~"agent-monitor.*"}[5m]))
+          span: 4
+
+    # ── Row 6: SLO Tracking ────────────────────────────────────────────────
+    - name: "SLO Tracking"
+      panels:
+        - title: "Availability SLO (99.9% target)"
+          type: gauge
+          query:
+            type: metrics
+            promql: |
+              (1 - sum(rate(http_requests_total{job="agent-monitor", status=~"5.."}[30d]))
+              / sum(rate(http_requests_total{job="agent-monitor"}[30d]))) * 100
+          thresholds:
+            - value: 99.9
+              color: green
+            - value: 99.5
+              color: yellow
+            - value: 99.0
+              color: red
+          span: 4
+
+        - title: "Latency SLO (P95 < 500ms)"
+          type: gauge
+          query:
+            type: metrics
+            promql: |
+              histogram_quantile(0.95,
+                sum(rate(http_request_duration_seconds_bucket{job="agent-monitor"}[30d])) by (le)
+              ) * 1000
+          thresholds:
+            - value: 300
+              color: green
+            - value: 500
+              color: yellow
+            - value: 1000
+              color: red
+          span: 4
+
+        - title: "Error Budget Remaining"
+          type: gauge
+          query:
+            type: metrics
+            promql: |
+              (0.001 - sum(rate(http_requests_total{job="agent-monitor", status=~"5.."}[30d]))
+              / sum(rate(http_requests_total{job="agent-monitor"}[30d])))
+              / 0.001 * 100
+          thresholds:
+            - value: 50
+              color: green
+            - value: 25
+              color: yellow
+            - value: 0
+              color: red
+          span: 4

--- a/deployments/monitoring/coralogix/values.yaml
+++ b/deployments/monitoring/coralogix/values.yaml
@@ -1,0 +1,180 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Coralogix OpenTelemetry Collector – Helm Values
+#
+# Deploys the Coralogix OTel collector as a DaemonSet + Gateway for shipping
+# logs, metrics, and traces from the Agent Monitor cluster.
+#
+# Prerequisites:
+#   1. Add Coralogix Helm repo:
+#        helm repo add coralogix https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
+#        helm repo update
+#   2. Create the API key secret:
+#        kubectl create secret generic coralogix-keys \
+#          --namespace agent-monitor \
+#          --from-literal=PRIVATE_KEY=<YOUR_CORALOGIX_PRIVATE_KEY>
+#
+# Install:
+#   helm install coralogix-otel coralogix/opentelemetry \
+#     --namespace agent-monitor \
+#     -f deployments/monitoring/coralogix/values.yaml
+# ─────────────────────────────────────────────────────────────────────────────
+
+global:
+  # Coralogix domain – set to your region's endpoint
+  # Options: coralogix.com | eu2.coralogix.com | coralogix.in | coralogix.us |
+  #          cx498.coralogix.com | coralogix.eu | coralogix.sg
+  domain: "coralogix.com"
+
+  # Reference the API key from the pre-created K8s secret
+  clusterName: "agent-monitor"
+
+# ── Secret reference ─────────────────────────────────────────────────────────
+secret:
+  enabled: true
+  name: "coralogix-keys"
+  # Key in the secret containing the Coralogix Send-Your-Data API key
+  privateKeySecretRef:
+    key: "PRIVATE_KEY"
+
+# ── Collector – DaemonSet mode (node-level collection) ───────────────────────
+opentelemetry-collector:
+  mode: daemonset
+
+  presets:
+    # Collect Kubernetes pod/container logs
+    logsCollection:
+      enabled: true
+      includeCollectorLogs: false
+
+    # Enrich telemetry with Kubernetes metadata
+    kubernetesAttributes:
+      enabled: true
+      extractAllPodLabels: true
+      extractAllPodAnnotations: false
+
+    # Collect host-level metrics (CPU, memory, disk, network)
+    hostMetrics:
+      enabled: true
+
+    # Collect kubelet/cAdvisor metrics
+    kubeletMetrics:
+      enabled: true
+
+  config:
+    receivers:
+      # Scrape Prometheus metrics from agent-monitor pods
+      prometheus:
+        config:
+          scrape_configs:
+            - job_name: "agent-monitor"
+              scrape_interval: 15s
+              kubernetes_sd_configs:
+                - role: pod
+                  namespaces:
+                    names:
+                      - agent-monitor
+                      - agent-monitor-staging
+                      - agent-monitor-production
+              relabel_configs:
+                - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+                  action: keep
+                  regex: "true"
+                - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+                  action: replace
+                  target_label: __metrics_path__
+                  regex: (.+)
+                - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+                  action: replace
+                  regex: ([^:]+)(?::\d+)?;(\d+)
+                  replacement: $$1:$$2
+                  target_label: __address__
+
+      # Receive OTLP from in-cluster services (gRPC + HTTP)
+      otlp:
+        protocols:
+          grpc:
+            endpoint: "0.0.0.0:4317"
+          http:
+            endpoint: "0.0.0.0:4318"
+
+    processors:
+      # Batch telemetry for efficient export
+      batch:
+        send_batch_size: 1024
+        send_batch_max_size: 2048
+        timeout: 5s
+
+      # Enrich with resource attributes
+      resource:
+        attributes:
+          - key: cx.application.name
+            value: "agent-monitor"
+            action: upsert
+          - key: cx.subsystem.name
+            from_attribute: k8s.container.name
+            action: upsert
+          - key: k8s.cluster.name
+            value: "agent-monitor"
+            action: upsert
+
+      # Memory limiter to prevent OOM
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
+
+      # Filter out noisy internal logs
+      filter/drop-internal:
+        logs:
+          exclude:
+            match_type: regexp
+            bodies:
+              - ".*kube-probe.*"
+              - ".*healthz.*"
+
+    exporters:
+      coralogix:
+        domain: "${CORALOGIX_DOMAIN}"
+        private_key: "${PRIVATE_KEY}"
+        application_name: "agent-monitor"
+        subsystem_name: "kubernetes"
+        timeout: 30s
+
+    service:
+      pipelines:
+        logs:
+          receivers: [otlp]
+          processors: [memory_limiter, resource, filter/drop-internal, batch]
+          exporters: [coralogix]
+        metrics:
+          receivers: [otlp, prometheus]
+          processors: [memory_limiter, resource, batch]
+          exporters: [coralogix]
+        traces:
+          receivers: [otlp]
+          processors: [memory_limiter, resource, batch]
+          exporters: [coralogix]
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+  tolerations:
+    - operator: Exists
+      effect: NoSchedule
+
+# ── Gateway mode (optional – for centralized export) ─────────────────────────
+opentelemetry-gateway:
+  enabled: false
+  replicaCount: 2
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: "1Gi"


### PR DESCRIPTION
- Add deployments/monitoring/coralogix/ with OTel Collector Helm values, alert definitions, custom dashboard (18 panels, SLO tracking), and Terraform-managed resources via coralogix/coralogix provider
- Update README.md with Coralogix/OpenTelemetry badges, observability subgraph in deployment diagram, and updated project structure tree
- Update ARCHITECTURE.md infrastructure diagram and capability table
- Update DEPLOYMENT.md observability stack diagram, monitoring setup commands, Coralogix dashboard section, and file tree
- Update deployments/README.md architecture diagram, monitoring section, provider table, and data flow diagram