### PR TITLE
feat(hooks): accept remote transcript titles from household hook forwarders

### DIFF
--- a/server/routes/hooks.js
+++ b/server/routes/hooks.js
@@ -186,6 +186,22 @@ const processEvent = db.transaction((hookType, data) => {
   if (!sessionId) return null;
 
   const session = ensureSession(sessionId, data);
+
+  // Remote household hooks (aideck-hook.js on other machines) cannot rely on
+  // the transcript being readable on THIS host (the JSONL lives on the remote
+  // machine's disk). They extract the transcript title locally and send it
+  // inline; apply it through the same precedence rules as the TranscriptCache
+  // path (custom wins, ai-title only fills auto/placeholder names).
+  if (data.remote_custom_title || data.remote_ai_title) {
+    syncSessionName(session, {
+      customTitle:
+        typeof data.remote_custom_title === "string"
+          ? data.remote_custom_title.slice(0, 200)
+          : null,
+      aiTitle: typeof data.remote_ai_title === "string" ? data.remote_ai_title.slice(0, 200) : null,
+    });
+  }
+
   let mainAgent = getMainAgent(sessionId);
   const mainAgentId = mainAgent?.id ?? null;
 


### PR DESCRIPTION
## What

Adds two optional fields to the `POST /api/hooks/event` payload — `data.remote_custom_title` and `data.remote_ai_title` — applied through the existing `syncSessionName()` precedence rules (explicit custom title always wins; ai-title only fills auto/placeholder names).

## Why

Sessions reported by hook forwarders running on **other machines** (e.g. a Windows box POSTing to a central dashboard) currently show the fallback name `Session <hex>`: the dashboard names sessions from the transcript's `custom-title`/`ai-title` JSONL lines via TranscriptCache, but the transcript lives on the remote machine's disk and can never be read by this host.

With this change the remote forwarder can extract the title locally (cheap tail-read of its own JSONL) and send it inline — remote sessions get real names with zero server-side filesystem coupling.

## Notes

- Values are capped at 200 chars and type-checked; non-string values are ignored.
- Same broadcast semantics as the TranscriptCache path (`session_updated` only on real change).
- Verified end-to-end against a live dashboard: a remote POST with `remote_ai_title` renamed the session in real time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Chqbe1ovWucKz6KJiCpAC3