### PR TITLE
Update macOS app documentation and remove outdated notes

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -172,9 +172,6 @@ Open **http://localhost:4820** in your browser.
 
 If you'd rather not keep a terminal window open, the project also ships an Electron 35-based **native macOS app** (the `desktop/` workspace). It embeds the Express server in-process, renders the built React client in a `BrowserWindow`, registers a menu-bar (tray) icon, and offers a one-click "Open at Login" toggle. Everything you'd see in the browser at `localhost:4820` lives inside a single `.app` you install once.
 
-> [!NOTE]
-> The desktop app is **macOS only** (v1). The DMG is ad-hoc signed by default, so macOS Gatekeeper warns on first launch — see [Install the app](#install-the-app) for the one-line bypass.
-
 ### Prerequisites
 
 | For… | You need |

--- a/README.md
+++ b/README.md
@@ -1272,9 +1272,6 @@ The dashboard also ships as an optional **native macOS application** — a singl
 
 Everything you see in the browser at `localhost:4820` lives inside this window, with macOS-native lifecycle on top: a menu-bar (tray) icon, a native application menu, Login Items integration for auto-start, and a single quit button that cleanly shuts the server down.
 
-> [!NOTE]
-> The desktop app is **macOS only** for now. Windows/Linux builds and an in-app auto-updater are tracked as follow-ups — Electron makes them straightforward, but each needs its own QA. The current upgrade path is to re-download the latest DMG; your data is stored outside the `.app` bundle, so it persists across reinstalls and updates.
-
 ### How it works
 
 Unlike running the dashboard from a terminal, the desktop app needs no `npm start`, no open shell, and no second copy of the server. The Electron **main process** hosts the Express server **in-process** — it `require()`s `server/index.js` directly in the same Node runtime, with **no child process and no IPC** — and points a Chromium `BrowserWindow` at the built React client.

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-dashboard-desktop",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-dashboard-desktop",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-dashboard-desktop",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "private": true,
   "description": "Native macOS desktop shell for Claude Code Agent Monitor.",
   "author": "Son Nguyen <hoangson091104@gmail.com>",

--- a/index.html
+++ b/index.html
@@ -3337,14 +3337,6 @@
               PID liveness check on read.
             </p>
           </div>
-          <div class="how-step">
-            <div class="how-step-num">05</div>
-            <h4>macOS only, for now</h4>
-            <p>
-              v1 targets macOS. The DMG is ad-hoc signed, so Gatekeeper warns on first launch -
-              one command clears it (see below). Windows and Linux are out of scope for now.
-            </p>
-          </div>
         </div>
         <div class="install reveal install-group">
           <div class="install-text">
@@ -3722,7 +3714,7 @@
                 outside the <code>.app</code> bundle, so it survives reinstalls and updates, and the
                 app recovers your shell <code>PATH</code> at startup so <em>Run Claude</em> can
                 launch the <code>claude</code> CLI. macOS only for now - see the
-                <a href="https://github.com/hoangsonww/Claude-Code-Agent-Monitor/blob/master/DESKTOP.md" target="_blank" rel="noopener noreferrer" style="color: var(--accent);">desktop app guide</a>.
+                <a href="https://github.com/hoangsonww/Claude-Code-Agent-Monitor/blob/master/DESKTOP.md" target="_blank" rel="noopener noreferrer" style="color: var(--accent);">MacOS app guide</a>.
               </p>
             </div></div>
           </details>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-dashboard",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-dashboard",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-dashboard",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Real-time dashboard for tracking Claude Code agent activity",
   "private": true,
   "type": "commonjs",


### PR DESCRIPTION
This pull request removes redundant and outdated notes about macOS-only support for the desktop app from user-facing documentation and the web dashboard, and updates a link label for clarity. These changes help streamline the documentation and improve clarity for users.

**Documentation cleanup and clarity:**

* Removed explicit callouts and notes stating that the desktop app is "macOS only" from `INSTALL.md` and `README.md` to reduce redundancy and outdated information. [[1]](diffhunk://#diff-09b140a43ebfdd8dbec31ce72cafffd15164d2860fd390692a030bcb932b54a0L175-L177) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1275-L1277)
* Removed the "macOS only, for now" step from the installation steps in `index.html` for a cleaner user experience.
* Updated the link label in the FAQ section of `index.html` from "desktop app guide" to "MacOS app guide" for improved clarity.