### PR TITLE
fix(timeline): make "Group by tool call" actually collapse vs the flat list

### DIFF
--- a/client/src/lib/__tests__/event-grouping.test.ts
+++ b/client/src/lib/__tests__/event-grouping.test.ts
@@ -1,0 +1,95 @@
+/**
+ * @file event-grouping.test.ts
+ * @description Tests groupEvents — the "Group by tool call" view. Verifies it is
+ * meaningfully more compact than the flat stream: tool Pre/Post pairs collapse by
+ * tool_use_id, and consecutive same-type non-tool events (e.g. TurnDuration
+ * floods) collapse into one run row, while a tool call breaks a run.
+ * @author Son Nguyen <hoangson091104@gmail.com>
+ */
+import { describe, it, expect } from "vitest";
+import { groupEvents, buildGroupTitle } from "../event-grouping";
+import type { DashboardEvent } from "../types";
+
+let nextId = 1;
+function ev(
+  event_type: string,
+  opts: { tool_use_id?: string; tool_name?: string; at?: string } = {}
+): DashboardEvent {
+  const id = nextId++;
+  const data = opts.tool_use_id
+    ? JSON.stringify({ tool_use_id: opts.tool_use_id, tool_name: opts.tool_name })
+    : JSON.stringify({});
+  return {
+    id,
+    session_id: "s1",
+    agent_id: "s1-main",
+    event_type,
+    tool_name: opts.tool_name ?? null,
+    summary: null,
+    data,
+    created_at: opts.at ?? `2026-06-26T08:00:${String(id).padStart(2, "0")}.000Z`,
+  } as DashboardEvent;
+}
+
+describe("groupEvents — Group by tool call", () => {
+  it("collapses a Pre/Post pair sharing a tool_use_id into one tool group", () => {
+    const events = [
+      ev("PostToolUse", { tool_use_id: "t1", tool_name: "Bash", at: "2026-06-26T08:00:05.000Z" }),
+      ev("PreToolUse", { tool_use_id: "t1", tool_name: "Bash", at: "2026-06-26T08:00:02.000Z" }),
+    ];
+    const groups = groupEvents(events);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.events).toHaveLength(2);
+    expect(groups[0]!.tool_name).toBe("Bash");
+    expect(groups[0]!.tool_use_id).toBe("t1");
+    expect(groups[0]!.isRun).toBe(false);
+    expect(groups[0]!.durationMs).toBe(3000); // 08:00:05 - 08:00:02
+  });
+
+  it("collapses consecutive same-type non-tool events into one run", () => {
+    const events = [ev("TurnDuration"), ev("TurnDuration"), ev("TurnDuration"), ev("TurnDuration")];
+    const groups = groupEvents(events);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.isRun).toBe(true);
+    expect(groups[0]!.eventType).toBe("TurnDuration");
+    expect(groups[0]!.events).toHaveLength(4);
+    expect(buildGroupTitle(groups[0]!)).toBe("TurnDuration ×4");
+  });
+
+  it("a tool call breaks an otherwise-consecutive run", () => {
+    // Order matters (this is the display order). Tool event splits the run.
+    const events = [
+      ev("TurnDuration", { at: "2026-06-26T08:00:01.000Z" }),
+      ev("TurnDuration", { at: "2026-06-26T08:00:02.000Z" }),
+      ev("PreToolUse", { tool_use_id: "tX", tool_name: "Read", at: "2026-06-26T08:00:03.000Z" }),
+      ev("TurnDuration", { at: "2026-06-26T08:00:04.000Z" }),
+    ];
+    const groups = groupEvents(events);
+    // 2 separate TurnDuration runs + 1 tool group = 3 groups (NOT one big run).
+    expect(groups).toHaveLength(3);
+    const runs = groups.filter((g) => g.isRun || g.eventType === "TurnDuration");
+    expect(runs.some((g) => g.events.length === 2)).toBe(true); // first run of 2
+    expect(groups.some((g) => g.tool_use_id === "tX")).toBe(true);
+  });
+
+  it("grouped view is strictly more compact than the flat stream", () => {
+    const events = [
+      ...Array.from({ length: 20 }, () => ev("TurnDuration")),
+      ev("PreToolUse", { tool_use_id: "tA", tool_name: "Bash" }),
+      ev("PostToolUse", { tool_use_id: "tA", tool_name: "Bash" }),
+      ...Array.from({ length: 15 }, () => ev("TurnDuration")),
+    ];
+    const groups = groupEvents(events);
+    // 37 raw events → 3 rows (run ×20, Bash tool call, run ×15).
+    expect(events.length).toBe(37);
+    expect(groups.length).toBe(3);
+  });
+
+  it("a lone non-tool event stays a single-event group (renders like a flat row)", () => {
+    const groups = groupEvents([ev("Notification")]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.isRun).toBe(false);
+    expect(groups[0]!.events).toHaveLength(1);
+    expect(groups[0]!.tool_use_id).toBeNull();
+  });
+});

