### PR TITLE
feat: enhance hook note styling and adjust layout in index.html and style.css

### DIFF
--- a/index.html
+++ b/index.html
@@ -3200,10 +3200,16 @@ docker run -d --name agent-monitor \
             </table>
           </div>
 
-          <div class="callout callout-warn">
-            <strong>Hook note:</strong> Claude Code hooks run on the host, not inside the container.
-            The containerized server receives hook events via HTTP on <code>localhost:4820</code>.
-            Run <code>npm run install-hooks</code> on the host after starting the container.
+          <div class="callout callout-warning">
+            <div class="callout-icon">⚠</div>
+            <div class="callout-body">
+              <strong>Hook note</strong>
+              <p>
+                Claude Code hooks run on the host, not inside the container. The containerized server
+                receives hook events via HTTP on <code>localhost:4820</code>. Run
+                <code>npm run install-hooks</code> on the host after starting the container.
+              </p>
+            </div>
           </div>
         </section>
 

--- a/wiki/style.css
+++ b/wiki/style.css
@@ -304,7 +304,6 @@ body {
   font-size: 18px;
   color: var(--text-muted);
   line-height: 1.6;
-  max-width: 640px;
   margin-bottom: 28px;
 }
 
@@ -314,8 +313,9 @@ body {
   overflow: hidden;
   mask-image: linear-gradient(to right, transparent, #000 6%, #000 94%, transparent);
   -webkit-mask-image: linear-gradient(to right, transparent, #000 6%, #000 94%, transparent);
-  max-width: 700px;
   min-width: 0;
+  padding-top: 6px;
+  margin-top: -6px;
 }
 
 .marquee-track {
@@ -1368,7 +1368,6 @@ hr {
 
 .screenshot-gallery.gallery-single {
   grid-template-columns: 1fr;
-  max-width: 780px;
 }
 
 .screenshot-card {


### PR DESCRIPTION
This pull request focuses on improving the user interface and layout consistency for both the documentation and the wiki. The main changes include enhancing the visual style of callout warnings in the documentation and refining the layout by adjusting or removing certain maximum width constraints and spacing in the wiki's CSS.

**Documentation UI improvements:**

* Updated the warning callout in the `<h3>Multi-Stage Build</h3>` section of `index.html` to use a more visually distinct style with an icon and improved structure for better visibility and clarity.

**Wiki layout and style adjustments:**

* Removed the `max-width` property from the `body` selector in `wiki/style.css` to allow for more flexible content width.
* Adjusted the `.marquee` class in `wiki/style.css` by removing the `max-width`, adding `padding-top: 6px`, and setting `margin-top: -6px` for improved spacing and alignment.
* Removed the `max-width` constraint from the `.screenshot-gallery.gallery-single` class in `wiki/style.css` to allow screenshots to use more available space.