### PR TITLE
feat(lightbox): implement lightbox feature for screenshot viewing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1097,40 +1097,48 @@
           <h3>Screenshots</h3>
           <div class="screenshot-gallery">
             <div class="screenshot-card">
-              <img src="images/sessions.png" alt="Sessions table with search, filters, status badges, and pagination" width="1917" height="1042" loading="lazy" decoding="async" />
-              <div class="screenshot-caption"><span class="caption-icon">📋</span> Sessions table — searchable, filterable, paginated</div>
+              <img src="images/dashboard.png" alt="Dashboard Overview" width="100%" loading="lazy" decoding="async" />
+              <div class="screenshot-caption"><span class="caption-icon">📡</span> <span><strong>Dashboard</strong> — overview stats, active agent cards, and recent activity feed</span></div>
             </div>
             <div class="screenshot-card">
-              <img src="images/session-agents.png" alt="Session detail — Agents tab with real-time overview tiles, top tools, subagent breakdown, token flow, and agent hierarchy tree" loading="lazy" decoding="async" />
-              <div class="screenshot-caption"><span class="caption-icon">🤖</span> Session detail · Agents — overview tiles, top tools, subagent breakdown, token flow, and agent tree</div>
+              <img src="images/board.png" alt="Kanban Board — Agents view" width="100%" loading="lazy" decoding="async" />
+              <div class="screenshot-caption"><span class="caption-icon">📋</span> <span><strong>Kanban Board (agents)</strong> — agents grouped by status across 4 columns</span></div>
             </div>
             <div class="screenshot-card">
-              <img src="images/session-conversation.png" alt="Session detail — Conversation tab with markdown rendering, syntax-highlighted code blocks, and per-tool styled tool calls" loading="lazy" decoding="async" />
-              <div class="screenshot-caption"><span class="caption-icon">💬</span> Session detail · Conversation — markdown, syntax-highlighted code, and per-tool styled tool calls</div>
+              <img src="images/board-sessions.png" alt="Kanban Board — Sessions view" width="100%" loading="lazy" decoding="async" />
+              <div class="screenshot-caption"><span class="caption-icon">🗂️</span> <span><strong>Kanban Board (sessions)</strong> — sessions grouped by status across 5 columns</span></div>
             </div>
             <div class="screenshot-card">
-              <img src="images/session-timeline.png" alt="Session detail — Timeline tab with chronological event timeline, multi-dimension filters, and tool-aware payload renderers" loading="lazy" decoding="async" />
-              <div class="screenshot-caption"><span class="caption-icon">🔬</span> Session detail · Timeline — chronological events with multi-dimension filters and tool-aware payloads</div>
+              <img src="images/sessions.png" alt="Sessions Overview" width="100%" loading="lazy" decoding="async" />
+              <div class="screenshot-caption"><span class="caption-icon">📂</span> <span><strong>Sessions</strong> — searchable, filterable, server-paginated table of recorded sessions</span></div>
             </div>
             <div class="screenshot-card">
-              <img src="images/board.png" alt="Kanban board, agents view: 4 columns (Working, Waiting, Completed, Error) of agent cards with model, cost, and tool info" width="1918" height="1047" loading="lazy" decoding="async" />
-              <div class="screenshot-caption"><span class="caption-icon">📂</span> Kanban board — agents view, 4-column status board with the yellow Waiting column</div>
+              <img src="images/session-agents.png" alt="Session Detail — Agents tab" width="100%" loading="lazy" decoding="async" />
+              <div class="screenshot-caption"><span class="caption-icon">🤖</span> <span><strong>Session Detail · Agents</strong> — overview tiles, subagent breakdown, and hierarchy tree</span></div>
             </div>
             <div class="screenshot-card">
-              <img src="images/board-sessions.png" alt="Kanban board, sessions view: 5 columns (Active, Waiting, Completed, Error, Abandoned) of session cards with agent count, model, cost, duration, and time-ago" width="3024" height="1720" loading="lazy" decoding="async" />
-              <div class="screenshot-caption"><span class="caption-icon">📁</span> Kanban board — sessions view, toggleable from the same page</div>
+              <img src="images/session-conversation.png" alt="Session Detail — Conversation tab" width="100%" loading="lazy" decoding="async" />
+              <div class="screenshot-caption"><span class="caption-icon">💬</span> <span><strong>Session Detail · Conversation</strong> — live transcript viewer with markdown rendering</span></div>
             </div>
             <div class="screenshot-card">
-              <img src="images/feed.png" alt="Real-time activity feed with streaming events, expandable payload rows, and session navigation button" width="3024" height="1672" loading="lazy" decoding="async" />
-              <div class="screenshot-caption"><span class="caption-icon">📰</span> Activity feed — click a row to expand payload; "Session →" button opens session details</div>
+              <img src="images/session-timeline.png" alt="Session Detail — Timeline tab" width="100%" loading="lazy" decoding="async" />
+              <div class="screenshot-caption"><span class="caption-icon">🔬</span> <span><strong>Session Detail · Timeline</strong> — chronological event timeline with multi-dimension filters</span></div>
             </div>
             <div class="screenshot-card">
-              <img src="images/analytics.png" alt="Analytics dashboard with token usage charts, tool frequency, and session trends" width="1918" height="1046" loading="lazy" decoding="async" />
-              <div class="screenshot-caption"><span class="caption-icon">📊</span> Analytics — token usage, tool frequency, and trends</div>
+              <img src="images/feed.png" alt="Activity Feed Overview" width="100%" loading="lazy" decoding="async" />
+              <div class="screenshot-caption"><span class="caption-icon">📰</span> <span><strong>Activity Feed</strong> — real-time event log with pause / resume and multi-dimension filters</span></div>
             </div>
             <div class="screenshot-card">