--- a/client/src/lib/event-grouping.ts
+++ b/client/src/lib/event-grouping.ts
@@ -1,14 +1,19 @@
 /**
  * @file event-grouping.ts
- * @description Client-side grouping of DashboardEvent rows by `tool_use_id`.
- * A single tool invocation typically emits two events - `PreToolUse` (Working)
- * and `PostToolUse` (Connected) - both carrying the same `tool_use_id` inside
- * their hook payload. Grouping collapses each such pair into one `EventGroup`
- * so the UI can show "Bash: curl ... (2.3s)" as one row instead of two, while
- * keeping the individual events accessible when the group is expanded.
+ * @description Client-side grouping for the "Group by tool call" view.
+ * Two collapses happen, so this mode is meaningfully more compact than the flat
+ * stream (which renders one row per raw event):
  *
- * Events without a `tool_use_id` (Stop, Notification, TurnDuration, etc.)
- * become single-event groups and render identically to a flat row.
+ *   1. **Tool calls** — a single tool invocation emits `PreToolUse` (Working) +
+ *      `PostToolUse` (Connected) sharing one `tool_use_id`; these collapse into
+ *      one row ("Bash · git commit (2.3s)"), expandable to the underlying events.
+ *   2. **Activity runs** — consecutive events of the SAME non-tool `event_type`
+ *      (e.g. a burst of 40 `TurnDuration` metadata events between tool calls)
+ *      collapse into one "TurnDuration ×40" row. Without this the flat and
+ *      grouped views look nearly identical on real sessions, which are dominated
+ *      by such metadata events.
+ *
+ * A lone non-tool event stays a one-event group and renders like a flat row.
  *
  * @author Son Nguyen <hoangson091104@gmail.com>
  */
