### PR TITLE
Update Husky scripts for new server and client directories

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -8,11 +8,11 @@ npx lint-staged
 
 # Type-check backend and frontend (fast incremental)
 echo "🧪 Type-checking backend..."
-cd backend && npx tsc --noEmit
+cd server && npx tsc --noEmit
 cd ..
 
 echo "🧪 Type-checking frontend..."
-cd frontend && npx tsc --noEmit
+cd client && npx tsc --noEmit
 cd ..
 
 echo "✅ Pre-commit checks passed!"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -5,12 +5,12 @@ echo "🚀 Running pre-push tests..."
 
 # Run backend tests
 echo "🧪 Running backend tests..."
-cd backend && npm run test
+cd server && npm run test
 cd ..
 
 # Run frontend tests
 echo "🧪 Running frontend tests..."
-cd frontend && npm run test
+cd client && npm run test
 cd ..
 
 echo "✅ Pre-push tests passed!"


### PR DESCRIPTION
This pull request updates the pre-commit and pre-push Git hooks to reflect recent directory renaming in the project. The scripts now reference `server` instead of `backend` and `client` instead of `frontend` to ensure type-checking and tests run against the correct directories.

**Update to directory references in Git hooks:**

* [`.husky/pre-commit`](diffhunk://#diff-d2bc4bbf14eadc292d84e0ef5f7a93115c23557f533809fc80b896934291529dL11-R15): Changed type-check commands to use `server` and `client` directories instead of `backend` and `frontend`.
* [`.husky/pre-push`](diffhunk://#diff-43bbc75a027a43baaddc57670d8ab49b4aa2981053c3cabba17567723d3a9fb6L8-R13): Updated test commands to use `server` and `client` directories instead of `backend` and `frontend`.