### PR TITLE
feat(convo): enhance conversation viewer in session details page

### DIFF
--- a/client/src/components/conversation/ConversationView.tsx
+++ b/client/src/components/conversation/ConversationView.tsx
@@ -268,6 +268,9 @@ export function ConversationView({ sessionId, initialTranscriptId }: Conversatio
       });
 
       if (result.messages.length === 0) {
+        // Nothing older exists — clear hasMore so the hint stops showing
+        // even if the server still claims more is available.
+        setHasMore(false);
         setLoadingHistory(false);
         return;
       }

--- a/client/src/components/conversation/MessageList.tsx
+++ b/client/src/components/conversation/MessageList.tsx
@@ -8,11 +8,22 @@
  * @author Son Nguyen <hoangson091104@gmail.com>
  */
 import { useState, useMemo } from "react";
-import { ChevronDown, ChevronRight, Bot, User, Brain, ScrollText } from "lucide-react";
+import {
+  ChevronDown,
+  ChevronRight,
+  Bot,
+  User,
+  Brain,
+  ScrollText,
+  Terminal,
+  Info,
+  AlertTriangle,
+} from "lucide-react";
 import type { TranscriptMessage, TranscriptContent } from "../../lib/types";
 import { ToolCallBlock } from "./ToolCallBlock";
 import { MarkdownContent } from "./MarkdownContent";
 import { fmt } from "../../lib/format";
+import { parseTuiSegments, stripAnsi, hasTuiTags, type TuiSegment } from "./tuiSegments";
 
 interface MessageListProps {
   messages: TranscriptMessage[];
@@ -33,23 +44,6 @@ function buildToolResultMap(messages: TranscriptMessage[]): Map<string, Transcri
   return map;
 }
 
-/**
- * Detect and format command messages.
- * Converts <command-message>X</command-message><command-name>/X</command-name><command-args>Y</command-args>
- * into /X Y format.
- */
-function formatCommandMessage(text: string): { isCommand: boolean; display: string } {
-  const cmdMatch = text.match(
-    /<command-message>([^<]*)<\/command-message>\s*<command-name>([^<]*)<\/command-name>\s*(?:<command-args>([^<]*)<\/command-args>)?/
-  );
-  if (cmdMatch) {
-    const name = cmdMatch[2] ?? cmdMatch[1] ?? "";
-    const args = cmdMatch[3] ?? "";
-    return { isCommand: true, display: args ? `${name} ${args}` : name };
-  }
-  return { isCommand: false, display: text };
-}
-
 /** Detect if text is skill loading content (starts with "Base directory for this skill:") */
 function isSkillContent(text: string): boolean {
   return text.startsWith("Base directory for this skill:");
@@ -66,6 +60,96 @@ function formatLocalTime(iso: string): string {
     return new Date(iso).toLocaleTimeString();
   } catch {
     return "";
+  }
+}
+
+/** Compact pill for /command invocations parsed out of TUI markup. */
+function CommandPill({ display }: { display: string }) {
+  return (
+    <div className="inline-flex items-center gap-2 text-sm text-emerald-300 font-mono bg-emerald-500/10 border border-emerald-500/20 rounded-md px-3 py-1.5 max-w-full">
+      <span className="text-emerald-500/70">›</span>
+      <span className="break-all">{display}</span>
+    </div>
+  );
+}
+
+/** Terminal-style fenced block for stdout/stderr captured from local commands. */
+function TerminalBlock({ text, stream }: { text: string; stream: "stdout" | "stderr" }) {
+  const cleaned = stripAnsi(text).replace(/^\n+|\n+$/g, "");
+  const isErr = stream === "stderr";
+  const accent = isErr
+    ? "border-red-500/30 bg-red-950/30 text-red-200/90"
+    : "border-surface-3 bg-surface-4/60 text-gray-200";
+  const labelColor = isErr ? "text-red-300/80" : "text-gray-400";
+  return (
+    <div className={`rounded-lg border ${accent} overflow-hidden`}>
+      <div
+        className={`flex items-center gap-1.5 px-3 py-1 text-[10px] uppercase tracking-wider border-b border-current/10 ${labelColor}`}
+      >
+        <Terminal className="w-3 h-3" />
+        <span>{stream}</span>
+      </div>
+      <pre className="px-3 py-2 text-xs font-mono whitespace-pre-wrap break-words leading-relaxed max-h-96 overflow-y-auto">
+        {cleaned}
+      </pre>
+    </div>
+  );
+}
+
+/** Subtle inline note for the local-command-caveat banner. */
+function CaveatBlock({ text }: { text: string }) {
+  return (
+    <div className="flex items-start gap-2 rounded-md border border-amber-500/15 bg-amber-500/[0.05] px-3 py-1.5 text-[11px] text-amber-200/70">
+      <Info className="w-3.5 h-3.5 mt-px flex-shrink-0 opacity-60" />
+      <span className="leading-relaxed italic">{stripAnsi(text).trim()}</span>
+    </div>
+  );
+}
+
+/** Render a single segment produced by parseTuiSegments. */
+function renderSegment(seg: TuiSegment, key: number): React.ReactNode {
+  switch (seg.kind) {
+    case "command":
+      return <CommandPill key={key} display={seg.display} />;
+    case "stdout":
+      return <TerminalBlock key={key} text={seg.text} stream="stdout" />;
+    case "stderr":
+      return <TerminalBlock key={key} text={seg.text} stream="stderr" />;
+    case "caveat":
+      return <CaveatBlock key={key} text={seg.text} />;
+    case "system-reminder":
+      return (
+        <CollapsibleBlock
+          key={key}
+          text={seg.text}
+          icon={<AlertTriangle className="w-3.5 h-3.5 text-amber-400/70 flex-shrink-0" />}
+          title="System reminder"
+          borderClass="border-amber-500/20"
+          bgClass="bg-amber-500/5"
+          textClass="text-amber-300/80"
+        />
+      );
+    case "persisted-output":
+      return (
+        <CollapsibleBlock
+          key={key}
+          text={seg.text}
+          icon={<ScrollText className="w-3.5 h-3.5 text-violet-400/60 flex-shrink-0" />}
+          title="Persisted output"
+          borderClass="border-violet-500/20"
+          bgClass="bg-violet-500/5"
+          textClass="text-violet-300/80"
+        />
+      );
+    case "text": {
+      const cleaned = stripAnsi(seg.text);
+      if (!cleaned.trim()) return null;
+      return (
+        <div key={key} className="min-w-0">
+          <MarkdownContent text={cleaned} />
+        </div>
+      );
+    }
   }
 }
 
