### PR TITLE
fix(workflows): load workflow agent transcripts and resolve nested subagent path drift

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -349,7 +349,7 @@ graph TD
 | `lib/webhooks.js`         | Universal webhook delivery engine driven by the provider registry. `buildRequest()` resolves the URL, formats the provider-native payload, and assembles headers (provider auth headers + generic-family custom headers + optional HMAC-SHA256 signature via `X-Webhook-Signature` / `X-Webhook-Timestamp`). `dispatchAlert()` fans a fired alert out to every enabled, in-scope target (optional per-rule scoping via `rule_ids`); each `deliver()` POSTs with an `AbortController` timeout and bounded retry/backoff (retries transport errors / 429 / 5xx, never other 4xx) and records the attempt-chain outcome in `webhook_deliveries` (pruned to the newest 2000 rows). Delivery is detached and fully fail-safe — it never throws into the alert path. Enabled targets are cached like alert rules; tunables (`WEBHOOK_TIMEOUT_MS`, `WEBHOOK_MAX_ATTEMPTS`, `WEBHOOK_RETRY_BASE_MS`) are env-overridable. `sendTest()` awaits a synthetic delivery for the test endpoint |
 | `routes/workflows.js`     | Aggregate workflow visualization data (agent orchestration graphs, tool transition flows, collaboration networks, workflow pattern detection, model delegation, error propagation, concurrency timelines, session complexity metrics, compaction impact). Accepts `?status=active\|completed` query parameter to filter all data by session status. Per-session drill-in endpoint with agent tree, tool timeline, and event details |
 | `lib/transcript-cache.js` | Stat-based JSONL transcript cache with incremental byte-offset reads. Shared between `hooks.js` (token extraction on every event) and the periodic compaction scanner (`index.js`). Extracts tokens, compaction entries, API errors (`isApiErrorMessage` + raw error responses), turn durations (`system` subtype `turn_duration`), thinking block counts, and usage extras (service_tier, speed, inference_geo). Uses `(path, mtime, size)` cache key — unchanged files return cached results instantly, grown files only parse new bytes, shrunk files (compaction) trigger full re-read. Each cache entry stores **only** `{mtimeMs, size, bytesRead, result}` — the previous shape that duplicated every growable array at both the top level and inside `result` is gone, halving steady-state memory per entry. Per-entry growable arrays (`turnDurations`, `errors`, `compaction.entries`, `usageExtras.*`) are bounded to `TRANSCRIPT_CACHE_MAX_ARRAY_LEN` (default `1000`, tail-kept) — older items remain in the `events` table thanks to hook dedup, so the cap only affects the in-memory view. Trimming runs both during parse (when an array reaches `2 * MAX_ARRAY_LEN`, amortized O(N)) and at finalize, so even a fresh full-file parse on a multi-day session cannot accumulate an unbounded transient before returning. **Chunked sync byte-stream reader** (`_streamRange`, 4 MiB chunks split on `0x0A` bytes — safe across UTF-8 multibyte sequences — with a growable per-line byte buffer capped at 64 MiB) replaces the previous `readFileSync("utf8")` so transcripts larger than V8's max JS string length (~512 MiB on 64-bit Node 20) parse without aborting Node with `FATAL ERROR: v8::ToLocalChecked Empty MaybeLocal`. Both full and incremental reads share the same line-level state machine (`_initParseState` / `_consumeLine` / `_finalizeState`). LRU eviction caps at 200 entries. Entries evicted on SessionEnd and abandoned session cleanup |
-| `scripts/import-history.js` | Batch history importer used by (a) server startup auto-import, (b) the `/api/import/*` routes, (c) the `import-history` CLI, and (d) live `SubagentStop` ingestion via the exported `scanAndImportSubagents(dbModule, sessionId, transcriptPath)`. Exposes `importAllSessions(dbModule)` for the default `~/.claude/projects` tree and the generalized `importFromDirectory(dbModule, rootDir, {onProgress})` which walks any directory recursively, classifies each `.jsonl` as session vs subagent (with `findSessionSubagents` probing both `<proj>/<sid>/subagents/*` and `<proj>/subagents/<sid>/*` layouts), and funnels everything through the shared `parseSessionFile` + `importSession` pipeline. `parseSubagentFile` extracts ordered `toolEvents` (tool_use + tool_result paired by `tool_use_id`) so `importSubagentFromJsonl` can emit per-tool `PreToolUse` + `PostToolUse` rows under each subagent's own `agent_id`. The importer dedups against live hook-created subagent rows via `findLiveSubagentForJsonl` (session + subagent_type + start-time within 30 s) so backfill never produces parallel `<sid>-jsonl-*` rows. **Re-import is fully incremental**: for each existing session a per-event-type high-water mark (`MAX(created_at) GROUP BY event_type`) is read up-front and only JSONL entries with `ts > cutoff[type]` are inserted for Stop / PostToolUse / TurnDuration / ToolError — so long-running sessions whose transcripts grow across multiple days continue to receive new events on every re-run instead of being blocked by the old "if zero of type X then dump all" check. `sessions.ended_at` is rolled forward to the JSONL's last activity when it surpasses the stored value, and `metadata.user_messages` / `assistant_messages` / `turn_count` are refreshed on every pass. Other idempotency keys are unchanged: `data LIKE '%"tool_use_id":"X"%'` skips any tool event already inserted, compaction agents/events dedup by uuid, API errors dedup by summary, and `baseline_*` columns preserve pre-compaction token totals. Token totals, per-model cost, compactions, subagents, tool events, API errors, and turn durations are identical to live ingestion. Creates `APIError`, `TurnDuration`, and `ToolError` event types during import; subagent tool events carry `imported: true, source: "subagent_jsonl"` in their data payload so analytics can distinguish backfilled rows when needed |
+| `scripts/import-history.js` | Batch history importer used by (a) server startup auto-import, (b) the `/api/import/*` routes, (c) the `import-history` CLI, and (d) live `SubagentStop` ingestion via the exported `scanAndImportSubagents(dbModule, sessionId, transcriptPath)`. Exposes `importAllSessions(dbModule)` for the default `~/.claude/projects` tree and the generalized `importFromDirectory(dbModule, rootDir, {onProgress})` which walks any directory recursively, classifies each `.jsonl` as session vs subagent (with `findSessionSubagents` probing both `<proj>/<sid>/subagents/*` and `<proj>/subagents/<sid>/*` layouts), and funnels everything through the shared `parseSessionFile` + `importSession` pipeline. The durable transcript snapshot (`snapshotTranscript`) additionally preserves **nested** Workflow-tool inner-agent transcripts (`subagents/workflows/<runId>/agent-*.jsonl`) via the separate `findSessionWorkflowSubagents` probe — mirroring the run subpath so the read route resolves the snapshot identically to the live file, without pulling those nested agents into the flat sub-agent import (no double-count). `parseSubagentFile` extracts ordered `toolEvents` (tool_use + tool_result paired by `tool_use_id`) so `importSubagentFromJsonl` can emit per-tool `PreToolUse` + `PostToolUse` rows under each subagent's own `agent_id`. The importer dedups against live hook-created subagent rows via `findLiveSubagentForJsonl` (session + subagent_type + start-time within 30 s) so backfill never produces parallel `<sid>-jsonl-*` rows. **Re-import is fully incremental**: for each existing session a per-event-type high-water mark (`MAX(created_at) GROUP BY event_type`) is read up-front and only JSONL entries with `ts > cutoff[type]` are inserted for Stop / PostToolUse / TurnDuration / ToolError — so long-running sessions whose transcripts grow across multiple days continue to receive new events on every re-run instead of being blocked by the old "if zero of type X then dump all" check. `sessions.ended_at` is rolled forward to the JSONL's last activity when it surpasses the stored value, and `metadata.user_messages` / `assistant_messages` / `turn_count` are refreshed on every pass. Other idempotency keys are unchanged: `data LIKE '%"tool_use_id":"X"%'` skips any tool event already inserted, compaction agents/events dedup by uuid, API errors dedup by summary, and `baseline_*` columns preserve pre-compaction token totals. Token totals, per-model cost, compactions, subagents, tool events, API errors, and turn durations are identical to live ingestion. Creates `APIError`, `TurnDuration`, and `ToolError` event types during import; subagent tool events carry `imported: true, source: "subagent_jsonl"` in their data payload so analytics can distinguish backfilled rows when needed |
 | `server/routes/import.js`   | Express router for the Import History feature. Three endpoints funnel into the same pipeline: `POST /api/import/rescan` (default projects dir), `POST /api/import/scan-path` (arbitrary absolute dir with `~` expansion), `POST /api/import/upload` (multer multipart accepting `.jsonl`, `.meta.json`, `.zip`, `.tar`, `.tar.gz`, `.tgz`, `.gz`). `GET /api/import/guide` returns OS-aware instructions + archive command + default-dir stats. Each request uses a per-request temp dir (`req._ccamUploadDir` for multer staging, a separate `workDir` for extraction) that is reclaimed in `finally`. Progress is broadcast as `import.progress` websocket messages throttled at ~150 ms. Limits configurable via `CCAM_IMPORT_MAX_BYTES` / `CCAM_IMPORT_MAX_FILES` |
 | `server/lib/archive.js`     | Safe archive extraction: `.zip` via `adm-zip`, `.tar`/`.tar.gz`/`.tgz` via `tar`, plain `.gz` via `zlib` in streaming mode. Every entry is validated through `safeJoin` which rejects absolute paths and `..` traversal before any bytes are written. Enforces a hard extraction cap (`MAX_EXTRACT_BYTES`, default 4 GB, tunable via `CCAM_IMPORT_MAX_EXTRACT_BYTES`) with `ExtractionLimitError` surfaced as HTTP 413 from the upload route — defense against zip/tar/gzip bombs. Also provides `detectKind` for filename-based dispatch and `mkTempDir`/`rmTempDir` helpers |
 | `lib/cc-discovery.js`     | Read-only discovery of every Claude Code config surface for the Config Explorer page. Pure file reads; never writes. Surfaces: skills (`<root>/skills/<name>/SKILL.md`), subagents (`<root>/agents/*.md`), slash commands (`<root>/commands/*.md`), output styles (`<root>/output-styles/*.md`), plugins (`<CLAUDE_HOME>/plugins/installed_plugins.json` joined with `enabledPlugins` in settings + per-plugin `contributes` count by scanning the install dir + `plugin.json` metadata), marketplaces (`known_marketplaces.json` enriched with each `marketplace.json`), MCP servers (top-level + per-project from `~/.claude.json`), hooks (across user / project / project-local settings.json), keybindings (`<CLAUDE_HOME>/keybindings.json`), statusline config + `statusline.py` / `statusline-command.sh` content, hook scripts dir (`<CLAUDE_HOME>/hooks/`), settings (with secret-key redaction matching `/token\|secret\|password\|api[_-]?key\|auth/i`), memory (`CLAUDE.md` at user + project). Path containment via `isUnder()` — every read must resolve under CLAUDE_HOME, project `.claude/`, or be a project CLAUDE.md. 256 KB read cap. Minimal YAML frontmatter parser handles `key: value` + quoted strings + indented continuation lines |
