### PR TITLE
fix(client): prevent analytics TS build error

### DIFF
--- a/client/src/pages/Analytics.tsx
+++ b/client/src/pages/Analytics.tsx
@@ -282,9 +282,9 @@ function CostTrendLine({
   });
 
   const linePoints = points.map((p) => `${p.x},${p.y}`).join(" ");
-  const first = points[0];
-  const last = points[points.length - 1];
-  const areaPoints = `${first.x},${height - padY} ${linePoints} ${last.x},${height - padY}`;
+  const firstX = points[0]?.x ?? padX;
+  const lastX = points[points.length - 1]?.x ?? padX;
+  const areaPoints = `${firstX},${height - padY} ${linePoints} ${lastX},${height - padY}`;
 
   return (
     <div className="relative">


### PR DESCRIPTION
This pull request makes a small improvement to the `CostTrendLine` component in `Analytics.tsx`. The change ensures that the area under the trend line is rendered correctly even when the `points` array is empty, preventing potential runtime errors.

* Improved handling of empty `points` arrays by using optional chaining and default values for `firstX` and `lastX` in the calculation of `areaPoints`.