@@ -16,8 +21,9 @@
 import type { DashboardEvent } from "./types";
 
 export type EventGroup = {
-  /** Stable key - either the tool_use_id, or `single:<event.id>` for
-   *  ungroupable events. Safe to use as a React list key. */
+  /** Stable key - the tool_use_id for tool groups, or `run:<event_type>:<n>`
+   *  for a (possibly length-1) run of consecutive same-type non-tool events.
+   *  Safe to use as a React list key. */
   key: string;
   /** Events in the group, sorted chronologically (oldest → newest). */
   events: DashboardEvent[];
@@ -33,6 +39,12 @@ export type EventGroup = {
   durationMs: number | null;
   /** Best summary to display - prefers the most recent non-empty summary. */
   summary: string | null;
+  /** True when this is a collapsed run of >1 consecutive same-type non-tool
+   *  events (e.g. "TurnDuration ×40"), as opposed to a tool-call group. */
+  isRun: boolean;
+  /** The shared `event_type` when every event in the group has the same one
+   *  (always set for runs; also set for single-event groups), else null. */
+  eventType: string | null;
 };
 
 function extractToolUseId(event: DashboardEvent): string | null {
@@ -53,9 +65,29 @@ export function groupEvents(events: DashboardEvent[]): EventGroup[] {
   const byKey = new Map<string, DashboardEvent[]>();
   const order: string[] = [];
 
+  // Single ordered pass. Tool events group GLOBALLY by tool_use_id (Pre/Post
+  // pair up even when separated). Non-tool events collapse only across an
+  // ADJACENT run of the same event_type — a tool event (or a different type)
+  // breaks the run — so the timeline order is preserved.
+  let runSeq = 0;
+  let runKey: string | null = null;
+  let runType: string | null = null;
+
   for (const event of events) {
     const toolUseId = extractToolUseId(event);
-    const key = toolUseId ?? `single:${event.id}`;
+    let key: string;
+    if (toolUseId) {
+      key = toolUseId;
+      runKey = null;
+      runType = null;
+    } else if (runKey && runType === event.event_type) {
+      key = runKey; // extend the current consecutive same-type run
+    } else {
+      runSeq++;
+      key = `run:${event.event_type}:${runSeq}`;
+      runKey = key;
+      runType = event.event_type;
+    }
     if (!byKey.has(key)) {
       byKey.set(key, []);
       order.push(key);
@@ -75,16 +107,20 @@ export function groupEvents(events: DashboardEvent[]): EventGroup[] {
         : null;
     const summary =
       [...sorted].reverse().find((e) => e.summary && e.summary.length > 0)?.summary ?? null;
+    const isTool = !key.startsWith("run:");
+    const allSameType = sorted.every((e) => e.event_type === first.event_type);
 
     groups.push({
       key,
       events: sorted,
       tool_name: first.tool_name,
-      tool_use_id: key.startsWith("single:") ? null : key,
+      tool_use_id: isTool ? key : null,
       firstAt: first.created_at,
       lastAt: last.created_at,
       durationMs,
       summary,
+      isRun: !isTool && sorted.length > 1,
+      eventType: allSameType ? first.event_type : null,
     });
   }
 
@@ -413,6 +449,10 @@ export function buildEventTitle(event: DashboardEvent): string {
 }
 
 export function buildGroupTitle(group: EventGroup): string {
+  // A collapsed run of same-type metadata events reads "TurnDuration ×40".
+  if (group.isRun && group.eventType) {
+    return `${group.eventType} ×${group.events.length}`;
+  }
   // Prefer the earliest event (usually PreToolUse) because it carries the
   // intended tool_input; the post event may or may not echo the same shape.
   const primary = group.events[0];


### PR DESCRIPTION
## Problem
The Session Detail timeline and the Activity Feed both have a **Group by tool call** ↔ **Flat list** toggle, but the two views looked nearly identical.

Real sessions are dominated by non-tool metadata events — one local session had **24,086 `TurnDuration`** events vs ~2,000 tool events. The old `groupEvents` only paired `PreToolUse`/`PostToolUse` by `tool_use_id` and left every other event as its own row, so the few collapsed tool pairs were invisible amid thousands of unchanged metadata rows. The toggle effectively did nothing.

## Fix (`client/src/lib/event-grouping.ts`)
`groupEvents` now collapses **two** things in one order-preserving pass:
1. **Tool calls** — `Pre`/`Post` sharing a `tool_use_id` → one row (unchanged).
2. **Activity runs** — consecutive events of the same non-tool `event_type` (e.g. a burst of `TurnDuration`) → one **`TurnDuration ×40`** row. A tool call (or a different event type) breaks a run, so timeline order is preserved.

`EventGroup` gains `isRun` + `eventType`; `buildGroupTitle` renders runs as `<type> ×<n>`. `EventGroupRow` already styles multi-event groups (teal border, expandable child list with a count), so runs render as distinct, expandable rows.

Net effect: grouped is now dramatically more compact than flat (e.g. **37 raw events → 3 rows**), so the toggle does what it says. Shared code → fixes both the Session Detail timeline and the Activity Feed.

## Verification
- New `client/src/lib/__tests__/event-grouping.test.ts` — tool-pair collapse (+ duration), run collapse (+ `×N` title), run-break by a tool call, overall compactness, lone-event passthrough.
- `npm run test:client` → **238 pass** (incl. screen snapshots — unchanged); `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RgwMnjGK1PjixtgwmGnykJ