@@ -592,7 +592,7 @@ graph LR
 | `/`             | Dashboard     | Two tabs (Monitor / Health). Monitor: `GET /api/stats`, `GET /api/agents`, `GET /api/events`, `GET /api/agents?session_id={sid}` (subagent hierarchy), dynamic item counts via `ResizeObserver`. Health: `GET /api/settings/info` + `GET /api/workflows` (5 s auto-refresh) — composite health score, storage donut, cache/error/success gauges, tool invocation bars, subagent effectiveness, model token distribution, compaction stats |
 | `/kanban`       | KanbanBoard   | View toggle persisted in `localStorage`. Agents view: `GET /api/agents?status={each}` per-status (default 10000 cap). Sessions view: `GET /api/sessions?status={each}&limit=10000` per-status. Each column then paginates client-side at `COLUMN_PAGE_SIZE=10`; the WS subscription scopes to the active view. |
 | `/sessions`     | Sessions      | `GET /api/sessions?status=&q=&limit=PAGE_SIZE&offset=page*PAGE_SIZE` — true server-side pagination. The search box passes `q` to the server (300 ms debounced). Response carries `total` for the paginator UI. Cost computation runs server-side over the visible page only. Polls `/api/run` (and listens for `run_status`) to badge any row whose session is currently being driven from `/run` with a clickable green **▶ Run** pill |
-| `/sessions/:id` | SessionDetail | `GET /api/sessions/:id` (agents + events), `GET /api/sessions/:id/stats` (overview tiles, top tools, subagent breakdown, token totals — debounced live-refresh on `new_event`/`agent_*`/`session_updated`), `GET /api/sessions/:id/transcripts` (Conversation tab transcript list), `GET /api/sessions/:id/transcript` (cursor-paginated message stream). Probes `/api/run` (and listens for `run_status`) to surface a green "Open in Run page" banner when this session is currently being driven by an in-flight Run handle |
+| `/sessions/:id` | SessionDetail | `GET /api/sessions/:id` (agents + events), `GET /api/sessions/:id/stats` (overview tiles, top tools, subagent breakdown, token totals — debounced live-refresh on `new_event`/`agent_*`/`session_updated`), `GET /api/sessions/:id/transcripts` (Conversation tab transcript list), `GET /api/sessions/:id/transcript` (cursor-paginated message stream; optional `run_id` resolves a workflow inner agent's nested transcript). Probes `/api/run` (and listens for `run_status`) to surface a green "Open in Run page" banner when this session is currently being driven by an in-flight Run handle |
 | `/activity`     | ActivityFeed  | `GET /api/events?limit=100` — click row to expand inline payload; "Session →" button navigates to `/sessions/:id` |
 | `/analytics`    | Analytics     | `GET /api/analytics`                                   |
 | `/workflows`    | Workflows     | `GET /api/workflows?status=active\|completed`, `GET /api/workflows/session/:id` + WebSocket auto-refresh (3s debounce) |
@@ -1189,6 +1189,7 @@ usage for billing purposes.
 | Default Claude Code                             | `<proj>/<sid>.jsonl`                         | Session transcript                                                      |
 | Default subagent                                | `<proj>/<sid>/subagents/agent-*.jsonl`       | Paired with parent on discovery                                         |
 | Alternative subagent                            | `<proj>/subagents/<sid>/agent-*.jsonl`       | Paired with parent on discovery                                         |
+| Workflow inner-agent (nested)                   | `<proj>/<sid>/subagents/workflows/<runId>/agent-*.jsonl` | Summarized by Workflow-run ingest; transcript resolved on read + preserved in the durable snapshot |
 | Orphan subagent (no parent JSONL in source)     | `<proj>/subagents/<sid>/agent-*.jsonl`       | `importFromDirectory` probes both candidates; attaches if `sid` exists  |
 | Flat JSONL drop                                 | `<root>/<sid>.jsonl`                         | Recognized as a loose session                                           |
 | Archives (`.zip`, `.tar`, `.tar.gz`, `.tgz`)    | any of the above nested inside               | Extracted into a per-request temp dir, then walked by the same importer |
@@ -1254,10 +1255,11 @@ under the launching session's transcript folder:
 ```
 <projects>/<enc-cwd>/<sessionId>/
   workflows/
-    scripts/<name>-wf_<runId>.js   # the workflow script — written at LAUNCH
-    wf_<runId>.json                # the run journal — written at COMPLETION
+    scripts/<name>-wf_<runId>.js          # the workflow script — written at LAUNCH
+    wf_<runId>.json                       # the run journal — written at COMPLETION
   subagents/
-    agent-<agentId>.jsonl          # one transcript per inner agent
+    workflows/<runId>/agent-<agentId>.jsonl  # inner-agent transcript (current builds — NESTED per run)
+    agent-<agentId>.jsonl                    # flat layout — older builds / regular sub-agents
 ```
 
 The run journal (`wf_<runId>.json`) is the first-class record: identity
@@ -1266,8 +1268,11 @@ The run journal (`wf_<runId>.json`) is the first-class record: identity
 `totalToolCalls`), `phases[]`, and `workflowProgress[]` — one entry per inner
 agent with `agentId`, `agentType`, `model`, `state`, `label`, `phaseTitle`,
 tokens, tool calls, duration, and previews. Critically,
