### PR TITLE
fix(server): stop the desktop app freezing on a large ~/.claude history (#223)

### DIFF
--- a/scripts/import-history.js
+++ b/scripts/import-history.js
@@ -33,6 +33,17 @@ const { extractFirstUserText } = require("../server/lib/transcript-cache");
 const CLAUDE_DIR = getClaudeHome();
 const PROJECTS_DIR = getProjectsDir();
 
+// Max session files a directory sweep scans synchronously before it yields to
+// the event loop. The desktop app hosts this Express server IN the Electron main
+// process (see desktop/src/server-host.ts), so a long synchronous scan of a
+// large ~/.claude/projects tree — one statSync + one getSession query per file —
+// would freeze the whole app window, not just delay an API response. Yielding
+// every N files keeps each synchronous burst short so a multi-thousand-session
+// history never monopolizes the loop. Under `npm start` the server is its own
+// process, so the same scan can't freeze the UI there — which is exactly why
+// the issue only reproduces in the packaged app (#223).
+const SWEEP_YIELD_EVERY_FILES = 100;
+
 /**
  * Snapshot an imported session's JSONL transcript (and its subagent
  * transcripts) into the dashboard's own data dir so the Conversation tab can
@@ -1841,6 +1852,10 @@ async function syncDefaultProjects(dbModule, options = {}) {
     return { changed };
   }
 
+  // Files scanned so far this sweep, across all project dirs — drives the
+  // cooperative yield below so a huge history never blocks the event loop.
+  let scanned = 0;
+
   for (const projDir of projectDirs) {
     const projPath = path.join(PROJECTS_DIR, projDir);
     let files;
@@ -1851,6 +1866,18 @@ async function syncDefaultProjects(dbModule, options = {}) {
     }
 
     for (const file of files) {
+      // Cooperative yield BEFORE the per-file work, so it covers the unchanged
+      // -file fast paths below (statSync + a getSession query) that otherwise
+      // never await. Without this, a cold-cache sweep of a large projects tree
+      // runs thousands of files back-to-back with no yield and freezes the
+      // desktop app's window (its server shares the Electron main event loop —
+      // see SWEEP_YIELD_EVERY_FILES). The heavy-parse path keeps its own yield
+      // further down; this one is what makes the common skip path cooperative.
+      if (scanned > 0 && scanned % SWEEP_YIELD_EVERY_FILES === 0) {
+        await new Promise((resolve) => setImmediate(resolve));
+      }
+      scanned++;
+
       const sourcePath = path.join(projPath, file);
       let mtime;
       try {

--- a/server/__tests__/session-sync-yield.test.js
+++ b/server/__tests__/session-sync-yield.test.js
@@ -1,0 +1,122 @@
+/**
+ * @file Regression test for issue #223 — the packaged desktop app froze on a
+ * large ~/.claude/projects history. The desktop shell hosts the Express server
+ * IN the Electron main process, so a session sweep that scans every file
+ * synchronously (statSync + a getSession query per file) with no yield freezes
+ * the whole window. `syncDefaultProjects` must yield to the event loop
+ * periodically — even on the all-unchanged, cold-cache fast path that never
+ * parses a transcript — so a multi-thousand-session history can't monopolize
+ * the loop. Under `npm start` the server is its own process, which is why the
+ * hang only reproduced in the packaged app.
+ *
+ * Runs in its own process (node --test isolates files), so pointing CLAUDE_HOME
+ * and DASHBOARD_DB_PATH at temp locations before requiring the modules gives a
+ * clean, isolated projects dir + database without touching the real ones.
+ * @author Son Nguyen <hoangson091104@gmail.com>
+ */
+
+const { describe, it, before, after } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+
+const TMP_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "ccam-sync-yield-"));
+process.env.CLAUDE_HOME = TMP_HOME;
+process.env.DASHBOARD_DB_PATH = path.join(TMP_HOME, "dashboard.db");
+process.env.DASHBOARD_DATA_DIR = path.join(TMP_HOME, "data");
+
+const PROJECTS_DIR = path.join(TMP_HOME, "projects");
+fs.mkdirSync(PROJECTS_DIR, { recursive: true });
+
+const dbModule = require("../db");
+const { syncDefaultProjects } = require("../../scripts/import-history");
+
+// Enough sessions that the sweep crosses several yield boundaries
+// (SWEEP_YIELD_EVERY_FILES = 100), so a cooperative sweep interleaves multiple
+// event-loop ticks while a blocking one interleaves zero.
+const SESSION_COUNT = 300;
+
+function sessionLines(sessionId) {
+  return [
+    {
+      type: "user",
+      cwd: "/w",
+      sessionId,
+      timestamp: "2026-04-18T12:00:00.000Z",
+      message: { content: "hi" },
+    },
+    {
+      type: "assistant",
+      cwd: "/w",
+      sessionId,
+      timestamp: "2026-04-18T12:00:00.000Z",
+      message: {
+        model: "claude-opus-4-8",
+        content: [{ type: "text", text: "ok" }],
+        usage: { input_tokens: 10, output_tokens: 5 },
+      },
+    },
+  ];
+}
+
+before(() => {
+  const projDir = path.join(PROJECTS_DIR, "-w");
+  fs.mkdirSync(projDir, { recursive: true });
+  for (let i = 0; i < SESSION_COUNT; i++) {
+    // Valid v4 UUID shape, unique per index.
+    const suffix = i.toString(16).padStart(12, "0");
+    const id = `00000000-0000-4000-8000-${suffix}`;
+    fs.writeFileSync(
+      path.join(projDir, `${id}.jsonl`),
+      sessionLines(id)
+        .map((o) => JSON.stringify(o))
+        .join("\n") + "\n"
+    );
+  }
+});
+
+after(() => {
+  if (dbModule.db) dbModule.db.close();
+  fs.rmSync(TMP_HOME, { recursive: true, force: true });
+});
+
+describe("syncDefaultProjects cooperative yielding (#223)", () => {
+  it("imports the full history on the first sweep", async () => {
+    const { changed } = await syncDefaultProjects(dbModule, { mtimeCache: new Map() });
+    assert.equal(
+      changed.length,
+      SESSION_COUNT,
+      "every session is imported on the cold first sweep"
+    );
+  });
+
+  it("yields to the event loop during an all-unchanged cold-cache sweep", async () => {
+    // Count event-loop ticks that fire DURING the sweep. A blocking sweep runs
+    // the whole scan synchronously (no await on the unchanged fast path), so a
+    // setImmediate chain scheduled alongside it gets zero ticks until it
+    // finishes. A cooperative sweep yields every SWEEP_YIELD_EVERY_FILES files,
+    // letting the chain advance mid-sweep.
+    let ticks = 0;
+    let active = true;
+    const pump = () => {
+      if (active) {
+        ticks += 1;
+        setImmediate(pump);
+      }
+    };
+    setImmediate(pump);
+
+    // Fresh (cold) cache but the rows already exist and the files are unchanged,
+    // so every file takes the fast path — the exact restart/poll scenario that
+    // froze the app. Nothing is reported as changed.
+    const { changed } = await syncDefaultProjects(dbModule, { mtimeCache: new Map() });
+    active = false;
+
+    assert.equal(changed.length, 0, "an unchanged sweep still reports no work");
+    assert.ok(
+      ticks >= 2,
+      `sweep must yield to the event loop on the fast path (observed ${ticks} ticks across ${SESSION_COUNT} files)`
+    );
+  });
+});