-              <img src="images/workflows.png" alt="Workflow graphs showing agent orchestration DAGs and tool execution Sankey diagrams" width="1918" height="1047" loading="lazy" decoding="async" />
-              <div class="screenshot-caption"><span class="caption-icon">🔀</span> Workflows — agent DAGs and tool Sankey diagrams</div>
+              <img src="images/analytics.png" alt="Analytics Overview" width="100%" loading="lazy" decoding="async" />
+              <div class="screenshot-caption"><span class="caption-icon">📊</span> <span><strong>Analytics</strong> — token usage, tool frequency, activity heatmap, and session trends</span></div>
+            </div>
+            <div class="screenshot-card">
+              <img src="images/workflows.png" alt="Workflows Overview" width="100%" loading="lazy" decoding="async" />
+              <div class="screenshot-caption"><span class="caption-icon">🔀</span> <span><strong>Workflows</strong> — agent DAGs, tool Sankey diagrams, and workflow intelligence</span></div>
+            </div>
+            <div class="screenshot-card">
+              <img src="images/settings.png" alt="Settings Overview" width="100%" loading="lazy" decoding="async" />
+              <div class="screenshot-caption"><span class="caption-icon">⚙️</span> <span><strong>Settings</strong> — model pricing rules, data management, and system info</span></div>
             </div>
           </div>
 

--- a/wiki/script.js
+++ b/wiki/script.js
@@ -392,3 +392,56 @@ document.querySelectorAll(".diagram-toggle").forEach((toggle) => {
     toggle.textContent = isOpen ? "Show diagram" : "Hide diagram";
   });
 });
+
+/* ─── Lightbox for Screenshots ──────────────────────────────────────────── */
+(function () {
+  const overlay = document.createElement("div");
+  overlay.className = "lightbox-overlay";
+  overlay.setAttribute("aria-hidden", "true");
+
+  const closeBtn = document.createElement("button");
+  closeBtn.className = "lightbox-close";
+  closeBtn.innerHTML = "&times;";
+  closeBtn.setAttribute("aria-label", "Close full screen");
+
+  const img = document.createElement("img");
+  img.className = "lightbox-image";
+  img.setAttribute("alt", "Enlarged screenshot");
+
+  overlay.appendChild(closeBtn);
+  overlay.appendChild(img);
+  document.body.appendChild(overlay);
+
+  function closeLightbox() {
+    overlay.classList.remove("active");
+    overlay.setAttribute("aria-hidden", "true");
+    document.body.style.overflow = ""; // restore scrolling
+    setTimeout(() => {
+      img.src = "";
+    }, 300);
+  }
+
+  overlay.addEventListener("click", (e) => {
+    if (e.target === overlay || e.target === closeBtn) {
+      closeLightbox();
+    }
+  });
+
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape" && overlay.classList.contains("active")) {
+      closeLightbox();
+    }
+  });
+
+  document
+    .querySelectorAll(".screenshot-card img, .hero-gallery img, .screenshot-gallery img")
+    .forEach((thumbnail) => {
+      thumbnail.addEventListener("click", () => {
+        img.src = thumbnail.src;
+        img.alt = thumbnail.alt;
+        overlay.classList.add("active");
+        overlay.setAttribute("aria-hidden", "false");
+        document.body.style.overflow = "hidden"; // prevent background scrolling
+      });
+    });
+})();

--- a/wiki/style.css
+++ b/wiki/style.css
@@ -1593,3 +1593,75 @@ hr {
   max-width: 100%;
   height: auto;
 }
+
+/* ─── Lightbox ──────────────────────────────────────────────────────────── */
+.lightbox-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.85);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+  opacity: 0;
+  visibility: hidden;
+  transition:
+    opacity 0.3s ease,
+    visibility 0.3s ease;
+  backdrop-filter: blur(5px);
+  -webkit-backdrop-filter: blur(5px);
+}
+
+.lightbox-overlay.active {
+  opacity: 1;
+  visibility: visible;
+}
+
+.lightbox-image {
+  max-width: 90vw;
+  max-height: 90vh;
+  object-fit: contain;
+  border-radius: 8px;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.5);
+  transform: scale(0.95);
+  transition: transform 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+
+.lightbox-overlay.active .lightbox-image {
+  transform: scale(1);
+}
+
+.lightbox-close {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 42px;
+  font-weight: 300;
+  cursor: pointer;
+  background: none;
+  border: none;
+  transition:
+    color 0.2s,
+    transform 0.2s;
+  z-index: 10000;
+  line-height: 1;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+}
+
+.lightbox-close:hover {
+  color: #fff;
+  transform: scale(1.1);
+}
+
+.screenshot-card img {
+  cursor: zoom-in;
+}


### PR DESCRIPTION
This pull request enhances the screenshot gallery experience and updates the visual presentation of screenshots throughout the documentation. The most significant changes include the addition of a lightbox feature for screenshots, updated screenshot images and captions for improved clarity, and new styling to support the lightbox functionality.

**Screenshot gallery improvements:**

* Added a lightbox feature that allows users to click on screenshots to view them in an enlarged, modal overlay, with keyboard and mouse controls for closing the lightbox. (`wiki/script.js`)
* Updated the screenshot gallery to use new or reorganized images, revised alt text, and improved captions for better clarity and accessibility. Added new screenshots for Settings and improved coverage of all major UI areas. (`index.html`)

**Styling enhancements:**

* Introduced new CSS styles for the lightbox overlay, close button, and enlarged images, including transitions, backdrop blur, and improved accessibility. Also updated screenshot thumbnails to indicate zoom-in capability. (`wiki/style.css`)