### PR TITLE
fix(sweep): gate maintenance-sweep workflow ingest by mtime fingerprint

### DIFF
--- a/server/__tests__/workflow-ingest.test.js
+++ b/server/__tests__/workflow-ingest.test.js
@@ -340,6 +340,58 @@ describe("workflowsMaxMtime", () => {
       "0 when there are no workflow artifacts"
     );
   });
+
+  // Regression guard for the maintenance sweep (server/index.js step 3) and
+  // startWorkflowPoll: both skip a session whose workflow artifacts are
+  // unchanged and re-ingest only once the fingerprint advances. Before the
+  // gate, the 5-min sweep full-re-parsed every workflow journal and every
+  // inner agent-*.jsonl for every active session every cycle; on a large
+  // corpus each sweep outran the interval, sweeps overlapped, and the event
+  // loop pegged (dashboard stopped responding). This asserts the exact
+  // skip/re-ingest decision that gate relies on. Isolated root — no shared
+  // fixture state so later suites are unaffected.
+  it("gates skip vs re-ingest: stable fingerprint when unchanged, higher after a new artifact", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "wf-gate-"));
+    try {
+      const sid = "sess-gate";
+      const tp = path.join(root, `${sid}.jsonl`);
+      fs.writeFileSync(tp, "");
+      const wdir = path.join(root, sid, "workflows");
+      writeJson(path.join(wdir, "wf_a.json"), {
+        runId: "wf_a",
+        status: "completed",
+        startTime: 1700000000000,
+        workflowProgress: [],
+      });
+
+      const seen = new Map(); // mirrors sweepWorkflowSeen / lastSeen
+
+      const m1 = workflowsMaxMtime(tp);
+      assert.ok(m1 > 0, "fingerprint > 0 with a journal");
+      assert.equal(m1 === 0 || seen.get(sid) === m1, false, "first sight ingests");
+      seen.set(sid, m1);
+
+      const m2 = workflowsMaxMtime(tp);
+      assert.equal(m2, m1, "fingerprint stable when nothing changes");
+      assert.equal(m2 === 0 || seen.get(sid) === m2, true, "unchanged session is skipped");
+
+      const later = path.join(wdir, "wf_b.json");
+      writeJson(later, {
+        runId: "wf_b",
+        status: "completed",
+        startTime: 1700000001000,
+        workflowProgress: [],
+      });
+      const bump = m1 / 1000 + 5; // seconds, safely newer than m1
+      fs.utimesSync(later, bump, bump);
+
+      const m3 = workflowsMaxMtime(tp);
+      assert.ok(m3 > m1, "fingerprint advances when a new artifact appears");
+      assert.equal(m3 === 0 || seen.get(sid) === m3, false, "changed session is re-ingested");
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("live running workflow (no terminal journal)", () => {

--- a/server/index.js
+++ b/server/index.js
@@ -733,6 +733,11 @@ if (require.main === module) {
   const { broadcast } = require("./websocket");
   const { importCompactions } = require("../scripts/import-history");
   const { transcriptCache } = require("./routes/hooks");
+  // Per-session newest workflow-artifact mtime already ingested by this sweep,
+  // so step 3 below skips sessions whose workflow files are unchanged (the same
+  // cheap fingerprint startWorkflowPoll uses). Declared once so it persists
+  // across sweep ticks.
+  const sweepWorkflowSeen = new Map();
   setInterval(() => {
     // 1. Stale session cleanup — batch agent updates to avoid N+1 queries
     const stale = cleanupDb.stmts.findStaleSessions.all("__periodic__", STALE_MINUTES);
@@ -809,9 +814,23 @@ if (require.main === module) {
     // 3. Scan active sessions for Workflow-tool run journals (issue #167).
     // Catches workflows that complete without a subsequent hook and flips
     // launch-detected "running" rows to "completed" once their journal lands.
-    const { ingestWorkflowsForSession } = require("./lib/workflow-ingest");
+    const { ingestWorkflowsForSession, workflowsMaxMtime } = require("./lib/workflow-ingest");
     for (const row of active) {
       if (!row.tp) continue;
+      // Skip sessions whose workflow artifacts are unchanged since the last
+      // ingest — the same cheap mtime fingerprint startWorkflowPoll uses.
+      // Without this the sweep full-re-parses every workflow journal and every
+      // inner agent-*.jsonl for every active session every cycle; on a large
+      // corpus that re-parse exceeds the sweep interval, sweeps overlap, and
+      // the event loop pegs (dashboard stops responding — white page).
+      let mtime = 0;
+      try {
+        mtime = workflowsMaxMtime(row.tp);
+      } catch {
+        mtime = 0;
+      }
+      if (mtime === 0 || sweepWorkflowSeen.get(row.session_id) === mtime) continue;
+      sweepWorkflowSeen.set(row.session_id, mtime);
       ingestWorkflowsForSession(cleanupDb, { id: row.session_id, transcript_path: row.tp })
         .then((changed) => {
           if (!changed || changed.length === 0) return;

--- a/server/index.js
+++ b/server/index.js
@@ -815,6 +815,12 @@ if (require.main === module) {
     // Catches workflows that complete without a subsequent hook and flips
     // launch-detected "running" rows to "completed" once their journal lands.
     const { ingestWorkflowsForSession, workflowsMaxMtime } = require("./lib/workflow-ingest");
+    // Forget fingerprints for sessions that are no longer active so the map
+    // can't grow without bound over the process lifetime.
+    const activeIds = new Set(active.map((r) => r.session_id));
+    for (const id of sweepWorkflowSeen.keys()) {
+      if (!activeIds.has(id)) sweepWorkflowSeen.delete(id);
+    }
     for (const row of active) {
       if (!row.tp) continue;
       // Skip sessions whose workflow artifacts are unchanged since the last
@@ -839,6 +845,9 @@ if (require.main === module) {
           if (sess) broadcast("session_updated", sess);
         })
         .catch((err) => {
+          // Forget the fingerprint so the next sweep retries this session
+          // instead of skipping it until its artifacts change again.
+          sweepWorkflowSeen.delete(row.session_id);
           console.warn(
             `[SWEEP] Workflow scan failed for session ${row.session_id}:`,
             err?.message || err


### PR DESCRIPTION
## Problem

The 5-minute maintenance sweep in `server/index.js` (step 3, added for #167) re-runs `ingestWorkflowsForSession` for **every active session on every tick, with no change detection**. That ingest is not incremental — it re-parses every workflow journal and every inner `agent-*.jsonl` for the session from scratch each call (`parseSubagentFile`, whole-file line-by-line). With many active sessions that each carry workflow history, the sweep repeatedly re-parses hundreds of MB of transcripts it has already ingested, every 5 minutes, saturating the single event loop with redundant work. On a busy self-hosted instance this pushed sustained CPU high enough that HTTP responses stalled and the dashboard rendered a blank page.

`startWorkflowPoll` already avoids exactly this with a cheap mtime fingerprint (`workflowsMaxMtime` + a `lastSeen` map) — it skips sessions whose workflow artifacts are unchanged. The maintenance sweep never got the same gate. (Note: `DASHBOARD_WORKFLOW_POLL_MS=0` disables only the poll, not this sweep.)

Observed: ~1100 workflow `agent-*.jsonl` files / ~210 MB across many sessions; sustained ~100% CPU on the main thread, accept queue full, local `curl :4820` timing out. After gating, steady-state CPU dropped to ~3% and HTTP latency to ~1.5 ms measured across several sweep cycles.

## Fix

Apply the same fingerprint gate the poll already uses to the sweep's step 3:

- a per-sweep `sweepWorkflowSeen` map (pruned to the active set each cycle so it can't grow unbounded), and
- `if (mtime === 0 || sweepWorkflowSeen.get(id) === mtime) continue;` before the ingest.

A completing workflow writes a new terminal journal, which advances `workflowsMaxMtime`, so the sweep still catches the `running → completed` transitions it exists to catch — only genuine no-ops are skipped. On ingest failure the fingerprint is dropped so the next sweep retries (relevant because when the poll is disabled the sweep is the only ingester).

## Scope — what this does and does not address

This removes the **redundant re-parse of unchanged sessions**, which is the dominant cost when many sessions carry idle/completed workflow history. It deliberately does not touch the ingest itself, so two pre-existing behaviors remain (out of scope here, flagged for follow-up):

- A session with a **continuously-writing live workflow** advances its fingerprint every tick, so it is re-ingested every cycle and still pays the full, non-incremental re-parse. The real cure there is per-file / offset-incremental ingest inside `ingestWorkflowsForSession` — which would also benefit the 12 s poll, since it shares this path.
- There is **no in-flight guard**, so ingests for a single hot session can still overlap (unlike `startSessionSync`, which guards with `running`/`queued`).

So this is a targeted, low-risk improvement to the sweep, not a rewrite of the ingest pipeline.

## Test

Adds a regression test in `server/__tests__/workflow-ingest.test.js` for the invariant the gate relies on: the fingerprint is stable across calls when nothing changes (→ skip) and advances when a new artifact lands (→ re-ingest). It uses `fs.utimesSync` for a deterministic mtime bump (not wall-clock), and is mutation-checked to be non-vacuous.

The sweep body is an anonymous `setInterval` inside `if (require.main === module)` with no exported seam, so the test can't drive the wiring itself; it locks down the `workflowsMaxMtime`-based decision the gate depends on. Extracting the sweep body into an exported function would let a future test exercise the wiring end-to-end.

```
node --test server/__tests__/workflow-ingest.test.js   # 12/12 green
```