@@ -233,23 +317,21 @@ export function MessageList({ messages, loading }: MessageListProps) {
                     );
                   }
 
-                  // Detect command messages, format for display
-                  const { isCommand, display } = formatCommandMessage(block.text);
-                  if (isCommand) {
+                  // Mixed TUI markup: caveat / command / stdout / stderr / system-reminder
+                  // can appear inline (sometimes interleaved with prose). Parse the text
+                  // into segments and render each with the appropriate visual treatment.
+                  if (hasTuiTags(block.text)) {
+                    const segments = parseTuiSegments(block.text);
                     return (
-                      <div
-                        key={bIdx}
-                        className="inline-flex items-center gap-2 text-sm text-emerald-300 font-mono bg-emerald-500/10 border border-emerald-500/20 rounded-md px-3 py-1.5 max-w-full"
-                      >
-                        <span className="text-emerald-500/70">›</span>
-                        <span className="break-all">{display}</span>
+                      <div key={bIdx} className="space-y-2 min-w-0">
+                        {segments.map((s, sIdx) => renderSegment(s, sIdx))}
                       </div>
                     );
                   }
 
                   return (
                     <div key={bIdx} className="min-w-0">
-                      <MarkdownContent text={block.text} />
+                      <MarkdownContent text={stripAnsi(block.text)} />
                     </div>
                   );
                 }