-`workflowProgress[].agentId` is the **exact** `subagents/agent-<agentId>.jsonl`
-basename, so the workflow → inner-agent linkage is explicit.
+`workflowProgress[].agentId` is the **exact** `agent-<agentId>.jsonl` basename,
+so the workflow → inner-agent linkage is explicit. Current Claude Code builds
+write that transcript **nested** under `subagents/workflows/<runId>/`; older
+builds (and all regular sub-agents) write it **flat** under `subagents/`. Both
+layouts are resolved on read — see "Reading full agent text in the UI" below.
 
 ### The terminal-journal constraint
 
@@ -1333,6 +1338,44 @@ Each ingest that changes anything broadcasts `workflow_upserted` and a
 with linked agents + events), and are attached to the launching session via the
 `workflows[]` field on `GET /api/sessions/:id`. The UI shows them in a
 "Workflow Runs" panel on the Workflows page and a subsection on Session Detail.
+
+### Reading full agent text in the UI
+
+The run journal only carries **truncated** `promptPreview` / `resultPreview`
+strings (Claude Code truncates them with a trailing `…`), so the panel alone can
+never show an inner agent's complete prompt or result. The full text lives in the
+per-agent `agent-<agentId>.jsonl` transcript, which the dashboard surfaces
+on demand:
+
+- **Dual-layout resolution.** `server/lib/claude-home.js` exposes
+  `resolveAgentTranscriptInDir(subagentsDir, agentId, runId?)`, used by all three
+  sub-agent path resolvers (`getSubagentTranscriptPath`,
+  `findSubagentTranscriptPath`, `getSnapshotSubagentTranscriptPath`). It checks
+  the **flat** path first (so regular sub-agents resolve exactly as before), then
+  the **nested** `workflows/<runId>/` path. When `runId` is known the run dir is
+  read directly; when it is unknown the nested tree is scanned and a match is
+  returned only if **exactly one** run contains that `agentId` — an ambiguous id
+  across runs resolves to `null` rather than guessing.
+- **`run_id` query param.** `GET /api/sessions/:id/transcript` accepts an
+  optional `run_id=wf_<…>` alongside `agent_id`, threaded into the resolver chain
+  so a workflow inner agent's nested transcript is found deterministically. The
+  endpoint shape is unchanged; the param is additive.
+- **Lazy fetch on expand.** The Workflow Runs panel
+  (`client/src/components/workflows/WorkflowRunsPanel.tsx`) fetches the transcript
+  the first time a result row is expanded (deduped per `${run_id}::${agentId}`),
+  derives prompt + result via `extractPromptResult`, and renders the full text —
+  falling back to the journal teaser while loading, on error, or for schema-mode
+  agents whose final turn is a tool call rather than text. Nothing is eagerly
+  ingested into the DB. "Full text" means the complete message body up to the
+  endpoint's per-message 10,240-char cap (`limit` ≤ 200 messages).
+- **Durable snapshot.** The snapshot writer (`snapshotTranscript` in
+  `scripts/import-history.js`) preserves nested workflow transcripts via the
+  dedicated `findSessionWorkflowSubagents` discovery — mirroring the live
+  `subagents/workflows/<runId>/` subpath into the snapshot dir — so the full text
+  still resolves after Claude Code prunes the live files under its
+  `cleanupPeriodDays` retention. This is kept **separate** from
+  `findSessionSubagents` (flat sub-agents) so the regular sub-agent import path is
+  unchanged and nested inner-agents are never double-counted.
 
 ### Schema
 

--- a/client/src/components/workflows/WorkflowRunsPanel.tsx
+++ b/client/src/components/workflows/WorkflowRunsPanel.tsx
@@ -6,7 +6,10 @@
  * SessionDetail) or self-fetching (pass a `statusFilter`, e.g. the Workflows
  * page) with live `workflow_upserted` updates. Each run expands to colored,
  * clickable phase filters, a per-agent metrics table, and an expandable list of
- * per-agent results (full prompt + result, no truncation).
+ * per-agent results. The collapsed row shows a short teaser from the run
+ * journal; expanding an agent lazily fetches its full transcript (the journal
+ * only carries server-truncated previews) and renders the complete prompt and
+ * result, falling back to the teaser when the transcript is pruned/unavailable.
  * @author Son Nguyen <hoangson091104@gmail.com>
  */
 
@@ -16,7 +19,12 @@ import { useTranslation } from "react-i18next";
 import { Workflow, ChevronRight, ChevronDown, Layers, ExternalLink, Loader2 } from "lucide-react";
 import { api } from "../../lib/api";
 import { eventBus } from "../../lib/eventBus";
-import type { WorkflowRun, WorkflowProgressEntry, WSMessage } from "../../lib/types";
+import type {
+  WorkflowRun,
+  WorkflowProgressEntry,
+  WSMessage,
+  TranscriptMessage,
+} from "../../lib/types";
 import { fmt, formatMs, timeAgo, truncate } from "../../lib/format";
 
 type StatusFilter = "all" | "active" | "completed";
@@ -108,6 +116,48 @@ export function fullPreview(raw: unknown): string {
   }
 }
 
