### PR TITLE
feat(cli): server up/down indicator + ccam start / ccam status

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -612,6 +612,10 @@ flowchart LR
 仪表盘的完整功能面同样可以在终端中使用——零依赖的 **`ccam`** CLI（`bin/ccam.js`），由 `npm run setup` 自动链接（失败即降级的 `npm link`）。CLI 通过 `~/.claude/.agent-dashboard.json`（与 hook 处理器相同的注册表）自动发现正在运行的服务器，可用 `CLAUDE_DASHBOARD_PORT`/`DASHBOARD_PORT` 覆盖，默认 `http://127.0.0.1:4820`。
 
 ```bash
+# 服务器
+ccam status                       # ● 运行中 / ○ 未运行 指示器
+ccam start [--port N]             # 在后台启动服务器（分离进程）
+
 # 监控
 ccam health                       # 仪表盘是否在运行？
 ccam stats                        # 总量、今日事件、状态分布
@@ -657,7 +661,7 @@ ccam clear-data --yes             # 删除全部数据（必须 --yes）
 ccam open                         # 在浏览器中打开仪表盘
 ```
 
-读取类命令始终安全；唯一的破坏性命令（`clear-data`）没有显式 `--yes` 时拒绝执行。若 `ccam` 不在 PATH 上，在仓库根目录运行一次 `npm link`。完整参考——标志、服务器发现顺序、安全模型、退出码——见 [docs/CLI.md](./docs/CLI.md)。
+基于 API 的命令需要服务器在运行——未运行时它们会打印一致的 `○ Dashboard server is NOT running` 指示并给出启动命令，`ccam start` 可在后台拉起生产服务器。读取类命令始终安全；唯一的破坏性命令（`clear-data`）没有显式 `--yes` 时拒绝执行。若 `ccam` 不在 PATH 上，在仓库根目录运行一次 `npm link`。完整参考——标志、服务器发现顺序、安全模型、退出码——见 [docs/CLI.md](./docs/CLI.md)。
 
 ## npm 脚本
 

--- a/README-VN.md
+++ b/README-VN.md
@@ -613,6 +613,10 @@ flowchart LR
 Toàn bộ bề mặt tính năng của dashboard cũng dùng được từ terminal qua CLI **`ccam`** không phụ thuộc thư viện ngoài (`bin/ccam.js`), được liên kết tự động bởi `npm run setup` (qua `npm link` kiểu fail-soft). CLI tự tìm server đang chạy qua `~/.claude/.agent-dashboard.json` (cùng sổ đăng ký mà hook handler dùng; ghi đè bằng `CLAUDE_DASHBOARD_PORT`/`DASHBOARD_PORT`, mặc định `http://127.0.0.1:4820`).
 
 ```bash
+# Máy chủ
+ccam status                       # chỉ báo ● đang chạy / ○ chưa chạy
+ccam start [--port N]             # khởi động server chạy nền (detached)
+
 # Giám sát
 ccam health                       # dashboard có đang chạy không?
 ccam stats                        # tổng số, sự kiện hôm nay, phân bố trạng thái
@@ -658,7 +662,7 @@ ccam clear-data --yes             # xóa TOÀN BỘ dữ liệu (bắt buộc --
 ccam open                         # mở dashboard trong trình duyệt
 ```
 
-Các lệnh đọc luôn an toàn; lệnh phá hủy duy nhất (`clear-data`) từ chối chạy nếu thiếu `--yes` tường minh. Nếu `ccam` chưa có trên PATH, chạy `npm link` một lần từ thư mục gốc của repo. Tài liệu đầy đủ — cờ, thứ tự phát hiện server, mô hình an toàn, mã thoát — tại [docs/CLI.md](./docs/CLI.md).
+Các lệnh dựa trên API cần server đang chạy — khi chưa chạy, chúng in chỉ báo nhất quán `○ Dashboard server is NOT running` kèm các lệnh khởi động, và `ccam start` đưa server production lên chạy nền. Các lệnh đọc luôn an toàn; lệnh phá hủy duy nhất (`clear-data`) từ chối chạy nếu thiếu `--yes` tường minh. Nếu `ccam` chưa có trên PATH, chạy `npm link` một lần từ thư mục gốc của repo. Tài liệu đầy đủ — cờ, thứ tự phát hiện server, mô hình an toàn, mã thoát — tại [docs/CLI.md](./docs/CLI.md).
 
 ## Tập lệnh npm
 