### PR DESCRIPTION
Fixes #223.

## Symptom
The packaged desktop app (Windows, reported by @ahoehma) **freezes a few seconds after launch** on a large history (~1.2K sessions) and only shows a handful (~35) of sessions. Running the **same repo via `npm`** loads all 1.2K sessions fine.

## Root cause
The desktop shell hosts the Express server **in the Electron main process** (`desktop/src/server-host.ts` `require()`s `server/index.js` — "Electron is a window onto the same code"). That means anything monopolizing the server's event loop freezes the **whole window**, not just an API response.

`syncDefaultProjects()` (the background session sweep in `server/index.js` `startSessionSync`) runs **250 ms after boot and again every 30 s**. It scans every session file with a synchronous `statSync` + `getSession` query and **only yields after a heavy transcript _parse_**. On the unchanged-file fast paths — the common case on every restart/poll — it **never yields**, so a multi-thousand-session sweep runs thousands of files back-to-back and pins the loop.

Under `npm start`/`npm run dev` the identical work runs in a **separate** process, so the browser UI stays responsive — which is exactly why the freeze only reproduces in the packaged app.

## Does this affect the macOS app too?
**Yes, architecturally.** The macOS shell uses the same in-process server host, so a large enough history would freeze it the same way. This fix helps both targets; the fix lives in the shared server code, not in platform-specific code.

## Fix
Yield to the event loop every `SWEEP_YIELD_EVERY_FILES` (100) files during the sweep, covering the fast paths that previously never awaited. Behavior is otherwise unchanged — same imports, same change reports, same `mtimeCache` semantics. Yielding is equally harmless on the standalone-server path.

## Tests
- New regression test `server/__tests__/session-sync-yield.test.js`: schedules a `setImmediate` heartbeat while a **cold-cache, all-unchanged** sweep of 300 files runs. Without the fix the sweep is fully synchronous → **0 ticks** (test fails); with the fix it interleaves event-loop ticks (test passes).
- Full server suite green: **633/633**.
- File-header audit passes.

I can't visually smoke-test the packaged Windows build from here (macOS dev machine), so verification is via the automated event-loop-yield test above plus the full suite. @ahoehma — a build from this branch should stay responsive while your ~1.2K sessions stream in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)