+/** Join the text blocks of one transcript message into a single string. */
+function messageText(m: TranscriptMessage): string {
+  return (m.content || [])
+    .filter((b) => b.type === "text" && b.text)
+    .map((b) => b.text as string)
+    .join("\n\n")
+    .trim();
+}
+
+/**
+ * Derive an agent's full prompt and result from its fetched transcript: the
+ * first user message carries the task prompt; the last assistant message that
+ * has text carries the returned result. Either is "" when absent (e.g. a
+ * schema-mode agent whose final turn is a tool call rather than text) — callers
+ * fall back to the journal teaser in that case.
+ */
+export function extractPromptResult(messages: TranscriptMessage[]): {
+  prompt: string;
+  result: string;
+} {
+  let prompt = "";
+  let result = "";
+  for (const m of messages || []) {
+    if (m.type === "user" && !prompt) {
+      const t = messageText(m);
+      if (t) prompt = t;
+    } else if (m.type === "assistant") {
+      const t = messageText(m);
+      if (t) result = t; // keep the last non-empty assistant text
+    }
+  }
+  return { prompt, result };
+}
+
+/** Per-agent transcript fetch state, keyed `${run_id}::${agentId}`. */
+interface AgentTranscriptState {
+  loading: boolean;
+  prompt?: string;
+  result?: string;
+  error?: boolean;
+}
+
 export function WorkflowRunsPanel({
   runs: controlledRuns,
   statusFilter,
@@ -122,6 +172,31 @@ export function WorkflowRunsPanel({
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
   const [phaseFilter, setPhaseFilter] = useState<Record<string, string | null>>({});
   const [openResults, setOpenResults] = useState<Set<string>>(() => new Set());
+  // Full agent transcripts fetched on demand when a result row is expanded,
+  // keyed `${run_id}::${agentId}`. The run journal only carries truncated
+  // previews; the complete text lives in the per-agent transcript file.
+  const [transcripts, setTranscripts] = useState<Record<string, AgentTranscriptState>>({});
+  const inflightRef = useRef<Set<string>>(new Set());
+
+  const loadTranscript = useCallback(
+    async (sessionId: string, runId: string, agentId: string, key: string) => {
+      if (inflightRef.current.has(key)) return;
+      inflightRef.current.add(key);
+      setTranscripts((prev) => ({ ...prev, [key]: { loading: true } }));
+      try {
+        const res = await api.sessions.transcript(sessionId, {
+          agent_id: agentId,
+          run_id: runId,
+          limit: 200,
+        });
+        const { prompt, result } = extractPromptResult(res.messages || []);
+        setTranscripts((prev) => ({ ...prev, [key]: { loading: false, prompt, result } }));
+      } catch {
+        setTranscripts((prev) => ({ ...prev, [key]: { loading: false, error: true } }));
+      }
+    },
+    []
+  );
 
   const fetchRuns = useCallback(async () => {
     if (controlled) return;
@@ -372,13 +447,28 @@ export function WorkflowRunsPanel({
                     {resultRows.map((a, i) => {
                       const key = `${run.run_id}::${a.agentId || i}`;
                       const open = openResults.has(key);
+                      const ts = transcripts[key];
+                      const hasFull = !!ts && !ts.loading && !ts.error;
+                      const fullPrompt =
+                        hasFull && ts.prompt
+                          ? ts.prompt
+                          : a.promptPreview
+                            ? String(a.promptPreview)
+                            : "";
+                      const fullResult =
+                        hasFull && ts.result ? ts.result : fullPreview(a.resultPreview);
                       return (
                         <div
                           key={key}
                           className="rounded border border-gray-800/70 bg-gray-900/30 overflow-hidden"
                         >
                           <button
-                            onClick={() => toggleResult(key)}
+                            onClick={() => {
+                              if (!open && a.agentId) {
+                                loadTranscript(run.session_id, run.run_id, a.agentId, key);
+                              }
+                              toggleResult(key);
+                            }}
                             className="w-full flex items-center gap-2 px-2 py-1.5 text-left hover:bg-gray-800/40 transition-colors"
                             aria-expanded={open}
                           >
@@ -412,14 +502,20 @@ export function WorkflowRunsPanel({
                                 </span>
                                 <span>{t("runs.tools", { count: a.toolCalls || 0 })}</span>
                                 {a.durationMs != null && <span>{formatMs(a.durationMs)}</span>}
+                                {ts?.loading && (
+                                  <span className="flex items-center gap-1 text-violet-400">
+                                    <Loader2 className="w-3 h-3 animate-spin" />
+                                    {t("runs.loadingFull")}
+                                  </span>
+                                )}
                               </div>
-                              {a.promptPreview && (
+                              {fullPrompt && (
                                 <div>
                                   <div className="text-[10px] uppercase tracking-wider text-gray-600 mb-0.5">
                                     {t("runs.promptLabel")}
                                   </div>
                                   <pre className="text-[11px] text-gray-400 whitespace-pre-wrap break-words bg-black/30 rounded p-2 max-h-48 overflow-auto">
-                                    {String(a.promptPreview)}
+                                    {fullPrompt}
                                   </pre>
                                 </div>
                               )}
@@ -428,7 +524,7 @@ export function WorkflowRunsPanel({
                                   {t("runs.resultLabel")}
                                 </div>
                                 <pre className="text-[11px] text-gray-300 whitespace-pre-wrap break-words bg-black/30 rounded p-2 max-h-96 overflow-auto">
-                                  {fullPreview(a.resultPreview)}
+                                  {fullResult}
                                 </pre>
                               </div>
                             </div>

--- a/client/src/components/workflows/__tests__/WorkflowRunsPanel.transcript.test.tsx
+++ b/client/src/components/workflows/__tests__/WorkflowRunsPanel.transcript.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * @file Tests for the lazy full-transcript fetch in WorkflowRunsPanel: expanding
+ * a result row fetches the agent's complete prompt/result (the run journal only
+ * carries truncated "…" previews), with a graceful fallback to the journal
+ * teaser when the fetch fails. Also unit-tests extractPromptResult.
+ * @author Son Nguyen <hoangson091104@gmail.com>
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+const { transcriptMock } = vi.hoisted(() => ({ transcriptMock: vi.fn() }));
+vi.mock("../../../lib/api", () => ({
+  api: { sessions: { transcript: transcriptMock } },
+}));
+
+import { WorkflowRunsPanel, extractPromptResult } from "../WorkflowRunsPanel";
+import type { WorkflowRun } from "../../../lib/types";
+import type { TranscriptMessage } from "../../../lib/types";
+
+function makeRun(overrides: Partial<WorkflowRun> = {}): WorkflowRun {
+  return {
+    run_id: "wf_x",
+    session_id: "s1",
+    task_id: null,
+    name: "review-changes",
+    status: "completed",
+    default_model: "claude-opus-4-8",
+    started_at: "2026-06-14T00:00:00.000Z",
+    ended_at: "2026-06-14T00:00:05.000Z",
+    duration_ms: 5000,
+    agent_count: 1,
+    total_tokens: 20000,
+    total_tool_calls: 5,
+    phases: [{ title: "Verify" }],
+    progress: [
+      { type: "workflow_phase", index: 1, title: "Verify" },
+      {
+        type: "workflow_agent",
+        agentId: "a1",
+        label: "verify:starship",
+        phaseTitle: "Verify",
+        state: "done",
+        tokens: 18000,
+        toolCalls: 3,
+        durationMs: 900,
+        promptPreview: "Verify the claim…",
+        resultPreview: '{"verdict":"confirmed","note":"VERIFYNOTE"}',
+      },
+    ],
+    script_path: null,
+    journal_path: null,
+    source: "journal",
+    created_at: "2026-06-14T00:00:00.000Z",
+    updated_at: "2026-06-14T00:00:05.000Z",
+    ...overrides,
+  };
+}
+
+const renderPanel = (runs: WorkflowRun[]) =>
+  render(
+    <MemoryRouter>
+      <WorkflowRunsPanel runs={runs} hideSessionLink />
+    </MemoryRouter>
+  );
+
+const runHeader = () => screen.getByRole("button", { name: /review-changes/ });
+const resultButton = () =>
+  screen
+    .getAllByRole("button")
+    .find((b) => /verify:starship/.test(b.textContent || "") && b.getAttribute("aria-expanded"))!;
+
+beforeEach(() => {
+  transcriptMock.mockReset();
+});
+
+const msg = (type: "user" | "assistant", text: string): TranscriptMessage =>
+  ({ type, content: [{ type: "text", text }] }) as TranscriptMessage;
+
+describe("extractPromptResult", () => {
+  it("takes the first user text as prompt and the last assistant text as result", () => {
+    const out = extractPromptResult([
+      msg("user", "do the task"),
+      msg("assistant", "thinking…"),
+      msg("assistant", "FINAL ANSWER"),
+    ]);
+    expect(out).toEqual({ prompt: "do the task", result: "FINAL ANSWER" });
+  });
+
+  it("returns empty strings for missing turns (e.g. schema-mode tool-only final)", () => {
+    expect(extractPromptResult([])).toEqual({ prompt: "", result: "" });
+    expect(extractPromptResult([msg("user", "only a prompt")])).toEqual({
+      prompt: "only a prompt",
+      result: "",
+    });
+  });
+});
+
+describe("WorkflowRunsPanel lazy transcript fetch", () => {
+  it("fetches the full transcript on expand and renders it instead of the teaser", async () => {
+    const LONG_RESULT =
+      "CONFIRMED across every primary source. " +
+      "The full reasoning runs well past the truncated journal preview. ".repeat(6).trim();
+    transcriptMock.mockResolvedValue({
+      messages: [msg("user", "Verify the starship claim in full."), msg("assistant", LONG_RESULT)],
+    });
+
+    renderPanel([makeRun()]);
+    fireEvent.click(runHeader());
+    fireEvent.click(resultButton());
+
+    // Called with the run_id so the route can resolve the nested transcript.
+    expect(transcriptMock).toHaveBeenCalledWith("s1", {
+      agent_id: "a1",
+      run_id: "wf_x",
+      limit: 200,
+    });
+
+    // Full fetched text appears (async) in a <pre>, and the prompt is the
+    // fetched one — not the short journal teaser.
+    const resultPre = await screen.findByText(
+      (_, el) => el?.tagName === "PRE" && (el.textContent || "").includes("runs well past"),
+      { selector: "pre" }
+    );
+    expect(resultPre).toBeInTheDocument();
+    expect(screen.getByText("Verify the starship claim in full.")).toBeInTheDocument();
+  });
+
+  it("falls back to the journal preview when the fetch fails", async () => {
+    transcriptMock.mockRejectedValue(new Error("network"));
+
+    renderPanel([makeRun()]);
+    fireEvent.click(runHeader());
+    fireEvent.click(resultButton());
+
+    // The pretty-printed journal preview (with the "confirmed" key) is shown.
+    expect(await screen.findByText(/confirmed/)).toBeInTheDocument();
+  });
+});

--- a/client/src/i18n/locales/en/workflows.json
+++ b/client/src/i18n/locales/en/workflows.json
@@ -22,6 +22,7 @@
     "resultsLabel": "Results",
     "promptLabel": "Prompt",
     "resultLabel": "Result",
+    "loadingFull": "Loading full text…",
     "tokens": "tokens",
     "agents_one": "{{count}} agent",
     "agents_other": "{{count}} agents",

--- a/client/src/i18n/locales/vi/workflows.json
+++ b/client/src/i18n/locales/vi/workflows.json
@@ -22,6 +22,7 @@
     "resultsLabel": "Kết quả",
     "promptLabel": "Lời nhắc",
     "resultLabel": "Kết quả",
+    "loadingFull": "Đang tải toàn bộ nội dung…",
     "tokens": "token",
     "agents_one": "{{count}} Agent",
     "agents_other": "{{count}} Agent",

--- a/client/src/i18n/locales/zh/workflows.json
+++ b/client/src/i18n/locales/zh/workflows.json
@@ -22,6 +22,7 @@
     "resultsLabel": "结果",
     "promptLabel": "提示词",
     "resultLabel": "结果",
+    "loadingFull": "正在加载完整内容…",
     "tokens": "token",
     "agents_one": "{{count}} 个 Agent",
     "agents_other": "{{count}} 个 Agent",

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -96,6 +96,7 @@ export const api = {
       id: string,
       params?: {
         agent_id?: string;
+        run_id?: string;
         limit?: number;
         offset?: number;
         after?: number;
@@ -104,6 +105,7 @@ export const api = {
     ) => {
       const qs = new URLSearchParams();
       if (params?.agent_id) qs.set("agent_id", params.agent_id);
+      if (params?.run_id) qs.set("run_id", params.run_id);
       if (params?.limit) qs.set("limit", String(params.limit));
       if (params?.offset) qs.set("offset", String(params.offset));
       if (params?.after != null) qs.set("after", String(params.after));

--- a/scripts/import-history.js
+++ b/scripts/import-history.js
@@ -64,6 +64,16 @@ function snapshotTranscript(sourceJsonlPath, sessionId) {
       if (path.resolve(destSub) === path.resolve(subPath)) continue;
       copyIfNewer(subPath, destSub);
     }
+
+    // Workflow-tool inner-agent transcripts live nested at
+    // `<sessionId>/subagents/workflows/<runId>/agent-*.jsonl`. Preserve the
+    // `workflows/<runId>/` subpath so the read route resolves the snapshot the
+    // same way it resolves the live nested file (see getSnapshotSubagentTranscriptPath).
+    for (const sub of findSessionWorkflowSubagents(sourceJsonlPath)) {
+      const destSub = path.join(snapDir, sessionId, "subagents", sub.rel);
+      if (path.resolve(destSub) === path.resolve(sub.abs)) continue;
+      copyIfNewer(sub.abs, destSub);
+    }
   } catch {
     /* non-fatal: metadata import already succeeded */
   }
@@ -1764,6 +1774,48 @@ function findSessionSubagents(sessionJsonlPath) {
 }
 
 /**
+ * Given a session JSONL path, return any Workflow-tool inner-agent transcripts,
+ * which Claude Code writes NESTED at
+ *   <sessionId>/subagents/workflows/<runId>/agent-*.jsonl
+ * (one level deeper than the flat sub-agent transcripts findSessionSubagents
+ * returns). Kept separate so the regular sub-agent import path is unchanged —
+ * these are summarized by the Workflow-run ingest, not imported as sub-agents —
+ * while the snapshot writer can still preserve them for the Conversation tab.
+ *
+ * Each entry is { abs, rel } where `rel` is the path relative to the session's
+ * `subagents` root (e.g. "workflows/<runId>/agent-<id>.jsonl"), so the snapshot
+ * can mirror the live nested layout exactly.
+ */
+function findSessionWorkflowSubagents(sessionJsonlPath) {
+  const dir = path.dirname(sessionJsonlPath);
+  const sessionId = path.basename(sessionJsonlPath, ".jsonl");
+  const subagentRoots = [
+    path.join(dir, sessionId, "subagents"),
+    path.join(dir, "subagents", sessionId),
+  ];
+  const result = [];
+  for (const root of subagentRoots) {
+    const workflowsDir = path.join(root, "workflows");
+    try {
+      if (!fs.existsSync(workflowsDir)) continue;
+      for (const d of fs.readdirSync(workflowsDir, { withFileTypes: true })) {
+        if (!d.isDirectory()) continue;
+        const runDir = path.join(workflowsDir, d.name);
+        for (const f of fs.readdirSync(runDir).filter((x) => x.endsWith(".jsonl"))) {
+          result.push({
+            abs: path.join(runDir, f),
+            rel: path.join("workflows", d.name, f),
+          });
+        }
+      }
+    } catch {
+      /* non-fatal */
+    }
+  }
+  return result;
+}
+
+/**
  * Generalized importer that accepts any root directory.
  *
  * Walks `rootDir` recursively, classifies every `.jsonl` as session or
@@ -1976,6 +2028,8 @@ module.exports = {
   collectJsonlFiles,
   classifyJsonl,
   findSessionSubagents,
+  findSessionWorkflowSubagents,
+  snapshotTranscript,
   importSession,
   scanAndImportSubagents,
   combineSessionTokens,

--- a/server/__tests__/workflow-transcript-resolution.test.js
+++ b/server/__tests__/workflow-transcript-resolution.test.js
@@ -1,0 +1,293 @@
+/**
+ * @file Tests for dual-layout (flat + nested Workflow-tool) sub-agent transcript
+ * resolution. Covers the resolver helpers in server/lib/claude-home.js, the
+ * durable snapshot writer in scripts/import-history.js, and the end-to-end
+ * GET /:id/transcript?run_id= route that surfaces a workflow inner agent's full
+ * (un-truncated) prompt/result text in the Workflows UI. Uses Node's built-in
+ * test runner with temp CLAUDE_HOME / DASHBOARD_DATA_DIR roots.
+ * @author Son Nguyen <hoangson091104@gmail.com>
+ */
+
+const { describe, it, before, after } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+const http = require("http");
+
+// Isolate the dashboard DB and Claude Code home BEFORE requiring server modules.
+const STAMP = `wf-transcript-${Date.now()}-${process.pid}`;
+const TMP = path.join(os.tmpdir(), STAMP);
+const CLAUDE_HOME = path.join(TMP, "home");
+const DATA_DIR = path.join(TMP, "data");
+const TEST_DB = path.join(TMP, "dashboard.db");
+process.env.DASHBOARD_DB_PATH = TEST_DB;
+process.env.CLAUDE_HOME = CLAUDE_HOME;
+process.env.DASHBOARD_DATA_DIR = DATA_DIR;
+
+const {
+  resolveAgentTranscriptInDir,
+  getSubagentTranscriptPath,
+  findSubagentTranscriptPath,
+  getSnapshotSubagentTranscriptPath,
+} = require("../lib/claude-home");
+const {
+  snapshotTranscript,
+  findSessionWorkflowSubagents,
+} = require("../../scripts/import-history");
+const { createApp, startServer } = require("../index");
+const { db } = require("../db");
+
+// encodeCwd is not exported; mirror its rule for building project paths.
+const enc = (cwd) => cwd.replace(/[^a-zA-Z0-9]/g, "-");
+
+const CWD = "/tmp/cam-wf-project";
+const SESSION = "sess-wf-resolve";
+const SESSION_SNAP = "sess-wf-snapshot";
+const RUN1 = "wf_run1aaaaaa";
+const RUN2 = "wf_run2bbbbbb";
+const WF_ID = "ad18a79192af10ed1"; // workflow inner agent — nested only
+const FLAT_ID = "bd29b80203bf21fe2"; // regular sub-agent — flat
+const DUP_ID = "cc1122334455667788"; // present in BOTH runs — ambiguous
+
+const PROJECTS = path.join(CLAUDE_HOME, "projects");
+const ENC_DIR = path.join(PROJECTS, enc(CWD));
+const SUBAGENTS = path.join(ENC_DIR, SESSION, "subagents");
+
+// A result longer than the journal's truncated preview would ever carry, so the
+// route test can prove the full text (not a "…"-suffixed teaser) comes back.
+const LONG_RESULT =
+  "CONFIRMED: " +
+  "the orbital telemetry reconciles across all three independent ground stations. ".repeat(8);
+const PROMPT_TEXT = "Adversarially verify the starship claim against primary sources.";
+
+function writeFile(p, contents) {
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, contents);
+}
+
+function jsonl(lines) {
+  return lines.map((o) => JSON.stringify(o)).join("\n") + "\n";
+}
+
+function transcriptJsonl(prompt, result) {
+  return jsonl([
+    { type: "user", message: { role: "user", content: [{ type: "text", text: prompt }] } },
+    {
+      type: "assistant",
+      message: { role: "assistant", content: [{ type: "text", text: result }] },
+    },
+  ]);
+}
+
+function fetch(urlPath) {
+  return new Promise((resolve, reject) => {
+    const url = new URL(urlPath, BASE);
+    const req = http.request(
+      { hostname: url.hostname, port: url.port, path: url.pathname + url.search, method: "GET" },
+      (res) => {
+        let body = "";
+        res.on("data", (c) => (body += c));
+        res.on("end", () => {
+          let parsed;
+          try {
+            parsed = JSON.parse(body);
+          } catch {
+            parsed = body;
+          }
+          resolve({ status: res.statusCode, body: parsed });
+        });
+      }
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+function post(urlPath, body) {
+  return new Promise((resolve, reject) => {
+    const url = new URL(urlPath, BASE);
+    const payload = JSON.stringify(body);
+    const req = http.request(
+      {
+        hostname: url.hostname,
+        port: url.port,
+        path: url.pathname,
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(payload),
+        },
+      },
+      (res) => {
+        let b = "";
+        res.on("data", (c) => (b += c));
+        res.on("end", () => resolve({ status: res.statusCode, body: JSON.parse(b || "{}") }));
+      }
+    );
+    req.on("error", reject);
+    req.write(payload);
+    req.end();
+  });
+}
+
+let server;
+let BASE;
+
+before(async () => {
+  // Live project tree: one flat sub-agent + nested workflow agents, with DUP_ID
+  // deliberately present in two runs to exercise glob ambiguity.
+  writeFile(path.join(SUBAGENTS, `agent-${FLAT_ID}.jsonl`), transcriptJsonl("flat", "flat-result"));
+  writeFile(
+    path.join(SUBAGENTS, "workflows", RUN1, `agent-${WF_ID}.jsonl`),
+    transcriptJsonl(PROMPT_TEXT, LONG_RESULT)
+  );
+  writeFile(
+    path.join(SUBAGENTS, "workflows", RUN1, `agent-${DUP_ID}.jsonl`),
+    transcriptJsonl("dup-r1", "dup-r1-result")
+  );
+  writeFile(
+    path.join(SUBAGENTS, "workflows", RUN2, `agent-${DUP_ID}.jsonl`),
+    transcriptJsonl("dup-r2", "dup-r2-result")
+  );
+
+  const app = createApp();
+  server = await startServer(app, 0);
+  BASE = `http://127.0.0.1:${server.address().port}`;
+});
+
+after(() => {
+  if (server) server.close();
+  if (db) db.close();
+  try {
+    fs.rmSync(TMP, { recursive: true, force: true });
+  } catch {
+    /* ignore cleanup errors */
+  }
+});
+
+describe("resolveAgentTranscriptInDir", () => {
+  it("prefers the flat layout (regular sub-agents resolve unchanged)", () => {
+    const hit = resolveAgentTranscriptInDir(SUBAGENTS, FLAT_ID);
+    assert.equal(hit, path.join(SUBAGENTS, `agent-${FLAT_ID}.jsonl`));
+  });
+
+  it("resolves a nested Workflow agent directly when the runId is known", () => {
+    const hit = resolveAgentTranscriptInDir(SUBAGENTS, WF_ID, RUN1);
+    assert.equal(hit, path.join(SUBAGENTS, "workflows", RUN1, `agent-${WF_ID}.jsonl`));
+  });
+
+  it("resolves a nested agent by scanning when it appears in exactly one run", () => {
+    const hit = resolveAgentTranscriptInDir(SUBAGENTS, WF_ID);
+    assert.equal(hit, path.join(SUBAGENTS, "workflows", RUN1, `agent-${WF_ID}.jsonl`));
+  });
+
+  it("returns null for an agentId ambiguous across runs (no guessing)", () => {
+    assert.equal(resolveAgentTranscriptInDir(SUBAGENTS, DUP_ID), null);
+  });
+
+  it("disambiguates an across-run agentId once the runId is supplied", () => {
+    assert.equal(
+      resolveAgentTranscriptInDir(SUBAGENTS, DUP_ID, RUN2),
+      path.join(SUBAGENTS, "workflows", RUN2, `agent-${DUP_ID}.jsonl`)
+    );
+  });
+
+  it("never throws and returns null for missing inputs", () => {
+    assert.equal(resolveAgentTranscriptInDir(null, WF_ID), null);
+    assert.equal(resolveAgentTranscriptInDir(SUBAGENTS, "does-not-exist"), null);
+    assert.equal(resolveAgentTranscriptInDir(SUBAGENTS, WF_ID, "wf_nope"), null);
+  });
+});
+
+describe("getSubagentTranscriptPath / findSubagentTranscriptPath", () => {
+  it("resolves a nested Workflow agent via cwd + runId", () => {
+    const hit = getSubagentTranscriptPath(SESSION, CWD, WF_ID, RUN1);
+    assert.equal(hit, path.join(SUBAGENTS, "workflows", RUN1, `agent-${WF_ID}.jsonl`));
+  });
+
+  it("still resolves a flat regular sub-agent (no runId — no regression)", () => {
+    const hit = getSubagentTranscriptPath(SESSION, CWD, FLAT_ID);
+    assert.equal(hit, path.join(SUBAGENTS, `agent-${FLAT_ID}.jsonl`));
+  });
+
+  it("falls back to a project scan (cwd unknown) for the nested layout", () => {
+    const hit = findSubagentTranscriptPath(SESSION, WF_ID, RUN1);
+    assert.equal(hit, path.join(SUBAGENTS, "workflows", RUN1, `agent-${WF_ID}.jsonl`));
+  });
+
+  it("returns null when nothing resolves", () => {
+    assert.equal(getSubagentTranscriptPath(SESSION, CWD, "missing", RUN1), null);
+    assert.equal(getSubagentTranscriptPath(SESSION, null, WF_ID, RUN1), null);
+  });
+});
+
+describe("snapshotTranscript (durable nested-layout fallback)", () => {
+  it("discovers nested Workflow sub-agents separately from flat ones", () => {
+    const mainPath = path.join(ENC_DIR, `${SESSION}.jsonl`);
+    writeFile(mainPath, jsonl([{ type: "summary", summary: "x" }]));
+    const found = findSessionWorkflowSubagents(mainPath);
+    const rels = found.map((f) => f.rel).sort();
+    assert.deepEqual(rels, [
+      path.join("workflows", RUN1, `agent-${WF_ID}.jsonl`),
+      path.join("workflows", RUN1, `agent-${DUP_ID}.jsonl`),
+      path.join("workflows", RUN2, `agent-${DUP_ID}.jsonl`),
+    ]);
+  });
+
+  it("preserves the nested layout into the snapshot so the read route resolves it", () => {
+    // Build an independent source session, snapshot it, then resolve from the
+    // snapshot dir exactly as the route's third fallback does.
+    const srcMain = path.join(ENC_DIR, `${SESSION_SNAP}.jsonl`);
+    const srcNested = path.join(
+      ENC_DIR,
+      SESSION_SNAP,
+      "subagents",
+      "workflows",
+      RUN1,
+      `agent-${WF_ID}.jsonl`
+    );
+    writeFile(srcMain, jsonl([{ type: "summary", summary: "snap" }]));
+    writeFile(srcNested, transcriptJsonl(PROMPT_TEXT, LONG_RESULT));
+
+    snapshotTranscript(srcMain, SESSION_SNAP);
+
+    const snapHit = getSnapshotSubagentTranscriptPath(SESSION_SNAP, WF_ID, RUN1);
+    assert.ok(snapHit, "snapshot resolver should find the preserved nested transcript");
+    assert.equal(fs.readFileSync(snapHit, "utf8"), fs.readFileSync(srcNested, "utf8"));
+  });
+
+  it("does not throw for a session with no transcripts", () => {
+    assert.doesNotThrow(() => snapshotTranscript(path.join(ENC_DIR, "nope.jsonl"), "nope"));
+  });
+});
+
+describe("GET /:id/transcript?run_id= (full workflow agent text)", () => {
+  it("returns the full, un-truncated prompt + result for a nested agent", async () => {
+    const created = await post("/api/sessions", { id: SESSION, name: "wf", cwd: CWD });
+    assert.equal(created.status, 201);
+
+    const res = await fetch(
+      `/api/sessions/${SESSION}/transcript?agent_id=${WF_ID}&run_id=${RUN1}&limit=200`
+    );
+    assert.equal(res.status, 200);
+    assert.ok(Array.isArray(res.body.messages));
+
+    const texts = res.body.messages
+      .flatMap((m) => m.content || [])
+      .filter((b) => b.type === "text")
+      .map((b) => b.text);
+    assert.ok(texts.includes(PROMPT_TEXT), "user prompt should be present in full");
+    assert.ok(texts.includes(LONG_RESULT), "assistant result should be present in full");
+    // The whole point of the fix: full text, not a "…"-suffixed teaser.
+    assert.ok(!texts.some((t) => t.endsWith("…")));
+  });
+
+  it("returns an empty message list (no throw) for an unknown run/agent", async () => {
+    const res = await fetch(
+      `/api/sessions/${SESSION}/transcript?agent_id=${WF_ID}&run_id=wf_missing&limit=200`
+    );
+    assert.equal(res.status, 200);
+    assert.deepEqual(res.body.messages, []);
+  });
+});

--- a/server/lib/claude-home.js
+++ b/server/lib/claude-home.js
@@ -74,22 +74,66 @@ function getTranscriptPath(sessionId, cwd) {
 }
 
 /**
- * Infer the sub-agent JSONL file path from sessionId, cwd, and agentId.
- * Falls back to scanning all project directories if the encoded path doesn't exist.
+ * Resolve a per-agent transcript file inside a session's `subagents` directory,
+ * supporting BOTH on-disk layouts Claude Code has used for sub-agent transcripts:
+ *   - flat:   <subagents>/agent-<agentId>.jsonl
+ *             (regular sub-agents, and older Workflow-tool builds)
+ *   - nested: <subagents>/workflows/<runId>/agent-<agentId>.jsonl
+ *             (current Workflow-tool fan-out runs)
+ *
+ * The flat path is checked first, so regular sub-agents resolve exactly as
+ * before. For the nested layout: when `runId` is known the run directory is read
+ * directly; when it is unknown the nested tree is scanned and a match is
+ * returned ONLY if exactly one run contains that agent — an ambiguous agentId
+ * across multiple runs resolves to null rather than guessing.
+ *
+ * @param {string} subagentsDir absolute path to a `.../subagents` directory
+ * @param {string} agentId the agent-<agentId>.jsonl key (no prefix/suffix)
+ * @param {string|null} [runId] the workflow run id, when known
+ * @returns {string|null} absolute transcript path, or null. Never throws.
  */
-function getSubagentTranscriptPath(sessionId, cwd, agentId) {
+function resolveAgentTranscriptInDir(subagentsDir, agentId, runId = null) {
+  if (!subagentsDir) return null;
+  const flat = path.join(subagentsDir, `agent-${agentId}.jsonl`);
+  if (fs.existsSync(flat)) return flat;
+
+  const workflowsDir = path.join(subagentsDir, "workflows");
+  if (!fs.existsSync(workflowsDir)) return null;
+
+  if (runId) {
+    const nested = path.join(workflowsDir, runId, `agent-${agentId}.jsonl`);
+    return fs.existsSync(nested) ? nested : null;
+  }
+
+  // Unknown run: accept only an unambiguous single match across all runs.
+  try {
+    const matches = [];
+    for (const d of fs.readdirSync(workflowsDir, { withFileTypes: true })) {
+      if (!d.isDirectory()) continue;
+      const cand = path.join(workflowsDir, d.name, `agent-${agentId}.jsonl`);
+      if (fs.existsSync(cand)) matches.push(cand);
+      if (matches.length > 1) break;
+    }
+    return matches.length === 1 ? matches[0] : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Infer the sub-agent JSONL file path from sessionId, cwd, agentId, and
+ * (optionally) the Workflow runId. Resolves both the flat and nested
+ * Workflow-tool layouts via resolveAgentTranscriptInDir. Falls back to scanning
+ * all project directories if the encoded path doesn't exist.
+ */
+function getSubagentTranscriptPath(sessionId, cwd, agentId, runId = null) {
   if (!cwd) return null;
   const encoded = encodeCwd(cwd);
-  const candidate = path.join(
-    getProjectsDir(),
-    encoded,
-    sessionId,
-    "subagents",
-    `agent-${agentId}.jsonl`
-  );
-  if (fs.existsSync(candidate)) return candidate;
+  const subagentsDir = path.join(getProjectsDir(), encoded, sessionId, "subagents");
+  const direct = resolveAgentTranscriptInDir(subagentsDir, agentId, runId);
+  if (direct) return direct;
   // Fallback: scan all project directories
-  return findSubagentTranscriptPath(sessionId, agentId);
+  return findSubagentTranscriptPath(sessionId, agentId, runId);
 }
 
 /**
@@ -126,15 +170,17 @@ function getSnapshotTranscriptPath(sessionId) {
 
 /**
  * Path to a snapshotted subagent transcript, mirroring the live layout
- * `<snapshotDir>/<sessionId>/subagents/agent-<agentId>.jsonl`. Supports the
+ * `<snapshotDir>/<sessionId>/subagents/agent-<agentId>.jsonl` (flat) and
+ * `<snapshotDir>/<sessionId>/subagents/workflows/<runId>/agent-<agentId>.jsonl`
+ * (nested Workflow-tool runs, preserved by the snapshot writer). Supports the
  * same compaction prefix-fuzzy match as findSubagentTranscriptPath. Returns
  * the path or null.
  */
-function getSnapshotSubagentTranscriptPath(sessionId, agentId) {
+function getSnapshotSubagentTranscriptPath(sessionId, agentId, runId = null) {
   const subDir = path.join(getTranscriptSnapshotDir(), sessionId, "subagents");
   if (!fs.existsSync(subDir)) return null;
-  const exact = path.join(subDir, `agent-${agentId}.jsonl`);
-  if (fs.existsSync(exact)) return exact;
+  const hit = resolveAgentTranscriptInDir(subDir, agentId, runId);
+  if (hit) return hit;
   if (agentId.startsWith("acompact-")) {
     try {
       const match = fs
@@ -150,11 +196,12 @@ function getSnapshotSubagentTranscriptPath(sessionId, agentId) {
 
 /**
  * Find a sub-agent JSONL file path by scanning when cwd is unknown.
- * Supports exact match and prefix fuzzy match:
- * - Exact: agent-<agentId>.jsonl
- * - Fuzzy: agent-acompact-*.jsonl (for compaction type)
+ * Supports both layouts (flat + nested Workflow-tool, via
+ * resolveAgentTranscriptInDir) and a prefix fuzzy match:
+ * - Exact:  agent-<agentId>.jsonl (or workflows/<runId>/agent-<agentId>.jsonl)
+ * - Fuzzy:  agent-acompact-*.jsonl (for compaction type)
  */
-function findSubagentTranscriptPath(sessionId, agentId) {
+function findSubagentTranscriptPath(sessionId, agentId, runId = null) {
   const projectsDir = getProjectsDir();
   if (!fs.existsSync(projectsDir)) return null;
   try {
@@ -164,9 +211,9 @@ function findSubagentTranscriptPath(sessionId, agentId) {
       const subagentsDir = path.join(projectsDir, d.name, sessionId, "subagents");
       if (!fs.existsSync(subagentsDir)) continue;
 
-      // Exact match
-      const exact = path.join(subagentsDir, `agent-${agentId}.jsonl`);
-      if (fs.existsSync(exact)) return exact;
+      // Exact match (flat or nested Workflow-tool layout)
+      const hit = resolveAgentTranscriptInDir(subagentsDir, agentId, runId);
+      if (hit) return hit;
 
       // Prefix fuzzy match (compaction type: agentId starts with "acompact-")
       if (agentId.startsWith("acompact-")) {
@@ -238,6 +285,7 @@ module.exports = {
   getTranscriptSnapshotDir,
   getSettingsPath,
   getTranscriptPath,
+  resolveAgentTranscriptInDir,
   getSubagentTranscriptPath,
   getSnapshotTranscriptPath,
   getSnapshotSubagentTranscriptPath,

--- a/server/routes/sessions.js
+++ b/server/routes/sessions.js
@@ -502,6 +502,8 @@ router.get("/:id/transcripts", async (req, res) => {
 // GET /:id/transcript — Read session JSONL transcript, return structured message list
 // Query params:
 //   agent_id: file-level short ID ("main" or "ad18a79192af10ed1", "acompact-xxx")
+//   run_id: Workflow run id ("wf_...") — disambiguates a workflow inner agent's
+//           nested transcript (subagents/workflows/<run_id>/agent-<agent_id>.jsonl)
 //   limit: max messages to return (default 50, max 200)
 //   after: JSONL line number, only return messages after this line (incremental mode)
 //   before: JSONL line number, only return messages before this line (history mode)
@@ -513,6 +515,7 @@ router.get("/:id/transcript", async (req, res) => {
   }
 
   const agentId = req.query.agent_id || null;
+  const runId = req.query.run_id || null;
   const limit = Math.min(parseInt(req.query.limit) || 50, 200);
   const afterLine = req.query.after ? parseInt(req.query.after) : null;
   const beforeLine = req.query.before ? parseInt(req.query.before) : null;
@@ -525,9 +528,9 @@ router.get("/:id/transcript", async (req, res) => {
   let jsonlPath;
   if (agentId && agentId !== "main") {
     jsonlPath =
-      getSubagentTranscriptPath(req.params.id, session.cwd, agentId) ||
-      findSubagentTranscriptPath(req.params.id, agentId) ||
-      getSnapshotSubagentTranscriptPath(req.params.id, agentId);
+      getSubagentTranscriptPath(req.params.id, session.cwd, agentId, runId) ||
+      findSubagentTranscriptPath(req.params.id, agentId, runId) ||
+      getSnapshotSubagentTranscriptPath(req.params.id, agentId, runId);
   } else {
     jsonlPath =
       getTranscriptPath(req.params.id, session.cwd) ||


### PR DESCRIPTION
## Summary

Full dynamic-workflow agent **prompt/result text was unreachable** in the Workflows UI — expanding a result row showed only the run journal's truncated `…` preview, never the agent's complete output.

Two coupled root causes:

1. **Path drift.** Current Claude Code builds write each Workflow inner-agent transcript **nested** at `…/subagents/workflows/<runId>/agent-<agentId>.jsonl`, but every sub-agent path resolver in `server/lib/claude-home.js` only built the **flat** `…/subagents/agent-<agentId>.jsonl` path → the file was never found.
2. **Truncation.** Even when shown, the panel rendered `promptPreview` / `resultPreview` straight from the journal, and Claude Code already truncates those (trailing `…`).

The fix resolves both layouts on read, threads an optional `run_id` through the existing transcript endpoint, lazily fetches the full text when a row is expanded, and preserves the nested transcripts in the durable snapshot so they survive Claude Code's `cleanupPeriodDays` pruning.

Closes #176

## Changes

### Server
- **`server/lib/claude-home.js`** — new `resolveAgentTranscriptInDir(subagentsDir, agentId, runId?)` resolves **flat first** (regular sub-agents resolve exactly as before), then **nested** `workflows/<runId>/`. With a known `runId` it reads the run dir directly; with an unknown `runId` it scans and returns a match **only if exactly one** run contains that agent (ambiguous → `null`, never guesses). All three resolvers (`getSubagentTranscriptPath`, `findSubagentTranscriptPath`, `getSnapshotSubagentTranscriptPath`) use it.
- **`server/routes/sessions.js`** — `GET /:id/transcript` accepts an optional `run_id`, threaded into the resolver chain. Additive param; response shape unchanged.
- **`scripts/import-history.js`** — `snapshotTranscript` now preserves nested workflow transcripts via a dedicated `findSessionWorkflowSubagents` probe that mirrors the `workflows/<runId>/` subpath into the snapshot dir. Deliberately **separate** from `findSessionSubagents` (flat) so the regular sub-agent import path is unchanged and nested inner-agents are never double-counted.

### Client
- **`client/src/components/workflows/WorkflowRunsPanel.tsx`** — lazily fetches the full transcript the first time a result row is expanded (deduped per `${run_id}::${agentId}`), derives prompt + result via the new exported `extractPromptResult`, and renders the complete text. Falls back to the journal teaser while loading, on error, or for schema-mode agents whose final turn is a tool call rather than text. Nothing is eagerly ingested.
- **`client/src/lib/api.ts`** — `sessions.transcript()` forwards `run_id`.
- **i18n** — `runs.loadingFull` added in lockstep across `en` / `zh` / `vi`.

### Docs & tests
- **`ARCHITECTURE.md`** — corrected the on-disk layout (nested vs flat), the supported-layouts table, the `/sessions/:id` route, the import-history entry, and a new "Reading full agent text in the UI" subsection.
- **`server/__tests__/workflow-transcript-resolution.test.js`** (15 tests) — flat/nested resolution, glob determinism + ambiguity, `run_id` disambiguation, no-throw on missing input, the snapshot writer→reader round-trip, and an end-to-end `GET …/transcript?run_id=` asserting the full (non-`…`) text comes back.
- **`client/.../WorkflowRunsPanel.transcript.test.tsx`** (4 tests) — `extractPromptResult`, fetch-on-expand with the right args, and graceful fallback to the journal preview on fetch failure.

## Backward compatibility
- All new params are optional and **flat-first**, so regular sub-agents and older flat-layout workflow runs resolve byte-identically to before.
- No DB schema, response shape, or WebSocket message change. No eager ingest.

## Fidelity note
"Full text" means the complete message body up to the endpoint's existing per-message **10,240-char** cap, with `limit` ≤ 200 messages — i.e. the same fidelity the Conversation tab already provides, vs. the journal's short preview.

## Verification
- `npm run test:server` — **360/360 pass** (includes the 15 new tests).
- `npm run build` — clean (`tsc -b && vite build`).
- `npx prettier --check .` — clean.
- New client tests pass; the **Workflows** render snapshot (which mounts `WorkflowRunsPanel`) passes.

> Note on the local client suite: 11 pre-existing failures in `Tabby` and the `Dashboard` snapshot come from Node 25's built-in `localStorage` shadowing jsdom's in those (untouched) components — they reproduce on a clean checkout of `master` and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