--- a/README.md
+++ b/README.md
@@ -619,6 +619,10 @@ For git clones, the server periodically `git fetch`es `origin` and compares your
 The dashboard's full feature surface is also available from any terminal via the dependency-free **`ccam`** CLI (`bin/ccam.js`). It is linked automatically by `npm run setup` (via `npm link`), after which `ccam <command>` works from any directory. It discovers the running dashboard through `~/.claude/.agent-dashboard.json` (the same live-server registry the hook handler uses), with `CLAUDE_DASHBOARD_PORT` / `DASHBOARD_PORT` env overrides, falling back to `http://127.0.0.1:4820`.
 
 ```bash
+# Server
+ccam status                       # ● running / ○ not running indicator
+ccam start [--port N]             # start the server in the background (detached)
+
 # Monitoring
 ccam health                       # is the dashboard up?
 ccam stats                        # totals, today's events, status distributions
@@ -664,7 +668,7 @@ ccam clear-data --yes             # delete ALL data (requires --yes)
 ccam open                         # open the dashboard in your browser
 ```
 
-Read commands are always safe; the one destructive command (`clear-data`) refuses to run without an explicit `--yes`. If `ccam` is not on your PATH (e.g. `npm link` needed elevated permissions), run `npm link` once from the repo root. Full reference — flags, discovery order, safety model, scripting/exit codes, troubleshooting — in [docs/CLI.md](./docs/CLI.md).
+API-backed commands need the server running — when it isn't, they print a consistent `○ Dashboard server is NOT running` indicator with the start commands, and `ccam start` brings a production server up in the background. Read commands are always safe; the one destructive command (`clear-data`) refuses to run without an explicit `--yes`. If `ccam` is not on your PATH (e.g. `npm link` needed elevated permissions), run `npm link` once from the repo root. Full reference — flags, discovery order, safety model, scripting/exit codes, troubleshooting — in [docs/CLI.md](./docs/CLI.md).
 
 ## npm Scripts
 