--- a/client/src/components/conversation/tuiSegments.ts
+++ b/client/src/components/conversation/tuiSegments.ts
@@ -1,0 +1,128 @@
+/**
+ * @file tuiSegments.ts
+ * @description Parses Claude TUI tag markup that appears in user messages —
+ * caveats, command invocations, captured stdout/stderr, system reminders —
+ * into a flat segment list the renderer can lay out inline. Also strips bare
+ * ANSI/SGR escape sequences (e.g. "[1m...[22m") that survive the JSONL pipe
+ * so messages render as plain text instead of leaking codes.
+ * @author Son Nguyen <hoangson091104@gmail.com>
+ */
+
+export type TuiSegment =
+  | { kind: "caveat"; text: string }
+  | { kind: "stdout"; text: string }
+  | { kind: "stderr"; text: string }
+  | { kind: "system-reminder"; text: string }
+  | { kind: "persisted-output"; text: string }
+  | { kind: "command"; display: string }
+  | { kind: "text"; text: string };
+
+const SIMPLE_TAGS: Record<string, TuiSegment["kind"]> = {
+  "local-command-caveat": "caveat",
+  "local-command-stdout": "stdout",
+  "local-command-stderr": "stderr",
+  "system-reminder": "system-reminder",
+  "persisted-output": "persisted-output",
+};
+
+const COMMAND_TAGS = ["command-name", "command-message", "command-args"] as const;
+
+const KNOWN_TAG_RE = new RegExp(
+  `<(?:${[...Object.keys(SIMPLE_TAGS), ...COMMAND_TAGS].join("|")})\\b`
+);
+
+// Strip both real ESC-prefixed SGR codes and the bare "[Nm" forms that show up
+// when the ESC byte is dropped during JSON encoding. Only matches when followed
+// by `m` (the SGR terminator), so it does not eat ordinary bracketed text.
+const ANSI_RE = /\[[\d;]*m|\[\d+(?:;\d+)*m/g;
+
+export function stripAnsi(text: string): string {
+  return text.replace(ANSI_RE, "");
+}
+
+interface MatchSpan {
+  start: number;
+  end: number;
+  segment: TuiSegment;
+}
+
+function findSimpleTagMatches(input: string): MatchSpan[] {
+  const matches: MatchSpan[] = [];
+  for (const [tag, kind] of Object.entries(SIMPLE_TAGS)) {
+    const re = new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`, "g");
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(input)) !== null) {
+      matches.push({
+        start: m.index,
+        end: m.index + m[0].length,
+        segment: { kind, text: m[1] ?? "" } as TuiSegment,
+      });
+    }
+  }
+  return matches;
+}
+
+function findCommandBlocks(input: string): MatchSpan[] {
+  // A command block is one or more <command-name|message|args> tags possibly
+  // separated by whitespace. Group them so a single pill renders even when
+  // the tags arrive in name -> message -> args order.
+  const re = /(?:<command-(?:name|message|args)>[^<]*<\/command-(?:name|message|args)>\s*){1,3}/g;
+  const out: MatchSpan[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(input)) !== null) {
+    const block = m[0];
+    const name = /<command-name>([^<]*)<\/command-name>/.exec(block)?.[1] ?? "";
+    const args = /<command-args>([^<]*)<\/command-args>/.exec(block)?.[1] ?? "";
+    if (!name) continue;
+    const trimmedArgs = args.trim();
+    out.push({
+      start: m.index,
+      end: m.index + block.length,
+      segment: {
+        kind: "command",
+        display: trimmedArgs ? `${name} ${trimmedArgs}` : name,
+      },
+    });
+  }
+  return out;
+}
+
+/**
+ * Walks a message text and splits out recognized TUI/command segments while
+ * preserving the surrounding prose as `text` segments. Returns a single
+ * `text` segment for inputs that contain no recognized markup.
+ */
+export function parseTuiSegments(input: string): TuiSegment[] {
+  if (!KNOWN_TAG_RE.test(input)) {
+    return [{ kind: "text", text: input }];
+  }
+
+  const matches = [...findSimpleTagMatches(input), ...findCommandBlocks(input)].sort(
+    (a, b) => a.start - b.start
+  );
+
+  const segments: TuiSegment[] = [];
+  let cursor = 0;
+  for (const m of matches) {
+    if (m.start < cursor) continue;
+    if (m.start > cursor) {
+      const between = input.slice(cursor, m.start);
+      if (between.trim()) {
+        segments.push({ kind: "text", text: between });
+      }
+    }
+    segments.push(m.segment);
+    cursor = m.end;
+  }
+  if (cursor < input.length) {
+    const tail = input.slice(cursor);
+    if (tail.trim()) segments.push({ kind: "text", text: tail });
+  }
+
+  return segments.length > 0 ? segments : [{ kind: "text", text: input }];
+}
+
+/** True if any recognized TUI tag would alter the rendering of this text. */
+export function hasTuiTags(input: string): boolean {
+  return KNOWN_TAG_RE.test(input);
+}

--- a/client/src/pages/Analytics.tsx
+++ b/client/src/pages/Analytics.tsx
@@ -853,7 +853,7 @@ export function Analytics() {
         <div className="card p-5 lg:col-span-2">
           <h3 className="text-sm font-medium text-gray-300 mb-4">{t("eventActivity")}</h3>
           <div className="overflow-x-auto">
-            <div className="min-w-max">
+            <div className="w-fit min-w-max mx-auto">
               <Heatmap weeks={weeks} />
             </div>
           </div>

--- a/server/db.js
+++ b/server/db.js
@@ -298,6 +298,13 @@ const stmts = {
   reactivateSession: db.prepare(
     "UPDATE sessions SET status = 'active', ended_at = NULL, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE id = ?"
   ),
+  // Updates session.model only when the new value differs from what's stored,
+  // so the broadcast/refresh path stays quiet across the common no-op case.
+  // Used by the hook ingestor to keep the displayed model in sync after the
+  // user invokes /model mid-session.
+  updateSessionModel: db.prepare(
+    "UPDATE sessions SET model = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE id = ? AND COALESCE(model, '') != ?"
+  ),
 
   getAgent: db.prepare("SELECT * FROM agents WHERE id = ?"),
   listAgents: db.prepare("SELECT * FROM agents ORDER BY started_at DESC LIMIT ? OFFSET ?"),

--- a/server/lib/transcript-cache.js
+++ b/server/lib/transcript-cache.js
@@ -48,6 +48,7 @@ class TranscriptCache {
           turnDurations: result?.turnDurations ? [...result.turnDurations] : null,
           thinkingBlockCount: result?.thinkingBlockCount || 0,
           usageExtras: result ? this._cloneUsageExtras(result.usageExtras) : null,
+          latestModel: result?.latestModel || null,
           result,
         });
         return result;
@@ -73,6 +74,7 @@ class TranscriptCache {
             turnDurations: hasTurnDurations ? merged.turnDurations : null,
             thinkingBlockCount: merged.thinkingBlockCount || 0,
             usageExtras: hasUsageExtras ? merged.usageExtras : null,
+            latestModel: merged.latestModel || null,
           };
           if (
             !result.tokensByModel &&
@@ -80,7 +82,8 @@ class TranscriptCache {
             !result.errors &&
             !result.turnDurations &&
             !result.thinkingBlockCount &&
-            !result.usageExtras
+            !result.usageExtras &&
+            !result.latestModel
           ) {
             this._set(key, {
               mtimeMs: stat.mtimeMs,
@@ -92,6 +95,7 @@ class TranscriptCache {
               turnDurations: null,
               thinkingBlockCount: 0,
               usageExtras: null,
+              latestModel: null,
               result: null,
             });
             return null;
@@ -106,6 +110,7 @@ class TranscriptCache {
             turnDurations: result.turnDurations ? [...result.turnDurations] : null,
             thinkingBlockCount: result.thinkingBlockCount || 0,
             usageExtras: this._cloneUsageExtras(result.usageExtras),
+            latestModel: result.latestModel || null,
             result,
           });
           return result;
@@ -133,6 +138,7 @@ class TranscriptCache {
         turnDurations: result?.turnDurations ? [...result.turnDurations] : null,
         thinkingBlockCount: result?.thinkingBlockCount || 0,
         usageExtras: result ? this._cloneUsageExtras(result.usageExtras) : null,
+        latestModel: result?.latestModel || null,
         result,
       });
       return result;
@@ -179,6 +185,11 @@ class TranscriptCache {
     const turnDurations = [];
     let thinkingBlockCount = 0;
     const usageExtras = { service_tiers: new Set(), speeds: new Set(), inference_geos: new Set() };
+    // Track the model of the most recent assistant entry encountered in this
+    // content block. JSONL is append-only and parsed in file order, so the
+    // last value seen here is the user's *current* model — used downstream to
+    // keep session.model in sync when the user invokes /model mid-session.
+    let latestModel = null;
 
     for (const line of content.split("\n")) {
       if (!line) continue;
@@ -229,6 +240,7 @@ class TranscriptCache {
 
         const model = msg.model;
         if (!model || model === "<synthetic>" || !msg.usage) continue;
+        latestModel = model;
         if (!tokensByModel[model]) {
           tokensByModel[model] = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
         }
@@ -268,7 +280,8 @@ class TranscriptCache {
       !hasErrors &&
       !hasTurnDurations &&
       !thinkingBlockCount &&
-      !hasUsageExtras
+      !hasUsageExtras &&
+      !latestModel
     )
       return null;
 
@@ -287,6 +300,7 @@ class TranscriptCache {
       turnDurations: hasTurnDurations ? turnDurations : null,
       thinkingBlockCount,
       usageExtras: serializedExtras,
+      latestModel,
     };
   }
 
@@ -350,7 +364,20 @@ class TranscriptCache {
       };
     }
 
-    return { tokensByModel, compaction, errors, turnDurations, thinkingBlockCount, usageExtras };
+    // JSONL is append-only and parsed in order, so the incremental block's
+    // latestModel (when present) is the newest reading — fall back to the
+    // previously-cached value when the new chunk had no assistant entries.
+    const latestModel = (incremental && incremental.latestModel) || cached.latestModel || null;
+
+    return {
+      tokensByModel,
+      compaction,
+      errors,
+      turnDurations,
+      thinkingBlockCount,
+      usageExtras,
+      latestModel,
+    };
   }
 
   _cloneTokens(tokensByModel) {

--- a/server/routes/hooks.js
+++ b/server/routes/hooks.js
@@ -468,7 +468,20 @@ const processEvent = db.transaction((hookType, data) => {
   if (data.transcript_path) {
     const result = transcriptCache.extract(data.transcript_path);
     if (result) {
-      const { tokensByModel, compaction } = result;
+      const { tokensByModel, compaction, latestModel } = result;
+
+      // Keep session.model in sync with the user's *current* model — the
+      // transcript's most recent assistant entry is the source of truth, since
+      // the /model command rewrites future entries but leaves session.model
+      // (set at session creation) alone. The prepared statement is a no-op
+      // when the value is unchanged, so we only broadcast on real flips.
+      if (latestModel) {
+        const upd = stmts.updateSessionModel.run(latestModel, sessionId, latestModel);
+        if (upd.changes > 0) {
+          const refreshed = stmts.getSession.get(sessionId);
+          if (refreshed) broadcast("session_updated", refreshed);
+        }
+      }
 
       // Register compaction agents and events.
       // Each isCompactSummary entry in the JSONL = one compaction that occurred.

--- a/server/routes/sessions.js
+++ b/server/routes/sessions.js
@@ -579,7 +579,10 @@ router.get("/:id/transcript", async (req, res) => {
       }
       // If we exhausted the stream without hitting limit, hasMore stays false
     } else if (beforeLine !== null) {
-      // History mode: collect messages with line < beforeLine using a sliding window
+      // History mode: collect messages with line < beforeLine using a sliding window.
+      // hasMore here means "more *older* messages exist before what we're returning"
+      // — the only way to know that is if we shifted any out of the window
+      // (total > limit). Hitting the boundary tells us nothing about older history.
       for await (const line of rl) {
         lineNum++;
         if (!line.trim()) continue;
@@ -591,8 +594,7 @@ router.get("/:id/transcript", async (req, res) => {
         }
         if (entry.type !== "user" && entry.type !== "assistant") continue;
         if (lineNum >= beforeLine) {
-          // We've reached the boundary — stop reading
-          hasMore = true; // there are more messages at or after beforeLine
+          // Reached the boundary — stop reading
           rl.close();
           rl.removeAllListeners();
           break;
@@ -607,7 +609,6 @@ router.get("/:id/transcript", async (req, res) => {
           messages.shift();
         }
       }
-      // total is the count of messages before beforeLine; if we shifted, there are more
       if (total > limit) hasMore = true;
     } else if (offset > 0) {
       // Legacy offset pagination: skip `offset` valid messages, then collect `limit`


### PR DESCRIPTION
This pull request introduces a significant improvement to how terminal UI (TUI) markup and command outputs are parsed and rendered in conversation messages, along with several backend enhancements for tracking the latest model used in a session. The main changes include a new TUI segment parser and renderer for the client, improved handling of command and system output blocks, and backend logic to keep session model information in sync with user actions.

**Frontend: TUI Markup Parsing and Rendering**

* Added a new module `tuiSegments.ts` that parses Claude TUI tag markup (such as caveats, command invocations, and captured stdout/stderr) into renderable segments, and provides utilities to strip ANSI escape codes.
* Refactored `MessageList.tsx` to use the new TUI segment parser, replacing the previous command message formatter. Now, messages containing TUI markup are split into segments and rendered with appropriate visual components (command pills, terminal blocks, caveat banners, etc.), improving readability and user experience. [[1]](diffhunk://#diff-f09ff4d300dcb112c1ee3021e8ffeadeb252967d6a97fefbcb7f41c7e64ecf17L11-R26) [[2]](diffhunk://#diff-f09ff4d300dcb112c1ee3021e8ffeadeb252967d6a97fefbcb7f41c7e64ecf17L36-L52) [[3]](diffhunk://#diff-f09ff4d300dcb112c1ee3021e8ffeadeb252967d6a97fefbcb7f41c7e64ecf17R66-R155) [[4]](diffhunk://#diff-f09ff4d300dcb112c1ee3021e8ffeadeb252967d6a97fefbcb7f41c7e64ecf17L236-R334)
* Added new visual components for command pills, terminal output blocks, and caveat/system reminder banners in the message list, leveraging the parsed segments.

**Backend: Session Model Tracking and Transcript Cache**

* Enhanced the transcript cache in `transcript-cache.js` to track the `latestModel` used in a transcript, propagating this information through all relevant cache and merge operations. This allows the backend to know the most recent model used in a session, even if the user changes it mid-session. [[1]](diffhunk://#diff-6cad717574ee51969f1cf8e032998bdf0656264a95647b009ac9336e5b5fb675R51) [[2]](diffhunk://#diff-6cad717574ee51969f1cf8e032998bdf0656264a95647b009ac9336e5b5fb675R77-R86) [[3]](diffhunk://#diff-6cad717574ee51969f1cf8e032998bdf0656264a95647b009ac9336e5b5fb675R98) [[4]](diffhunk://#diff-6cad717574ee51969f1cf8e032998bdf0656264a95647b009ac9336e5b5fb675R113) [[5]](diffhunk://#diff-6cad717574ee51969f1cf8e032998bdf0656264a95647b009ac9336e5b5fb675R141) [[6]](diffhunk://#diff-6cad717574ee51969f1cf8e032998bdf0656264a95647b009ac9336e5b5fb675R188-R192) [[7]](diffhunk://#diff-6cad717574ee51969f1cf8e032998bdf0656264a95647b009ac9336e5b5fb675R243) [[8]](diffhunk://#diff-6cad717574ee51969f1cf8e032998bdf0656264a95647b009ac9336e5b5fb675L271-R284) [[9]](diffhunk://#diff-6cad717574ee51969f1cf8e032998bdf0656264a95647b009ac9336e5b5fb675R303) [[10]](diffhunk://#diff-6cad717574ee51969f1cf8e032998bdf0656264a95647b009ac9336e5b5fb675L353-R380)
* Added a new SQL statement `updateSessionModel` in `db.js` to update the session's model only if it has changed, reducing unnecessary broadcasts and keeping the displayed model in sync with user actions.
* Updated the hook ingestion route to use the new `latestModel` field from the transcript cache to synchronize the session model, broadcasting updates only when the model actually changes.

**Other UI/UX Improvements**

* Adjusted the heatmap container in the analytics page for better centering and layout.
* Improved the logic in `ConversationView.tsx` to clear the "has more" flag when no older messages exist, preventing misleading UI hints.
* Clarified a comment in the session transcript route regarding the meaning of the `hasMore` flag when paginating message history.