### PR TITLE
feat: add Claude Opus 4.8 pricing + fix Stop-hook stall

### DIFF
--- a/scripts/hook-handler.js
+++ b/scripts/hook-handler.js
@@ -8,6 +8,13 @@
  * app running alongside `npm run dev`) so each one keeps its real-time
  * stream.
  *
+ * Delivery is fire-and-forget: we exit as soon as the request body is on the
+ * wire, WITHOUT waiting for the dashboard's HTTP response. The hook only needs
+ * to *deliver* the event — on loopback the local server reads the buffered
+ * request and processes it even after this short-lived process exits. Waiting
+ * for the response is what made Claude Code sit at "running hooks" for seconds
+ * whenever a dashboard was busy, slow, or wedged.
+ *
  * @author Son Nguyen <hoangson091104@gmail.com>
  */
 
@@ -49,13 +56,21 @@ process.stdin.on("end", () => {
   });
   const contentLength = Buffer.byteLength(payload);
 
-  // Fan out one POST per live server. Each per-target promise always
-  // resolves (never rejects), so a single dead listener cannot starve the
-  // others and we can wait on Promise.all without a single failure exiting
-  // the process early.
+  // Fan out one POST per live server. Each per-target promise resolves the
+  // moment the request body has been flushed — NOT when the dashboard replies
+  // — so a busy, slow, or wedged dashboard can't stall the hook. Each promise
+  // always resolves (never rejects), so one dead listener can't starve the
+  // others and Promise.all can't be left hanging by a single failure.
   const sends = ports.map(
     (port) =>
       new Promise((resolve) => {
+        let settled = false;
+        const done = () => {
+          if (settled) return;
+          settled = true;
+          resolve();
+        };
+
         const req = http.request(
           {
             hostname: "127.0.0.1",
@@ -66,27 +81,31 @@ process.stdin.on("end", () => {
               "Content-Type": "application/json",
               "Content-Length": contentLength,
             },
-            timeout: 3000,
+            timeout: 2000,
           },
-          (res) => {
-            res.resume();
-            res.once("end", resolve);
-            res.once("close", resolve);
-          }
+          // Drain any response so the socket closes cleanly if the server does
+          // reply before we exit. We never block on it.
+          (res) => res.resume()
         );
-        req.on("error", resolve);
+
+        req.on("error", done); // dead listener (ECONNREFUSED) — nothing to deliver
         req.on("timeout", () => {
           req.destroy();
-          resolve();
+          done();
         });
         req.write(payload);
-        req.end();
+        // The 'end' callback fires once the body is on the wire: delivery is
+        // done and the local server will process it on its own schedule.
+        req.end(done);
       })
   );
 
-  Promise.all(sends).finally(() => process.exit(0));
+  // Give the kernel one tick to hand the buffered request bytes to the local
+  // server before our sockets close, then exit. The hook returns in ms.
+  Promise.all(sends).finally(() => setImmediate(() => process.exit(0)));
 });
 
-// Safety net timeout — guarantees the hook never blocks Claude Code even if
-// every dashboard hangs forever.
-setTimeout(() => process.exit(0), 5000);
+// Safety net — guarantees the hook never blocks Claude Code even if a send
+// somehow never settles. Shorter than the old 5s wait because we no longer
+// block on the dashboard's response, only on the request flush.
+setTimeout(() => process.exit(0), 2500);

