### PR TITLE
chore(cla): enforce Contributor License Agreement on all PRs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -7,6 +7,7 @@ Thanks for taking the time to contribute. Please read this guide before opening 
 ## Table of Contents
 
 - [Code of Conduct](#code-of-conduct)
+- [Contributor License Agreement (CLA)](#contributor-license-agreement-cla)
 - [Getting Started](#getting-started)
 - [Development Workflow](#development-workflow)
 - [Branching and Commits](#branching-and-commits)
@@ -20,6 +21,23 @@ Thanks for taking the time to contribute. Please read this guide before opening 
 ## Code of Conduct
 
 This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you agree to uphold it.
+
+---
+
+## Contributor License Agreement (CLA)
+
+All contributions require a signed **[Contributor License Agreement](../CLA.md)**. This is enforced automatically — there is nothing to set up ahead of time.
+
+1. Open your pull request as normal.
+2. On your **first** PR, the `🖋️ CLA Assistant` bot comments asking you to sign. Read [`CLA.md`](../CLA.md), then post this comment on the PR, verbatim:
+
+   ```
+   I have read the CLA Document and I hereby sign the CLA
+   ```
+
+3. The bot records your signature and turns the **CLA Assistant** status check green. The PR cannot be merged until it is green.
+
+You sign **once** — the signature covers all of your current and future contributions, so returning contributors are never asked again. If you contribute **on behalf of a company**, contact the maintainer ([@hoangsonww](https://github.com/hoangsonww)) to arrange a Corporate CLA first.
 
 ---
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,6 +27,7 @@
 ## Checklist
 
 - [ ] I have read the [contributing guidelines](../CONTRIBUTING.md)
+- [ ] I have signed the [CLA](../CLA.md) (the `🖋️ CLA Assistant` bot will prompt me on my first PR)
 - [ ] My code follows the project's coding standards
 - [ ] I have added/updated tests that prove my fix or feature works
 - [ ] All new and existing tests pass (`npm test`)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,10 @@ name: 🚀 CI / CD Pipeline for Claude Code Agent Monitor
 on:
   push:
     branches: ["**"]
+    # CLA signature commits (made by github-actions[bot] via cla.yml) only touch
+    # this path — skip the full CI/CD pipeline for them.
+    paths-ignore:
+      - "signatures/**"
   pull_request:
     branches: ["**"]
 

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,74 @@
+# CLA Assistant — Contributor License Agreement enforcement
+#
+# Every pull request author must sign the project's Contributor License Agreement
+# (see CLA.md at the repo root) before their PR can be merged. This workflow uses
+# the community CLA Assistant action to:
+#   1. Comment on a PR the first time an unsigned contributor opens one, asking
+#      them to sign by leaving a fixed comment on the PR.
+#   2. Record each signature (GitHub username + signed commit SHA + timestamp) in
+#      `signatures/version1/cla.json` on the default branch. A contributor signs
+#      once and is never asked again on future PRs.
+#   3. Set a `CLA Assistant` commit status — red until signed, green afterwards —
+#      so the requirement can be enforced as a required status check in branch
+#      protection.
+#
+# Triggers:
+#   - pull_request_target (opened / synchronize / closed): re-checks signatures
+#     for every PR and locks the signature record when a PR merges.
+#   - issue_comment (created): catches the "I hereby sign the CLA" / "recheck"
+#     comments. The job is gated so it only runs for those two comment bodies or
+#     for pull_request_target events — ordinary issue/PR chatter is ignored.
+#
+# Storage: signatures live on the default branch under signatures/version1/cla.json.
+# The signature commits are made by github-actions[bot]; the CI/CD workflow
+# (ci.yml) ignores the signatures/ path so these commits do not trigger builds.
+#
+# Token: uses the built-in GITHUB_TOKEN (no extra secret needed) because the
+# signature file is stored inside this repository.
+#
+# Author: Son Nguyen <hoangson091104@gmail.com>
+name: 🖋️ CLA Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    name: "🖋️ Verify CLA signature"
+    runs-on: ubuntu-latest
+    # Run on PR events, or only on the two relevant comment bodies — never on
+    # unrelated issue/PR comments.
+    if: |
+      (github.event.comment.body == 'recheck' ||
+       github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') ||
+      github.event_name == 'pull_request_target'
+    steps:
+      - name: "CLA Assistant"
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          # Built-in token — sufficient because signatures are stored in this repo.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Where signatures are recorded (default branch of this repo).
+          path-to-signatures: "signatures/version1/cla.json"
+          # Public URL of the CLA contributors must agree to.
+          path-to-document: "https://github.com/hoangsonww/Claude-Code-Agent-Monitor/blob/master/CLA.md"
+          # Store signatures on the default branch.
+          branch: "master"
+          # Bots never sign. Every human contributor (including maintainers) must.
+          allowlist: "dependabot[bot],renovate[bot],github-actions[bot]"
+          # Lock the signature record once a PR is merged.
+          lock-pullrequest-aftermerge: true
+          # Exact comment a contributor must post to sign.
+          custom-pr-sign-comment: "I have read the CLA Document and I hereby sign the CLA"
+          # Allow re-running the check by commenting "recheck".
+          custom-allsigned-prcomment: "✅ All contributors have signed the CLA. Thank you!"

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,139 @@
+# Contributor License Agreement (CLA)
+
+**Project:** Claude Code Agent Monitor
+**Maintainer / "Project Owner":** Son Nguyen ([@hoangsonww](https://github.com/hoangsonww))
+
+Thank you for your interest in contributing to Claude Code Agent Monitor (the
+"Project"). This Contributor License Agreement ("Agreement") documents the rights
+granted by contributors to the Project Owner. It protects you as a contributor as
+well as the Project Owner and the Project's users; it does **not** change your
+rights to use your own contributions for any other purpose.
+
+This Agreement applies to every contribution you submit to the Project, whether
+the contribution is submitted before or after the date you sign, and regardless
+of the channel through which it is submitted (pull request, patch, issue
+attachment, or otherwise).
+
+By signing this Agreement (see **[How to sign](#how-to-sign)** below) you accept
+and agree to the following terms for your past, present, and future
+Contributions to the Project.
+
+---
+
+## 1. Definitions
+
+- **"You"** (or **"Your"**) means the individual who submits a Contribution, or
+  the legal entity on whose behalf the Contribution is submitted. For a legal
+  entity, the entity making a Contribution and all other entities that control,
+  are controlled by, or are under common control with that entity are considered
+  a single Contributor.
+- **"Contribution"** means any original work of authorship, including any
+  modification of or addition to an existing work, that is intentionally
+  submitted by You to the Project for inclusion in, or documentation of, any of
+  the products owned or managed by the Project ("Work"). "Submitted" means any
+  form of electronic, verbal, or written communication sent to the Project or its
+  maintainers, including but not limited to communication on source-code
+  control systems, issue trackers, and pull requests, but excluding
+  communication that is conspicuously marked or otherwise designated in writing
+  by You as **"Not a Contribution."**
+
+## 2. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to the
+Project Owner and to recipients of software distributed by the Project a
+perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare derivative works of, publicly display,
+publicly perform, sublicense, and distribute Your Contributions and such
+derivative works.
+
+The Project is distributed under the **MIT License** (see [`LICENSE`](LICENSE)).
+You agree that Your Contributions may be licensed to others under that same
+license, and under any later version of that license that the Project Owner
+adopts for the Project.
+
+## 3. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to the
+Project Owner and to recipients of software distributed by the Project a
+perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made, use,
+offer to sell, sell, import, and otherwise transfer the Work. This license
+applies only to those patent claims licensable by You that are necessarily
+infringed by Your Contribution(s) alone or by combination of Your
+Contribution(s) with the Work to which such Contribution(s) was submitted.
+
+If any entity institutes patent litigation against You or any other entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that Your
+Contribution, or the Work to which You have contributed, constitutes direct or
+contributory patent infringement, then any patent licenses granted to that
+entity under this Agreement for that Contribution or Work shall terminate as of
+the date such litigation is filed.
+
+## 4. Representations
+
+You represent that:
+
+1. You are legally entitled to grant the above licenses. If Your employer(s) has
+   rights to intellectual property that You create that includes Your
+   Contributions, You represent that You have received permission to make
+   Contributions on behalf of that employer, that Your employer has waived such
+   rights for Your Contributions to the Project, or that Your employer has
+   executed a separate Corporate CLA with the Project Owner.
+2. Each of Your Contributions is Your original creation (see Section 5 for
+   submissions on behalf of others).
+3. Your Contribution submissions include complete details of any third-party
+   license or other restriction (including, but not limited to, related patents
+   and trademarks) of which You are personally aware and which are associated
+   with any part of Your Contributions.
+
+## 5. Third-Party Work
+
+Should You wish to submit work that is not Your original creation, You may submit
+it to the Project separately from any Contribution, identifying the complete
+details of its source and of any license or other restriction (including, but
+not limited to, related patents, trademarks, and license agreements) of which
+You are personally aware, and conspicuously marking the work as
+**"Submitted on behalf of a third-party: [named here]"**.
+
+## 6. No Obligation & No Warranty
+
+You understand that the decision to include Your Contribution in any project or
+source repository is entirely that of the Project Owner, and this Agreement does
+not guarantee that the Contributions will be included in any product. Except for
+the express representations in Section 4, You provide Your Contributions on an
+**"AS IS"** basis, **without warranties or conditions of any kind**, either
+express or implied.
+
+## 7. Notice of Changes
+
+You agree to notify the Project Owner of any facts or circumstances of which You
+become aware that would make these representations inaccurate in any respect.
+
+---
+
+## How to sign
+
+Signatures are collected automatically when you open a pull request, via the
+[CLA Assistant](https://github.com/contributor-assistant/github-action) GitHub
+Action.
+
+1. Open a pull request as usual.
+2. A bot will comment on your PR asking you to sign this CLA (this happens once
+   per GitHub account — returning contributors are not asked again).
+3. Read this document, then post the following comment **verbatim** on the pull
+   request:
+
+   ```
+   I have read the CLA Document and I hereby sign the CLA
+   ```
+
+4. The bot records your GitHub username, the signed commit, and a timestamp in
+   `signatures/version1/cla.json`, and turns the CLA status check green. Your PR
+   can then be merged.
+
+Your signature covers all of your current and future Contributions to the
+Project. You only need to sign once.
+
+If you are contributing **on behalf of a company**, please contact the Project
+Owner so that a Corporate CLA can be arranged before your contributions are
+merged.

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ A professional dashboard to track and visualize your Claude Code agent sessions,
 - [Deployment Modes](#deployment-modes)
 - [Project Structure](#project-structure)
 - [Troubleshooting](#troubleshooting)
+- [Contributing](#contributing)
 - [License](#license)
 
 ---
@@ -2075,6 +2076,14 @@ agent-dashboard/
 | WebSocket disconnected            | The client auto-reconnects every 2 seconds. Check that port 4820 is not blocked by a firewall                                                                    |
 | Stale data after restart          | The database persists across restarts. Run `npm run seed` for fresh demo data, or delete `data/dashboard.db` to reset                                            |
 | MCP tools fail to connect         | Confirm dashboard API is up on `MCP_DASHBOARD_BASE_URL` and rebuild/start MCP (`npm run mcp:build`, `npm run mcp:start`)                                         |
+
+---
+
+## Contributing
+
+Contributions are welcome — see [`.github/CONTRIBUTING.md`](.github/CONTRIBUTING.md) for the full guide.
+
+All contributors must sign the [Contributor License Agreement](CLA.md). This is enforced automatically on every pull request by the `🖋️ CLA Assistant` GitHub Action: the first time you open a PR, a bot asks you to sign by commenting `I have read the CLA Document and I hereby sign the CLA`. The PR's **CLA Assistant** status check stays red until you do, and signing once covers all future contributions.
 
 ---
 


### PR DESCRIPTION
## Summary

Add a **Contributor License Agreement** and automated enforcement so every pull-request author must sign before their PR can be merged.

## Changes

- **`CLA.md`** — Individual CLA: copyright grant, patent grant + defensive-termination, contributor representations, third-party-work clause, and sign-by-comment instructions. Aligned with the project's MIT license.
- **`.github/workflows/cla.yml`** — `contributor-assistant/github-action@v2.6.1` on `pull_request_target` + `issue_comment`. Records signatures in `signatures/version1/cla.json` on `master`, sets the **CLA Assistant** commit status. Bots (`dependabot`, `renovate`, `github-actions`) are allowlisted; every human contributor must sign. Uses the built-in `GITHUB_TOKEN` (no extra secret).
- **`.github/workflows/ci.yml`** — `paths-ignore: signatures/**` on push so the bot's signature commits don't trigger the full CI/CD pipeline.
- **`CONTRIBUTING.md`, `PULL_REQUEST_TEMPLATE.md`, `README.md`** — document the signing flow.

## How contributors sign

1. Open a PR → the `🖋️ CLA Assistant` bot comments asking to sign.
2. Comment, verbatim: `I have read the CLA Document and I hereby sign the CLA`.
3. The **CLA Assistant** status check goes green. Signing once covers all future contributions.

## Enforcement note

Merge-blocking requires **CLA Assistant** to be a *required status check* in branch protection on `master` (configured separately from this PR).

## Type of Change

- [x] Infrastructure / CI / DevOps
- [x] Documentation update

## Checklist

- [x] I have read the contributing guidelines
- [x] Code is formatted (`npm run format:check`)
- [x] All tests pass (`npm test`) — ran via pre-commit hook (225 client + server tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)