--- a/bin/ccam.js
+++ b/bin/ccam.js
@@ -100,9 +100,7 @@ async function api(method, pathname, body) {
       signal: AbortSignal.timeout(30_000),
     });
   } catch {
-    console.error(c.red(`✖ Cannot reach the dashboard at ${baseUrl()}`));
-    console.error(c.dim("  Start it with: npm run dev   (or npm start)"));
-    process.exit(1);
+    serverDownExit();
   }
   let data = null;
   try {
@@ -119,6 +117,35 @@ async function api(method, pathname, body) {
 }
 const get = (p) => api("GET", p);
 const post = (p, b) => api("POST", p, b);
+
+/**
+ * Print the standard "server is not running" indicator and exit 1. Every
+ * command that needs the API funnels through this, so the guidance is
+ * identical everywhere: the ccam CLI talks to the local dashboard server,
+ * and `ccam start` (or npm run dev / npm start) brings one up.
+ */
+function serverDownExit() {
+  console.error(`${c.red("○ Dashboard server is NOT running")} ${c.dim(`(tried ${baseUrl()})`)}`);
+  console.error(c.dim("  This command needs the server. Start it with one of:"));
+  console.error(
+    `    ${c.bold("ccam start")}        ${c.dim("# production server in the background")}`
+  );
+  console.error(
+    `    ${c.bold("npm run dev")}       ${c.dim("# dev mode (hot reload), foreground")}`
+  );
+  console.error(`    ${c.bold("npm start")}         ${c.dim("# production mode, foreground")}`);
+  process.exit(1);
+}
+
+/** True when the dashboard answers /api/health at the resolved URL. */
+async function serverIsUp() {
+  try {
+    const res = await fetch(`${baseUrl()}/api/health`, { signal: AbortSignal.timeout(2_500) });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
 
 /** Minimal flag parser: --key value / --key. Positionals returned in order. */
 function parseArgs(argv) {
@@ -668,6 +695,72 @@ async function cmdReinstallHooks() {
   console.log(`${c.green("✔")} Claude Code hooks reinstalled`);
 }
 
+/**
+ * Start the dashboard server in the background (production mode, serving the
+ * built client) and wait until /api/health answers. No-ops with a pointer to
+ * the live URL when a server is already up. The child is fully detached with
+ * its output appended to data/ccam-server.log, so closing this terminal does
+ * not stop the dashboard; stop it later with `kill <pid>` (the PID is
+ * printed and registered in ~/.claude/.agent-dashboard.json).
+ */
+async function cmdStart(flags) {
+  if (await serverIsUp()) {
+    console.log(`${c.green("●")} Dashboard already running at ${c.bold(baseUrl())}`);
+    return;
+  }
+  const clientDist = path.join(REPO_ROOT, "client", "dist", "index.html");
+  if (!fs.existsSync(clientDist)) {
+    console.error(c.red("✖ client/dist is missing — the production server needs a built client."));
+    console.error(c.dim("  Build it once with: npm run build   (then re-run: ccam start)"));
+    console.error(c.dim("  Or run the dev servers instead:     npm run dev"));
+    process.exit(1);
+  }
+  const logDir = path.join(REPO_ROOT, "data");
+  fs.mkdirSync(logDir, { recursive: true });
+  const logFile = path.join(logDir, "ccam-server.log");
+  const out = fs.openSync(logFile, "a");
+  const env = { ...process.env, NODE_ENV: "production" };
+  if (flags.port) env.DASHBOARD_PORT = String(flags.port);
+  const child = spawn(process.execPath, [path.join(REPO_ROOT, "server", "index.js")], {
+    detached: true,
+    stdio: ["ignore", out, out],
+    env,
+    cwd: REPO_ROOT,
+  });
+  child.unref();
+  process.stdout.write(c.dim(`Starting dashboard server (pid ${child.pid}, log ${logFile}) `));
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    if (await serverIsUp()) {
+      console.log(
+        `\n${c.green("●")} Dashboard ${c.bold("up")} at ${baseUrl()} ${c.dim(`(pid ${child.pid})`)}`
+      );
+      console.log(c.dim(`  Stop it with: kill ${child.pid}`));
+      return;
+    }
+    process.stdout.write(c.dim("."));
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  console.error(`\n${c.red("✖ Server did not become healthy within 30 s")} — check ${logFile}`);
+  process.exit(1);
+}
+
+/** Up/down indicator without exiting non-zero noise — the at-a-glance check. */
+async function cmdStatus() {
+  if (await serverIsUp()) {
+    const h = await get("/api/health");
+    console.log(
+      `${c.green("●")} Dashboard server is ${c.bold("running")} at ${baseUrl()} (${h.timestamp})`
+    );
+  } else {
+    console.log(
+      `${c.red("○")} Dashboard server is ${c.bold("NOT running")} ${c.dim(`(tried ${baseUrl()})`)}`
+    );
+    console.log(c.dim("  Start it with: ccam start   (or npm run dev / npm start)"));
+    process.exit(1);
+  }
+}
+
 function cmdOpen() {
   const url = baseUrl();
   const opener =
@@ -684,6 +777,10 @@ function cmdHelp() {
   console.log(`${c.bold("ccam")} — Claude Code Agent Monitor CLI
 
 ${c.bold("Usage:")} ccam <command> [options]
+
+${c.bold("Server")}
+  status                      Up/down indicator for the dashboard server
+  start [--port N]            Start the server in the background and wait for healthy
 
 ${c.bold("Monitoring")}
   health                      Check the dashboard is up
@@ -732,7 +829,10 @@ ${c.bold("Administration")}
 
 ${c.bold("Server discovery:")} CLAUDE_DASHBOARD_PORT / DASHBOARD_PORT env vars win,
 otherwise the live server is found via ~/.claude/.agent-dashboard.json,
-falling back to http://127.0.0.1:4820.`);
+falling back to http://127.0.0.1:4820.
+
+${c.bold("Note:")} ccam talks to the local dashboard server — API-backed commands
+require it to be running (${c.bold("ccam start")} brings one up in the background).`);
 }
 
 // ── Entry point ─────────────────────────────────────────────────────────────
@@ -743,6 +843,10 @@ async function main() {
   switch (cmd) {
     case "health":
       return cmdHealth();
+    case "status":
+      return cmdStatus();
+    case "start":
+      return cmdStart(flags);
     case "stats":
       return cmdStats();
     case "kanban":

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -66,9 +66,26 @@ The CLI finds your running dashboard the same way the Claude Code hook handler d
 | 2 | `~/.claude/.agent-dashboard.json` | Written by every running dashboard (`{port, pid, startedAt}` entries); stale entries are skipped via a PID liveness check |
 | 3 | `http://127.0.0.1:4820` | Default port fallback |
 
-If no server answers, every command exits `1` with `✖ Cannot reach the dashboard …` and the command to start one.
+If no server answers, every API-backed command exits `1` with the `○ Dashboard server is NOT running` indicator and the ways to start one (see [Server Lifecycle](#server-lifecycle)).
 
 ## Commands
+
+### Server Lifecycle
+
+The CLI talks to the local dashboard server — **API-backed commands require it to be running**. When it isn't, every such command prints a consistent indicator and exits `1`:
+
+```
+○ Dashboard server is NOT running (tried http://127.0.0.1:4820)
+  This command needs the server. Start it with one of:
+    ccam start        # production server in the background
+    npm run dev       # dev mode (hot reload), foreground
+    npm start         # production mode, foreground
+```
+
+| Command | Description |
+| ------- | ----------- |
+| `ccam status` | At-a-glance up/down indicator (`●` running / `○` not running); exits `1` when down |
+| `ccam start [--port N]` | Start the production server **in the background** (detached; survives closing the terminal), wait up to 30 s for `/api/health`, print the URL + PID and the `kill <pid>` stop command. Logs append to `data/ccam-server.log`. No-ops with a pointer when a server is already up. Requires a built client (`npm run build` once) |
 
 ### Monitoring
 
@@ -153,7 +170,7 @@ If no server answers, every command exits `1` with `✖ Cannot reach the dashboa
 
 | Symptom | Fix |
 | ------- | --- |
-| `✖ Cannot reach the dashboard` | Start the server (`npm run dev` or `npm start`). If it runs on a custom port, set `DASHBOARD_PORT` or rely on the discovery file |
+| `○ Dashboard server is NOT running` | Start it: `ccam start` (background), `npm run dev`, or `npm start`. If it runs on a custom port, set `DASHBOARD_PORT` or rely on the discovery file |
 | `ccam: command not found` | Run `npm link` from the repo root (setup's fail-soft link may have skipped on permissions), or use `node bin/ccam.js …` |
 | Wrong server answers (multiple dashboards) | Set `CLAUDE_DASHBOARD_PORT` explicitly — env overrides always beat discovery |
 | `tail` shows nothing | Events only flow while hooks are installed and a Claude Code session is active — check `ccam doctor` |

--- a/server/__tests__/ccam-cli.test.js
+++ b/server/__tests__/ccam-cli.test.js
@@ -336,6 +336,8 @@ describe("ccam CLI — help & errors", () => {
     const { code, out } = await ccam("help");
     assert.equal(code, 0);
     for (const word of [
+      "status",
+      "start",
       "health",
       "stats",
       "kanban",
@@ -377,7 +379,7 @@ describe("ccam CLI — help & errors", () => {
     assert.match(err, /Unknown command/);
   });
 
-  it("unreachable server exits 1 with a start hint", async () => {
+  it("unreachable server exits 1 with the not-running indicator + start hint", async () => {
     const r = await new Promise((resolve) => {
       const child = spawn(process.execPath, [CLI, "health"], {
         env: { ...process.env, DASHBOARD_PORT: "1" }, // nothing listens on port 1
@@ -387,7 +389,35 @@ describe("ccam CLI — help & errors", () => {
       child.on("close", (code) => resolve({ code, err }));
     });
     assert.equal(r.code, 1);
-    assert.match(r.err, /Cannot reach the dashboard/);
+    assert.match(r.err, /Dashboard server is NOT running/);
+    assert.match(r.err, /ccam start/);
     assert.match(r.err, /npm run dev/);
+  });
+
+  it("status reports running when the server is up", async () => {
+    const { code, out } = await ccam("status");
+    assert.equal(code, 0);
+    assert.match(out, /running/);
+    assert.match(out, new RegExp(String(PORT)));
+  });
+
+  it("status exits 1 with the down indicator when the server is down", async () => {
+    const r = await new Promise((resolve) => {
+      const child = spawn(process.execPath, [CLI, "status"], {
+        env: { ...process.env, DASHBOARD_PORT: "1" },
+      });
+      let out = "";
+      child.stdout.on("data", (d) => (out += d));
+      child.on("close", (code) => resolve({ code, out }));
+    });
+    assert.equal(r.code, 1);
+    assert.match(r.out, /NOT running/);
+    assert.match(r.out, /ccam start/);
+  });
+
+  it("start no-ops with a pointer when a server is already running", async () => {
+    const { code, out } = await ccam("start");
+    assert.equal(code, 0);
+    assert.match(out, /already running/);
   });
 });


### PR DESCRIPTION
## Summary

Makes the CLI's server dependency explicit and self-serviceable. `ccam` only works against a running dashboard — now every API-backed command says so consistently, and the CLI can start the server itself.

## Changes

- **Consistent down indicator** — a single `serverDownExit()` helper: `○ Dashboard server is NOT running (tried <url>)` + the three start options (`ccam start` / `npm run dev` / `npm start`), exit `1`. Identical wording across all commands.
- **`ccam status`** — at-a-glance `●` running / `○` not running; exits `1` when down.
- **`ccam start [--port N]`** — starts the production server **in the background** (detached `server/index.js`, `NODE_ENV=production`, logs appended to `data/ccam-server.log`), waits up to 30 s for `/api/health`, prints URL + PID + the `kill` command. No-ops with a pointer when already running; refuses with a `npm run build` hint when `client/dist` is missing.
- **Tests** — CLI suite grows to 35: updated unreachable-message assertions, new status-up / status-down / start-noop cases.
- **Docs** — `docs/CLI.md` Server Lifecycle section + troubleshooting row; README + VN + CN command blocks gain the Server group and the server-required note.

Verified end-to-end on a scratch env: down indicators, cold start → healthy ~1 s, no-op restart, clean kill.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## How to Test

1. With no server running: `ccam status` (○, exit 1), `ccam stats` (indicator + start options).
2. `ccam start` → `●` + PID; `ccam start` again → "already running"; `ccam status` → running.
3. `npm run test:server` — all green (35 CLI tests).

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/hoangsonww/Claude-Code-Agent-Monitor/blob/master/.github/CONTRIBUTING.md)
- [x] I have signed the [CLA](https://github.com/hoangsonww/Claude-Code-Agent-Monitor/blob/master/CLA.md) (the `🖋️ CLA Assistant` bot will prompt me on my first PR)
- [x] My code follows the project's coding standards
- [x] I have added/updated tests that prove my fix or feature works
- [x] All new and existing tests pass (`npm test`)
- [x] Code is formatted (`npm run format:check`)
- [x] I have updated documentation where necessary

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146oeseRLX17wL3iTqc1trq