--- a/server/__tests__/hook-handler.test.js
+++ b/server/__tests__/hook-handler.test.js
@@ -1,0 +1,105 @@
+/**
+ * @file Regression tests for scripts/hook-handler.js delivery behavior. The
+ * handler must never block Claude Code waiting for the dashboard's HTTP
+ * response — it delivers the event (flushes the request) and exits, leaving the
+ * local server to process the buffered request on its own schedule. These tests
+ * lock in that non-blocking contract so a future refactor can't reintroduce the
+ * "stuck running hooks" stall (handler waiting up to the per-request timeout for
+ * a slow/busy/wedged dashboard to reply).
+ */
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("path");
+const http = require("http");
+const { spawn } = require("child_process");
+
+const HANDLER = path.resolve(__dirname, "../../scripts/hook-handler.js");
+
+// A mock dashboard that fully RECEIVES the request (records the body) but can be
+// told to delay its HTTP response — emulating a busy/slow/wedged server.
+function startMockServer({ responseDelayMs }) {
+  const received = [];
+  const server = http.createServer((req, res) => {
+    let body = "";
+    req.on("data", (c) => (body += c));
+    req.on("end", () => {
+      received.push(body);
+      const reply = () => {
+        try {
+          res.end('{"ok":true}');
+        } catch {
+          /* client already gone — expected when the handler exits early */
+        }
+      };
+      if (responseDelayMs > 0) setTimeout(reply, responseDelayMs);
+      else reply();
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      resolve({ server, port: server.address().port, received });
+    });
+  });
+}
+
+// Spawn the real handler, pipe a hook payload to stdin, and time how long it
+// takes to exit.
+function runHandler({ port, hookType = "Stop", payload }) {
+  return new Promise((resolve, reject) => {
+    const start = process.hrtime.bigint();
+    const child = spawn(process.execPath, [HANDLER, hookType], {
+      env: { ...process.env, CLAUDE_DASHBOARD_PORT: String(port) },
+      stdio: ["pipe", "ignore", "ignore"],
+    });
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      resolve({ code, ms: Number(process.hrtime.bigint() - start) / 1e6 });
+    });
+    child.stdin.write(JSON.stringify(payload));
+    child.stdin.end();
+  });
+}
+
+describe("hook-handler non-blocking delivery", () => {
+  it("exits without waiting for a slow dashboard response, yet still delivers the event", async () => {
+    // Server takes 5s to respond — far longer than the handler's own safety net.
+    const { server, port, received } = await startMockServer({ responseDelayMs: 5000 });
+    try {
+      const { code, ms } = await runHandler({
+        port,
+        payload: { session_id: "hh-slow", stop_reason: "end_turn" },
+      });
+
+      assert.equal(code, 0, "handler should exit cleanly");
+      // Must NOT have waited on the 5s response (and must beat its 2.5s safety
+      // net): a healthy deliver-and-exit is well under a second.
+      assert.ok(
+        ms < 2000,
+        `handler should exit fast (was ${ms.toFixed(0)}ms) despite the 5s server response`
+      );
+
+      // Delivery is preserved even though we exited before the reply.
+      await new Promise((r) => setTimeout(r, 200));
+      assert.equal(received.length, 1, "event should be delivered exactly once");
+      assert.match(received[0], /hh-slow/, "delivered payload should carry the session id");
+      assert.match(received[0], /"hook_type":"Stop"/, "payload should be wrapped with hook_type");
+    } finally {
+      server.close();
+    }
+  });
+
+  it("exits promptly when no dashboard is listening (connection refused)", async () => {
+    // Grab a port then close it so nothing is listening there.
+    const { server, port } = await startMockServer({ responseDelayMs: 0 });
+    await new Promise((r) => server.close(r));
+
+    const { code, ms } = await runHandler({
+      port,
+      payload: { session_id: "hh-dead", stop_reason: "end_turn" },
+    });
+
+    assert.equal(code, 0, "handler should still exit cleanly with no listener");
+    assert.ok(ms < 2000, `handler should exit fast on a refused connection (was ${ms.toFixed(0)}ms)`);
+  });
+});

--- a/server/__tests__/hook-handler.test.js
+++ b/server/__tests__/hook-handler.test.js
@@ -100,6 +100,9 @@ describe("hook-handler non-blocking delivery", () => {
     });
 
     assert.equal(code, 0, "handler should still exit cleanly with no listener");
-    assert.ok(ms < 2000, `handler should exit fast on a refused connection (was ${ms.toFixed(0)}ms)`);
+    assert.ok(
+      ms < 2000,
+      `handler should exit fast on a refused connection (was ${ms.toFixed(0)}ms)`
+    );
   });
 });

