### PR TITLE
docs(readme): use absolute URL for the CLA link (CLA gate test)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2083,7 +2083,7 @@ agent-dashboard/
 
 Contributions are welcome — see [`.github/CONTRIBUTING.md`](.github/CONTRIBUTING.md) for the full guide.
 
-All contributors must sign the [Contributor License Agreement](CLA.md). This is enforced automatically on every pull request by the `🖋️ CLA Assistant` GitHub Action: the first time you open a PR, a bot asks you to sign by commenting `I have read the CLA Document and I hereby sign the CLA`. The PR's **CLA Assistant** status check stays red until you do, and signing once covers all future contributions.
+All contributors must sign the [Contributor License Agreement](https://github.com/hoangsonww/Claude-Code-Agent-Monitor/blob/master/CLA.md). This is enforced automatically on every pull request by the `🖋️ CLA Assistant` GitHub Action: the first time you open a PR, a bot asks you to sign by commenting `I have read the CLA Document and I hereby sign the CLA`. The PR's **CLA Assistant** status check stays red until you do, and signing once covers all future contributions.
 
 ---
 


### PR DESCRIPTION
## Summary

Small docs change used to **test the CLA enforcement gate** end-to-end. Swaps the README CLA reference from a relative link to the absolute URL `https://github.com/hoangsonww/Claude-Code-Agent-Monitor/blob/master/CLA.md`.

## What to expect on this PR

1. The `🖋️ CLA Assistant` bot comments asking the author to sign.
2. The **🖋️ Verify CLA signature** check is **red** and merge is **blocked** — including for maintainers (enforced by the no-bypass `cla-required` ruleset).
3. Sign by commenting, verbatim: `I have read the CLA Document and I hereby sign the CLA`
4. The bot records the signature on the `cla-signatures` branch, the check turns **green**, and the PR becomes mergeable.

## Type of Change

- [x] Documentation update

🤖 Generated with [Claude Code](https://claude.com/claude-code)