### PR TITLE
fix(workflows): clamp per-subagent-type avgDuration to >= 0

### DIFF
--- a/server/__tests__/api.test.js
+++ b/server/__tests__/api.test.js
@@ -1738,13 +1738,78 @@ describe("Compaction agent ingestion", () => {
 
     const res = await fetch("/api/workflows");
     assert.equal(res.status, 200);
-    const compactionType = (res.body.types || []).find((t) => t.subagent_type === "compaction");
+    // Subagent effectiveness (incl. avgDuration per type) is at .effectiveness,
+    // not .types — the prior key never matched, so this assertion was dead.
+    const compactionType = (res.body.effectiveness || []).find(
+      (t) => t.subagent_type === "compaction"
+    );
     if (compactionType && compactionType.avgDuration !== null) {
       assert.ok(
         compactionType.avgDuration >= 0,
         `compaction avgDuration must be >= 0, got ${compactionType.avgDuration}`
       );
     }
+  });
+
+  it("workflows avgDuration for non-compaction subagents is clamped to >= 0", async () => {
+    // The #156 startup repair only heals compaction rows. A non-compaction
+    // subagent whose ended_at < started_at (clock skew, replayed/synced
+    // transcripts, or fleet/Workflow-tool ingestion) is NOT repaired, so the
+    // per-type avgDuration query must clamp negative durations itself.
+    const sid = `noncompact-avg-sess-${Date.now()}`;
+    stmts.insertSession.run(sid, "noncompact-avg", "completed", "/tmp", "test-model", null);
+    stmts.insertAgent.run(`${sid}-main`, sid, "main", "main", null, "completed", null, null, null);
+
+    // One valid Explore row (+10s) and one broken Explore row (ended 30s before
+    // started). The broken row is deliberately left un-repaired.
+    const goodId = `${sid}-explore-good`;
+    stmts.insertAgent.run(
+      goodId,
+      sid,
+      "Explore",
+      "subagent",
+      "Explore",
+      "completed",
+      null,
+      `${sid}-main`,
+      null
+    );
+    db.prepare("UPDATE agents SET started_at = ?, ended_at = ? WHERE id = ?").run(
+      new Date(Date.now() - 10_000).toISOString(),
+      new Date().toISOString(),
+      goodId
+    );
+
+    const brokenId = `${sid}-explore-broken`;
+    stmts.insertAgent.run(
+      brokenId,
+      sid,
+      "Explore",
+      "subagent",
+      "Explore",
+      "completed",
+      null,
+      `${sid}-main`,
+      null
+    );
+    db.prepare("UPDATE agents SET ended_at = ? WHERE id = ?").run(
+      new Date(Date.now() - 30_000).toISOString(),
+      brokenId
+    );
+    const before = db.prepare("SELECT started_at, ended_at FROM agents WHERE id = ?").get(brokenId);
+    assert.ok(
+      before.ended_at < before.started_at,
+      "precondition: broken row should have ended_at < started_at"
+    );
+
+    const res = await fetch("/api/workflows");
+    assert.equal(res.status, 200);
+    const exploreType = (res.body.effectiveness || []).find((t) => t.subagent_type === "Explore");
+    assert.ok(exploreType, "Explore subagent type should appear in effectiveness");
+    assert.ok(
+      exploreType.avgDuration >= 0,
+      `non-compaction avgDuration must be >= 0, got ${exploreType.avgDuration}`
+    );
   });
 });
 

--- a/server/routes/workflows.js
+++ b/server/routes/workflows.js
@@ -320,9 +320,14 @@ function getSubagentEffectiveness(statusFilter) {
   const withMetrics = types.map((t) => {
     const durRow = db
       .prepare(
+        // Clamp each row's duration to >= 0 before averaging. The #156 startup
+        // repair only heals compaction rows; any other subagent type whose
+        // ended_at < started_at (clock skew, replayed/synced transcripts) would
+        // otherwise drag this average negative. MAX(0, …) mirrors the Math.max(0)
+        // guard durationSec() already applies to every other duration here.
         `SELECT AVG(
           CASE WHEN ended_at IS NOT NULL THEN
-            (julianday(ended_at) - julianday(started_at)) * 86400
+            MAX(0, (julianday(ended_at) - julianday(started_at)) * 86400)
           ELSE NULL END
         ) as avg_duration
         FROM agents WHERE subagent_type = ? AND type = 'subagent'${sf.clause}`


### PR DESCRIPTION
## Summary

The `/api/workflows` subagent-effectiveness `avgDuration` is the one duration calculation in `server/routes/workflows.js` with no negative guard, so a single subagent row whose `ended_at < started_at` can report a **negative average duration**. This is the same class of bug as #156, but for every subagent type the #156 repair doesn't cover.

## Changes

- **`server/routes/workflows.js`** — clamp each row's duration with `MAX(0, …)` inside `getSubagentEffectiveness`'s `AVG()` query. Every other duration calc in this file already guards against negatives (`durationSec()` uses `Math.max(0, …)`; the concurrency lanes clamp to `[0,1]`), and the #156 startup repair collapses broken rows to a 0-second duration — but that repair only targets `subagent_type = 'compaction'` (`server/db.js`). Any **other** subagent type whose `ended_at < started_at` (clock skew across machines syncing `~/.claude`, replayed/imported transcripts, or the new Workflow-tool fleet ingestion in `lib/workflow-ingest.js`) still dragged its average negative. Clamping per row matches the repair's "instantaneous → 0" semantics and guarantees `avgDuration >= 0`.
- **`server/__tests__/api.test.js`** — the existing #156 test read `res.body.types`, but subagent effectiveness is returned at `res.body.effectiveness`, so its `avgDuration >= 0` assertion never actually ran. Pointed it at the correct key and added a regression test that seeds a **non-compaction** subagent (`Explore`) with a broken, deliberately un-repaired invariant and asserts the API never returns a negative average.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (no functional changes)
- [ ] Documentation update
- [ ] Infrastructure / CI / DevOps
- [ ] Dependency update

## How to Test

1. `npm run test:server` — all server tests pass (345), including the new `"workflows avgDuration for non-compaction subagents is clamped to >= 0"`.
2. To see the bug without the fix: revert the `MAX(0, …)` change and re-run — the new test fails with `non-compaction avgDuration must be >= 0, got -10`.
3. Manual repro: seed a subagent row with `ended_at` 30s before `started_at` (any `subagent_type` other than `compaction`) and `GET /api/workflows` — before the fix that type's `effectiveness[].avgDuration` is negative; after, it is clamped to `>= 0`.

## Checklist

- [x] I have read the [contributing guidelines](../CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] I have added/updated tests that prove my fix or feature works
- [x] All new and existing tests pass (`npm test`)
- [x] Code is formatted (`npm run format:check`)
- [ ] I have updated documentation where necessary (no behavior/command/path changes — none needed)

> Note on tests: `npm run test:server` is green (345/345). The `npm run test:client` suite reports 11 unrelated failures (`Tabby`, `Dashboard` snapshot) **only on Node 26** — `localStorage` is `undefined` under jsdom 27 on that runtime; these reproduce on a clean `master` checkout and are untouched by this server-only change. The repo's CI runs Node 22, where the client suite passes.