--- a/server/db.js
+++ b/server/db.js
@@ -156,6 +156,7 @@ db.exec(`
 // Each model gets its own explicit row — no catch-all grouping
 const DEFAULT_PRICING = [
   // Opus family
+  ["claude-opus-4-8%", "Claude Opus 4.8", 5, 25, 0.5, 6.25],
   ["claude-opus-4-7%", "Claude Opus 4.7", 5, 25, 0.5, 6.25],
   ["claude-opus-4-6%", "Claude Opus 4.6", 5, 25, 0.5, 6.25],
   ["claude-opus-4-5%", "Claude Opus 4.5", 5, 25, 0.5, 6.25],
@@ -177,7 +178,7 @@ const DEFAULT_PRICING = [
 
 // Top-up: insert any default pattern that isn't already present. Preserves
 // user edits to existing rows — we only add what's missing, never overwrite.
-// This runs every startup so new default models (e.g. Opus 4.7) appear in the
+// This runs every startup so new default models (e.g. Opus 4.8) appear in the
 // Settings UI automatically without requiring a manual "Reset Defaults".
 {
   const existing = new Set(


### PR DESCRIPTION
This PR has two independent changes.

---

## 1. Add Claude Opus 4.8 default pricing

Adds a default `model_pricing` row for **Claude Opus 4.8**, identical to Opus 4.7.

| Field | Value |
|---|---|
| Input | $5 / MTok |
| Cache write (5m) | $6.25 / MTok |
| Cache read (hits & refreshes) | $0.50 / MTok |
| Output | $25 / MTok |

> The published table also lists a 1h cache write of $10 / MTok, but `model_pricing` only stores a single `cache_write_per_mtok` (the 5m rate, `$6.25`) — same as every other row.

**Change:** `server/db.js` — added `["claude-opus-4-8%", "Claude Opus 4.8", 5, 25, 0.5, 6.25]` to `DEFAULT_PRICING` (newest-first). Startup top-up seeds it automatically for existing installs; the frontend fetches pricing dynamically and `formatModelName` already renders `claude-opus-4-8*` as "Claude Opus 4.8", so no client changes are needed.

---

## 2. Fix: Stop hook "stuck running hooks" stall

**Symptom:** after Claude finishes a turn, the TUI sits at "running hooks" for a while.

**Root cause (measured, not guessed):** `scripts/hook-handler.js` POSTed each event to the dashboard and then **waited for the HTTP response** before exiting (`res.once("end")` across all servers via `Promise.all`, introduced with the multi-server fan-out in `a492d25`). Claude Code blocks on the hook process, so whenever a dashboard was busy, slow, or wedged, the handler sat on its **3s per-request timeout** — on *every* hook (PreToolUse/PostToolUse on each tool call, plus Stop). It is **not** the server's processing: a 27 MB transcript parses in ~224 ms and a normal Stop is ~0.6 ms.

**Evidence** — handler exit time against a dashboard that *receives and processes* the event but is slow to reply:

| Handler | Stop hook exit | Event delivered? |
|---|---|---|
| before | **3.06 s** | ✅ |
| after | **0.06 s** | ✅ |

**Fix:** the hook only needs to *deliver* the event, not read the reply. On loopback the local server reads the buffered request and processes it even after the short-lived hook process exits. The handler now resolves each send the moment the request body is flushed (`req.end` callback) and exits on the next tick — verified end-to-end against the real server (event still lands in the DB).

**Changes:**
- `scripts/hook-handler.js` — deliver-and-exit instead of waiting for the response; safety net trimmed 5s → 2.5s.
- `server/__tests__/hook-handler.test.js` — new regression test: spawns the real handler against a 5s-slow mock server and asserts it exits in < 2s while still delivering exactly one event (plus a refused-connection fast-exit case).

---

## Verification

- `npm run test:server`: **255 passing**, including the 2 new hook-handler tests. The only 5 failures are pre-existing `getUpdatesStatus` tests that `git commit` into temp repos and fail in this sandbox due to a commit-signing error — unrelated to these changes.
- Pricing: confirmed `claude-opus-4-8[-date][1m]` → `claude-opus-4-8%` (no collision with 4-7); cost for 1M in + 1M out = $30, matching Opus 4.7.

https://claude.ai/code/session_018PMwK9oWb1vjs3dYfGCnec