### PR TITLE
feat: attribute live tool events to working subagent

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -206,21 +206,24 @@ if (require.main === module) {
     }
   }, SWEEP_INTERVAL_MS);
 
-  // Auto-import legacy sessions and backfill compaction tracking on startup
+  // Auto-import legacy sessions and backfill compaction tracking on startup.
+  // Skipped when DB already has sessions — the import is a one-time bootstrap
+  // that blocks the event loop for minutes on large ~/.claude/ dirs (700+ files).
   const { importAllSessions, backfillCompactions } = require("../scripts/import-history");
   const dbModule = require("./db");
-  importAllSessions(dbModule)
-    .then(({ imported, skipped, errors }) => {
-      if (imported > 0) console.log(`Imported ${imported} legacy sessions from ~/.claude/`);
-      if (errors > 0) console.log(`${errors} session files had errors during import`);
-    })
-    .then(() => backfillCompactions(dbModule))
-    .then(({ backfilled }) => {
-      if (backfilled > 0) console.log(`Backfilled ${backfilled} compaction events from ~/.claude/`);
-    })
-    .catch(() => {
-      // Non-fatal — legacy import is best-effort
-    });
+  const existingCount = dbModule.db.prepare("SELECT COUNT(*) AS c FROM sessions").get().c;
+  if (existingCount === 0) {
+    importAllSessions(dbModule)
+      .then(({ imported, skipped, errors }) => {
+        if (imported > 0) console.log(`Imported ${imported} legacy sessions from ~/.claude/`);
+        if (errors > 0) console.log(`${errors} session files had errors during import`);
+      })
+      .then(() => backfillCompactions(dbModule))
+      .then(({ backfilled }) => {
+        if (backfilled > 0) console.log(`Backfilled ${backfilled} compaction events from ~/.claude/`);
+      })
+      .catch(() => {});
+  }
 }
 
 module.exports = { createApp, startServer };

--- a/server/index.js
+++ b/server/index.js
@@ -220,7 +220,8 @@ if (require.main === module) {
       })
       .then(() => backfillCompactions(dbModule))
       .then(({ backfilled }) => {
-        if (backfilled > 0) console.log(`Backfilled ${backfilled} compaction events from ~/.claude/`);
+        if (backfilled > 0)
+          console.log(`Backfilled ${backfilled} compaction events from ~/.claude/`);
       })
       .catch(() => {});
   }

--- a/server/routes/hooks.js
+++ b/server/routes/hooks.js
@@ -197,9 +197,10 @@ const processEvent = db.transaction((hookType, data) => {
       //
       // Heuristic: main is waiting + working subagents exist → subagent is the actor.
       //            main is working/waiting with no subagents → main is the actor.
-      const deepestWorking = (mainAgent && mainAgent.status === "waiting")
-        ? stmts.findDeepestWorkingAgent.get(sessionId, sessionId)
-        : null;
+      const deepestWorking =
+        mainAgent && mainAgent.status === "waiting"
+          ? stmts.findDeepestWorkingAgent.get(sessionId, sessionId)
+          : null;
       const subagentIsActor = !!deepestWorking;
       if (subagentIsActor && toolName !== "Agent") {
         agentId = deepestWorking.id;

--- a/server/routes/hooks.js
+++ b/server/routes/hooks.js
@@ -197,10 +197,13 @@ const processEvent = db.transaction((hookType, data) => {
       //
       // Heuristic: main is waiting + working subagents exist → subagent is the actor.
       //            main is working/waiting with no subagents → main is the actor.
-      const subagentIsActor =
-        mainAgent &&
-        mainAgent.status === "waiting" &&
-        !!stmts.findDeepestWorkingAgent.get(sessionId, sessionId);
+      const deepestWorking = (mainAgent && mainAgent.status === "waiting")
+        ? stmts.findDeepestWorkingAgent.get(sessionId, sessionId)
+        : null;
+      const subagentIsActor = !!deepestWorking;
+      if (subagentIsActor && toolName !== "Agent") {
+        agentId = deepestWorking.id;
+      }
       if (
         mainAgent &&
         !subagentIsActor &&
@@ -225,6 +228,14 @@ const processEvent = db.transaction((hookType, data) => {
       // NOTE: PostToolUse for "Agent" tool fires immediately when a subagent is
       // backgrounded — it does NOT mean the subagent finished its work.
       // Subagent completion is handled by SubagentStop, not here.
+
+      // Attribute to the working subagent when main is waiting (same heuristic as PreToolUse).
+      if (mainAgent && mainAgent.status === "waiting" && toolName !== "Agent") {
+        const deepest = stmts.findDeepestWorkingAgent.get(sessionId, sessionId);
+        if (deepest) {
+          agentId = deepest.id;
+        }
+      }
 
       // Only clear current_tool on the main agent if it's actively working.
       // Skip if waiting (waiting for subagents) or already completed.


### PR DESCRIPTION
## Problem

PR #106 added JSONL-based backfill of subagent tool events, but that only runs **after** a subagent stops (`SubagentStop` hook). While a subagent is actively working, all its tool events (Read, Bash, Grep, Edit, etc.) still show as `datapilot › main` because the hook handler always sets `agentId = mainAgentId`.

Additionally, `importAllSessions` runs on every startup and blocks the event loop for minutes on large `~/.claude/` dirs (700+ JSONL files), making the dashboard unresponsive.

## Solution

### Live tool event attribution

```
Before:  PreToolUse(Read) → agentId = main     (always)
After:   PreToolUse(Read) → agentId = coder    (when main is waiting + coder is working)
```

In `PreToolUse` and `PostToolUse` handlers, when main agent status is `"waiting"` and a working subagent exists, attribute the event to the deepest working subagent instead of main. The `Agent` tool spawn is excluded — it correctly stays under the spawning agent.

### Startup import skip

Skip `importAllSessions` when the DB already has sessions. The import is a one-time bootstrap for first-run — re-running it on every startup blocks the Node.js event loop processing 700+ files synchronously via better-sqlite3.

## Changed files

```
server/routes/hooks.js  — live attribution in PreToolUse + PostToolUse
server/index.js         — conditional startup import
```

## Test plan

- [x] Existing subagent-attribution tests pass (5/5)
- [x] Server starts instantly (no event loop blocking)
- [x] New subagent tool events show correct origin label in UI