### PR TITLE
Fix session status handling on stale transcript scans

### DIFF
--- a/server/__tests__/api.test.js
+++ b/server/__tests__/api.test.js
@@ -1631,6 +1631,127 @@ describe("Transcript cache integration", () => {
 });
 
 // ============================================================
+// Watchdog: stale-error idempotence
+// ============================================================
+describe("Watchdog API-error detection", () => {
+  function writeTranscriptWithError(p) {
+    fs.writeFileSync(
+      p,
+      JSON.stringify({
+        isApiErrorMessage: true,
+        error: "rate_limit_error",
+        message: { content: [{ text: "Rate limit exceeded" }] },
+        timestamp: new Date().toISOString(),
+      }) + "\n"
+    );
+  }
+
+  it("should NOT re-flip a recovered session to error when only pre-existing transcript errors remain", async () => {
+    const tmpTranscript = path.join(os.tmpdir(), `watchdog-stale-${Date.now()}.jsonl`);
+    writeTranscriptWithError(tmpTranscript);
+
+    const sessionId = `watchdog-stale-${Date.now()}`;
+    const hooks = require("../routes/hooks");
+
+    try {
+      // Initial event creates the session and triggers error capture via processEvent.
+      await post("/api/hooks/event", {
+        hook_type: "PreToolUse",
+        data: {
+          session_id: sessionId,
+          transcript_path: tmpTranscript,
+          tool_name: "Read",
+          cwd: "/tmp",
+        },
+      });
+
+      // SessionEnd path is what reads errors out of the transcript inside processEvent;
+      // simulate the watchdog instead by manually marking the session as error.
+      stmts.updateSession.run(null, "error", null, null, sessionId);
+      const errored = stmts.getSession.get(sessionId);
+      assert.strictEqual(errored.status, "error", "precondition: session marked error");
+
+      // User retries → reactivation logic flips back to active.
+      await post("/api/hooks/event", {
+        hook_type: "UserPromptSubmit",
+        data: { session_id: sessionId, transcript_path: tmpTranscript, cwd: "/tmp" },
+      });
+      const recovered = stmts.getSession.get(sessionId);
+      assert.strictEqual(recovered.status, "active", "UserPromptSubmit should reactivate");
+
+      // Backdate updated_at so the watchdog considers the session stale.
+      db.prepare("UPDATE sessions SET updated_at = ? WHERE id = ?").run(
+        new Date(Date.now() - 60_000).toISOString(),
+        sessionId
+      );
+
+      // Invalidate the cache so the watchdog actually re-reads the transcript on this tick.
+      hooks.transcriptCache.invalidate(tmpTranscript);
+      hooks.watchdogCheck();
+
+      const after = stmts.getSession.get(sessionId);
+      assert.strictEqual(
+        after.status,
+        "active",
+        "watchdog must NOT revert recovered session to error when no new transcript errors arrived"
+      );
+    } finally {
+      try {
+        fs.unlinkSync(tmpTranscript);
+      } catch {
+        // ignore
+      }
+    }
+  });
+
+  it("should still mark session as error when a NEW transcript error appears", async () => {
+    const tmpTranscript = path.join(os.tmpdir(), `watchdog-new-${Date.now()}.jsonl`);
+    fs.writeFileSync(tmpTranscript, ""); // start empty
+
+    const sessionId = `watchdog-new-${Date.now()}`;
+    const hooks = require("../routes/hooks");
+
+    try {
+      // Establish an active session against a clean transcript.
+      await post("/api/hooks/event", {
+        hook_type: "PreToolUse",
+        data: {
+          session_id: sessionId,
+          transcript_path: tmpTranscript,
+          tool_name: "Read",
+          cwd: "/tmp",
+        },
+      });
+      assert.strictEqual(stmts.getSession.get(sessionId).status, "active");
+
+      // A new API error appears in the transcript afterwards.
+      writeTranscriptWithError(tmpTranscript);
+
+      // Make session look stale to the watchdog.
+      db.prepare("UPDATE sessions SET updated_at = ? WHERE id = ?").run(
+        new Date(Date.now() - 60_000).toISOString(),
+        sessionId
+      );
+      hooks.transcriptCache.invalidate(tmpTranscript);
+      hooks.watchdogCheck();
+
+      const after = stmts.getSession.get(sessionId);
+      assert.strictEqual(
+        after.status,
+        "error",
+        "watchdog must flip session to error when a new transcript error is detected"
+      );
+    } finally {
+      try {
+        fs.unlinkSync(tmpTranscript);
+      } catch {
+        // ignore
+      }
+    }
+  });
+});
+
+// ============================================================
 // Nested Agent Spawning (agents spawning agents spawning agents)
 // ============================================================
 describe("Nested Agent Spawning", () => {

--- a/server/routes/hooks.js
+++ b/server/routes/hooks.js
@@ -569,6 +569,7 @@ const processEvent = db.transaction((hookType, data) => {
 
       // Register API errors from transcript (quota limits, rate limits, overloaded, etc.)
       if (result.errors) {
+        let newErrorRecorded = false;
         for (const apiErr of result.errors) {
           // Deduplicate: check if we already recorded this error (same type+message+timestamp)
           const errKey = `${apiErr.type}:${apiErr.timestamp || ""}`;
@@ -596,12 +597,14 @@ const processEvent = db.transaction((hookType, data) => {
             summary: `${apiErr.type}: ${apiErr.message}`,
             created_at: apiErr.timestamp || new Date().toISOString(),
           });
+          newErrorRecorded = true;
         }
 
-        // Any API error immediately puts session + agent into error state.
-        // If the user retries (UserPromptSubmit / PreToolUse), the
-        // reactivation logic at the top of processEvent will recover them.
-        if (result.errors.length > 0) {
+        // Only flip to error when we recorded a NEW error this call. Pre-existing
+        // transcript errors must not re-overwrite status, otherwise sessions the
+        // user already recovered from (UserPromptSubmit reactivation above) get
+        // yanked back into 'error' the moment the transcript scan re-reads them.
+        if (newErrorRecorded) {
           const curSession = stmts.getSession.get(sessionId);
           if (curSession && curSession.status === "active") {
             stmts.updateSession.run(null, "error", null, null, sessionId);
@@ -835,16 +838,19 @@ function watchdogCheck() {
             created_at: apiErr.timestamp || new Date().toISOString(),
           });
         }
-      }
 
-      // Mark session + agent as error (whether errors are new or pre-existing)
-      stmts.updateSession.run(null, "error", null, null, sess.id);
-      broadcast("session_updated", stmts.getSession.get(sess.id));
-      if (mainAgent && mainAgent.status !== "completed" && mainAgent.status !== "error") {
-        stmts.updateAgent.run(null, "error", null, null, null, null, mainAgentId);
-        if (mainAgentId) {
-          stmts.clearAgentAwaitingInput.run(mainAgentId);
-          broadcast("agent_updated", stmts.getAgent.get(mainAgentId));
+        // Only flip to error when we actually detected a new error this tick.
+        // Pre-existing transcript errors must not re-overwrite status, otherwise
+        // sessions the user already recovered from (UserPromptSubmit reactivation
+        // at the top of processEvent) get yanked back into 'error' on every poll.
+        stmts.updateSession.run(null, "error", null, null, sess.id);
+        broadcast("session_updated", stmts.getSession.get(sess.id));
+        if (mainAgent && mainAgent.status !== "completed" && mainAgent.status !== "error") {
+          stmts.updateAgent.run(null, "error", null, null, null, null, mainAgentId);
+          if (mainAgentId) {
+            stmts.clearAgentAwaitingInput.run(mainAgentId);
+            broadcast("agent_updated", stmts.getAgent.get(mainAgentId));
+          }
         }
       }
     }
@@ -859,4 +865,5 @@ const watchdogTimer = setInterval(watchdogCheck, WATCHDOG_INTERVAL_MS);
 if (watchdogTimer.unref) watchdogTimer.unref();
 
 router.transcriptCache = transcriptCache;
+router.watchdogCheck = watchdogCheck;
 module.exports = router;


### PR DESCRIPTION
This pull request introduces improvements to the session error-handling logic, particularly around how the watchdog detects and responds to API errors recorded in session transcripts. The main goal is to prevent sessions that have already been recovered by the user from being incorrectly flipped back to an error state due to pre-existing transcript errors. Additionally, new tests have been added to ensure this behavior is correct.

**Watchdog and session error-handling improvements:**

* Updated the logic in `processEvent` (in `server/routes/hooks.js`) so that a session is only flipped to an error state when a new API error is detected in the transcript, rather than on every scan of pre-existing errors. This prevents already-recovered sessions from being set back to error unnecessarily. [[1]](diffhunk://#diff-912ce5001b66c503fac5613c2ea2a7a473a9f1bdcf3fa78e24ac43da8e7f6499R572) [[2]](diffhunk://#diff-912ce5001b66c503fac5613c2ea2a7a473a9f1bdcf3fa78e24ac43da8e7f6499R600-R607)
* Modified the `watchdogCheck` function to only mark sessions as error if a new error is detected during the current check, ensuring that sessions aren't repeatedly set to error due to old transcript errors. [[1]](diffhunk://#diff-912ce5001b66c503fac5613c2ea2a7a473a9f1bdcf3fa78e24ac43da8e7f6499L838-R845) [[2]](diffhunk://#diff-912ce5001b66c503fac5613c2ea2a7a473a9f1bdcf3fa78e24ac43da8e7f6499R856)
* Exposed the `watchdogCheck` function on the router object for easier testing.

**Testing enhancements:**

* Added new integration tests in `server/__tests__/api.test.js` to verify watchdog idempotence: one test ensures that recovered sessions aren't erroneously flipped back to error by the watchdog when only old transcript errors are present, and another test checks that sessions are still marked as error when a new transcript error appears.