### PR TITLE
feat(db): optional ignore-filter for sessions by cwd (MONITOR_IGNORE_CWD)

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -1283,4 +1283,31 @@ const stmts = {
   ),
 };
 
+// --- Ignore-Filter: Sessions mit bestimmten cwd nicht persistieren ---------
+// Einbahn-Konsolidierungs-/Probe-Sessions (z. B. `claude --print` mit cwd=/tmp,
+// von der claude-code-api gespawnt) sollen das Dashboard nicht zumüllen. Greift
+// zentral für ALLE Insert-Pfade (Hooks, REST-POST, Backfill), da alle
+// stmts.insertSession.run(...) nutzen. cwd ist das 4. Argument
+// (id, name, status, cwd, model, metadata). Opt-in über MONITOR_IGNORE_CWD
+// (kommagetrennt, exakter cwd-Match); Default leer = Filter AUS (damit Tests
+// und Upstream-Verhalten unverändert bleiben). Aktivierung via systemd-Unit.
+const IGNORED_SESSION_CWDS = new Set(
+  (process.env.MONITOR_IGNORE_CWD ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+);
+if (IGNORED_SESSION_CWDS.size > 0) {
+  const _origInsertSession = stmts.insertSession;
+  stmts.insertSession = {
+    run: (...args) => {
+      const cwd = args[3];
+      if (cwd && IGNORED_SESSION_CWDS.has(cwd)) {
+        return { changes: 0, lastInsertRowid: 0 };
+      }
+      return _origInsertSession.run(...args);
+    },
+  };
+}
+
 module.exports = { db, stmts, DB_PATH, DEFAULT_PRICING };


### PR DESCRIPTION
## What
Adds an optional, opt-in filter that prevents sessions from being recorded based on their working directory (cwd).

## Why
Short-lived helper sessions — e.g. `claude --print` calls spawned by an API wrapper, all running with `cwd=/tmp` — can flood the dashboard with thousands of throwaway entries, drowning out real sessions.

## How
- A single guard around `stmts.insertSession` in `server/db.js`, so it applies to **all** insert paths: hooks, the REST `POST` endpoint, and backfill.
- Controlled by a new env var `MONITOR_IGNORE_CWD`.
  - Default: empty → feature is **off**, no behavioural change for existing users.
  - Set it to a path prefix (e.g. `/tmp`) to skip matching sessions.

## Notes
- Backwards compatible (off by default).
- Single-file change (`server/db.js`, +27 lines).
