### PR TITLE
docs(client): comprehensive TSDoc across lib/ — restore TypeScript as top language

### DIFF
--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,9 +1,74 @@
 /**
  * @file api.ts
  * @description Defines a set of functions for interacting with the backend API of the agent dashboard application. It includes methods for fetching statistics, managing sessions and agents, retrieving analytics data, handling settings, and managing model pricing. The module abstracts away the details of making HTTP requests and provides a clean interface for the rest of the application to use when communicating with the server.
+ *
+ * ## What this module is
+ * `api.ts` is the single, centralized REST client for the React dashboard. Every page/hook that
+ * needs data from the Express backend (`server/`) goes through the {@link api} object exported here
+ * rather than calling `fetch` directly. Keeping all HTTP access in one place gives the app a single
+ * choke point for authentication, base-path handling, JSON (de)serialization, and error
+ * normalization, and it keeps the network surface visible and greppable in one file.
+ *
+ * ## Layering / where this sits
+ * The end-to-end data flow of the product is:
+ *
+ *   Claude Code hooks -> Express API (`server/`) -> SQLite -> WebSocket broadcast -> React UI.
+ *
+ * This file covers exactly one hop of that flow: the request/response REST calls the browser makes
+ * to the Express API. It is deliberately *not* responsible for real-time updates. Live pushes
+ * (new events, status transitions, run output, import progress, etc.) arrive out-of-band over the
+ * WebSocket connection and are handled by the `eventBus` / `useWebSocket` layer. A typical page
+ * therefore does an initial REST `list`/`get` through this module to hydrate, then listens on the
+ * socket for incremental changes. The two mechanisms are complementary; neither replaces the other.
+ *
+ * ## Conventions shared by (almost) every call
+ * - **Base path.** All paths passed to {@link request} are relative to {@link BASE} ("/api"). The
+ *   Vite dev server proxies "/api" to the Express port in development, and in production the same
+ *   origin serves both the built client and the API, so a relative base works in both modes.
+ * - **Auth.** When the operator has locked the server down with a `DASHBOARD_TOKEN`, the token is
+ *   attached to every request as the `x-dashboard-token` header. In the default zero-config loopback
+ *   setup there is no token and the header is omitted. See {@link dashboardToken}.
+ * - **JSON in/out.** Requests default to `Content-Type: application/json`; bodies are hand-serialized
+ *   with `JSON.stringify` at each call site (so the caller controls the exact shape) and responses
+ *   are parsed with `res.json()` and returned as the method's generic `T`.
+ * - **Errors.** Non-2xx responses are converted into a thrown `Error` by {@link request}; the message
+ *   is the server's structured `error.message` when present, otherwise `HTTP <status>`. Callers get a
+ *   rejected promise they can surface in a toast / error boundary; they never see the raw `Response`.
+ * - **Pagination.** List endpoints accept `limit`/`offset` and echo them back alongside a `total`.
+ *   Transcript reading is the exception: it paginates by JSONL line number (`after`/`before`) because
+ *   the underlying file grows live and numeric offsets would drift (see {@link api.sessions.transcript}).
+ * - **Timezone bucketing.** Endpoints that group data by day (`stats`, `analytics`, `pricing.cost`)
+ *   send the browser's `getTimezoneOffset()` as `tz_offset` so "today" and per-day rollups line up
+ *   with the *viewer's* local midnight instead of the server's clock/UTC.
+ * - **Query-string building.** Optional filters are assembled with `URLSearchParams` and only appended
+ *   when at least one value is present, so a filter-less call hits a clean, cache-friendly URL.
+ *
+ * ## Two deliberate escapes from {@link request}
+ * A couple of operations cannot use the shared JSON wrapper and open-code their own `fetch`:
+ *   1. {@link api.import.upload} sends `multipart/form-data` (a `FormData` body), which must *not*
+ *      carry the JSON `Content-Type` header, so it calls `fetch` directly.
+ *   2. {@link api.settings.exportData} returns a *URL string* rather than performing a fetch, because
+ *      the DB export is consumed as an `<a href download>` navigation, not an XHR.
+ *
+ * ## Shape of the exports
+ * The bulk of the module is the {@link api} object: a nested, resource-grouped map of endpoint
+ * functions whose grouping mirrors the `server/routes/*.js` file layout (sessions, agents, events,
+ * analytics, settings, workflows, pricing, import, cc-config, run, alerts, webhooks). The remainder
+ * of the file is the set of exported TypeScript `interface`/`type` declarations describing the
+ * request bodies and response payloads that are *specific to this client* (many response DTOs are
+ * imported from `./types`; the ones declared here are the client-only ones, e.g. the CC-config
+ * explorer shapes, the Run-page process handles, and the import-result shape).
+ *
  * @author Son Nguyen <hoangson091104@gmail.com>
  */
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared response/entity DTOs. These are the cross-cutting types produced by the
+// server and reused across many endpoints (sessions, agents, events, analytics,
+// pricing, webhooks, alerts, workflows, transcripts, update status). Types that
+// are specific to a single client feature area are declared further down in this
+// file instead of being imported here.
+// ─────────────────────────────────────────────────────────────────────────────
 import type {
   Agent,
   AlertEvent,
@@ -30,6 +95,8 @@ import type {
   WorkflowRunDetail,
 } from "./types";
 
+// Root path all endpoint paths are appended to. Kept relative (no host) so the
+// same client bundle works behind the Vite dev proxy and in same-origin prod.
 const BASE = "/api";
 
 /**
@@ -37,14 +104,30 @@ const BASE = "/api";
  * operator binds the server to a LAN and sets DASHBOARD_TOKEN; for the default
  * loopback bind there is no token and this returns null (zero-config). Read from
  * an injected global first, then localStorage so a LAN user can set it once.
+ *
+ * Resolution order (first hit wins):
+ *   1. `globalThis.__DASHBOARD_TOKEN__` — a value the server can inject into the
+ *      served HTML so an operator-provisioned token is available on first paint
+ *      without any client-side setup.
+ *   2. `localStorage["dashboard_token"]` — a token the user pasted into the UI
+ *      once; it persists across reloads for that browser.
+ *
+ * The whole body is wrapped in try/catch because both `globalThis` access and
+ * `localStorage` can throw (e.g. storage disabled/blocked in some privacy modes);
+ * any failure degrades gracefully to "no token" rather than crashing the client.
+ *
+ * @returns The resolved token string, or `null` when none is configured/available.
  */
 export function dashboardToken(): string | null {
   try {
+    // Prefer a server-injected global (set into the page before the app boots).
     const injected = (globalThis as { __DASHBOARD_TOKEN__?: unknown }).__DASHBOARD_TOKEN__;
     if (typeof injected === "string" && injected) return injected;
+    // Fall back to a token the user saved in this browser's localStorage.
     const stored = localStorage.getItem("dashboard_token");
     return stored && stored.length > 0 ? stored : null;
   } catch {
+    // Storage/global access blocked → behave as an unauthenticated loopback client.
     return null;
   }
 }
@@ -55,12 +138,30 @@ export function dashboardToken(): string | null {
  * the `x-dashboard-token` header, and normalizes non-2xx responses into a
  * thrown `Error` whose message is the server's `error.message` (falling back
  * to `HTTP <status>` when the body isn't JSON or has no message).
- * @param path Path segment appended to `/api` (should start with "/").
+ *
+ * This is the workhorse behind the entire {@link api} surface. Centralizing it
+ * here means individual endpoint methods stay one-liners and never repeat auth,
+ * header-merging, or error-shaping logic. Two callers intentionally bypass it:
+ * the multipart upload ({@link api.import.upload}) and the export-URL builder
+ * ({@link api.settings.exportData}) — see the module overview for why.
+ *
+ * Header precedence (later spreads win): the JSON `Content-Type` default is set
+ * first, then the auth token, then any caller-supplied `options.headers` — so a
+ * caller can override `Content-Type` if it ever needs to, and per-call headers
+ * are merged into (not replaced by) the defaults.
+ *
+ * @typeParam T   The expected parsed JSON shape of a successful response body.
+ * @param path    Path segment appended to `/api` (should start with "/").
  * @param options Standard `fetch` options; `headers` are merged, not replaced.
- * @returns The parsed JSON response body, typed as `T`.
+ * @returns       The parsed JSON response body, typed as `T`.
+ * @throws {Error} When the response status is not ok (non-2xx). The thrown
+ *   message is `body.error.message` if the error body parsed as JSON and carried
+ *   one, otherwise the literal `HTTP <status>`.
  */
 async function request<T>(path: string, options?: RequestInit): Promise<T> {
   const token = dashboardToken();
+  // Build the effective header set. Order matters: defaults first so that the
+  // token and any caller headers can override, and caller headers land last.
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     ...(token ? { "x-dashboard-token": token } : {}),
@@ -68,6 +169,9 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
   };
   const res = await fetch(`${BASE}${path}`, { ...options, headers });
   if (!res.ok) {
+    // Try to recover a structured error message from the JSON body; if the body
+    // isn't JSON (or json() throws), fall back to an empty object so the `?.`
+    // chain below cleanly degrades to the generic `HTTP <status>` message.
     const body = await res.json().catch(() => ({}));
     throw new Error(body?.error?.message || `HTTP ${res.status}`);
   }
@@ -81,14 +185,43 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
  * on a non-2xx response the promise rejects with an `Error`. Real-time updates
  * arrive separately over the WebSocket (see {@link eventBus}/`useWebSocket`) -
  * this object only covers request/response REST calls.
+ *
+ * How to read this object: each top-level key (`updates`, `stats`, `sessions`,
+ * `agents`, `events`, `analytics`, `settings`, `workflows`, `pricing`, `import`,
+ * `ccConfig`, `run`, `alerts`, `webhooks`) is one backend resource area. The
+ * nested functions are the individual endpoints in that area. Because every
+ * function ultimately calls {@link request}, they all share the same auth,
+ * JSON-encoding, and error-throwing behavior documented on that helper — the
+ * per-method docs below focus on the specific route, params, and response shape.
  */
 export const api = {
+  // ───────────────────────── Updates / self-update API ─────────────────────────
   /** Self-update status: whether this install is a git clone and, if so,
-   *  whether the tracked upstream/origin remote is ahead. */
+   *  whether the tracked upstream/origin remote is ahead. Backs the "update
+   *  available" banner and the Settings "check for updates" affordance. Maps to
+   *  `server/routes/updates.js`. */
   updates: {
-    /** GET /api/updates/status - cached/last-known result. */
+    /**
+     * GET /api/updates/status - cached/last-known result.
+     *
+     * Cheap read that returns whatever the server last computed (it does not
+     * hit the network / run git itself), so the UI can render the update banner
+     * immediately on load without waiting on a `git fetch`.
+     *
+     * @returns {@link UpdateStatusPayload} describing clone-vs-tarball, current
+     *   vs upstream commit, and whether an update is available.
+     */
     status: () => request<UpdateStatusPayload>("/updates/status"),
-    /** POST /api/updates/check - force a fresh `git fetch` + comparison. */
+    /**
+     * POST /api/updates/check - force a fresh `git fetch` + comparison.
+     *
+     * Triggers the server to actually contact the remote and recompute the
+     * ahead/behind state, then returns the refreshed payload. Sends an empty
+     * JSON body because it's a POST with no parameters. Invoked when the user
+     * explicitly clicks "check for updates".
+     *
+     * @returns The freshly recomputed {@link UpdateStatusPayload}.
+     */
     check: () =>
       request<UpdateStatusPayload>("/updates/check", {
         method: "POST",
@@ -96,18 +229,58 @@ export const api = {
       }),
   },
 
+  // ──────────────────────────────── Stats API ────────────────────────────────
   /** Lightweight overview counters for the dashboard header. */
   stats: {
-    /** GET /api/stats. Sends the browser's UTC offset so `events_today` is
-     *  bucketed by the viewer's local midnight, not the server's. */
+    /**
+     * GET /api/stats. Sends the browser's UTC offset so `events_today` is
+     * bucketed by the viewer's local midnight, not the server's.
+     *
+     * The `tz_offset` query param carries `Date#getTimezoneOffset()` (minutes
+     * that local time is *behind* UTC) so the server can compute "today" in the
+     * viewer's timezone. Polled/refreshed to keep the header counters current.
+     *
+     * @returns {@link Stats} — the small set of headline counters (totals,
+     *   active counts, events-today, etc.) shown in the dashboard header.
+     */
     get: () => request<Stats>(`/stats?tz_offset=${new Date().getTimezoneOffset()}`),
   },
 
+  // ─────────────────────────────── Sessions API ───────────────────────────────
   /** Session CRUD/read, plus their nested agents/events/transcripts. */
   sessions: {
-    /** GET /api/sessions/facets - distinct `cwd` values for the filter dropdown. */
+    /**
+     * GET /api/sessions/facets - distinct `cwd` values for the filter dropdown.
+     *
+     * Powers the "working directory" filter on the Sessions list: the server
+     * returns the set of distinct project directories seen across sessions so
+     * the UI can offer them as filter options.
+     *
+     * @returns An object with `cwds`: the distinct working-directory strings.
+     */
     facets: () => request<{ cwds: string[] }>("/sessions/facets"),
-    /** GET /api/sessions - paginated, filterable, sortable session list. */
+    /**
+     * GET /api/sessions - paginated, filterable, sortable session list.
+     *
+     * Every parameter is optional and only serialized into the query string
+     * when provided, so an argument-less call returns the default first page.
+     * `q` is a free-text search; `status`/`cwd` narrow by lifecycle and project
+     * directory; `sort_by`/`sort_desc` control ordering; `limit`/`offset` page.
+     * Note the `sort_desc` guard uses `!== undefined` (so an explicit `false`
+     * is still sent), whereas `limit`/`offset` use truthiness (so `0` is
+     * treated as "unset" and omitted).
+     *
+     * @param params Optional filter/sort/pagination controls.
+     * @param params.status   Lifecycle filter (e.g. "active"/"completed").
+     * @param params.q        Free-text query matched server-side.
+     * @param params.cwd      Restrict to one working directory (see `facets`).
+     * @param params.sort_by  Column to sort by.
+     * @param params.sort_desc Descending when true; sent even when explicitly false.
+     * @param params.limit    Page size.
+     * @param params.offset   Row offset into the result set.
+     * @returns `{ sessions, total, limit, offset }` — the page plus the total
+     *   row count and the effective paging window for building pager controls.
+     */
     list: (params?: {
       status?: string;
       q?: string;
@@ -118,20 +291,33 @@ export const api = {
       offset?: number;
     }) => {
       const qs = new URLSearchParams();
+      // Only append params that were actually supplied so the URL stays minimal.
       if (params?.status) qs.set("status", params.status);
       if (params?.q) qs.set("q", params.q);
       if (params?.cwd) qs.set("cwd", params.cwd);
       if (params?.sort_by) qs.set("sort_by", params.sort_by);
+      // `!== undefined` (not truthiness) so an explicit `sort_desc: false` is preserved.
       if (params?.sort_desc !== undefined) qs.set("sort_desc", String(params.sort_desc));
       if (params?.limit) qs.set("limit", String(params.limit));
       if (params?.offset) qs.set("offset", String(params.offset));
       const queryString = qs.toString();
+      // Omit the "?" entirely when there are no params, for a clean/cacheable URL.
       return request<{ sessions: Session[]; total: number; limit: number; offset: number }>(
         `/sessions${queryString ? `?${queryString}` : ""}`
       );
     },
-    /** GET /api/sessions/:id - one session with its agents, events, and any
-     *  Workflow-tool runs launched from it. */
+    /**
+     * GET /api/sessions/:id - one session with its agents, events, and any
+     * Workflow-tool runs launched from it.
+     *
+     * The single call that hydrates the Session detail page: it returns the
+     * session record together with its child agents, its event feed, and any
+     * Workflow-tool fleet runs associated with it, so the page can render in
+     * one round-trip. The id is URL-encoded to stay safe for path use.
+     *
+     * @param id The session id.
+     * @returns `{ session, agents, events, workflows }` for the detail view.
+     */
     get: (id: string) =>
       request<{
         session: Session;
@@ -139,17 +325,57 @@ export const api = {
         events: DashboardEvent[];
         workflows: WorkflowRun[];
       }>(`/sessions/${encodeURIComponent(id)}`),
-    /** GET /api/sessions/:id/stats - per-session rollups for the detail page. */
+    /**
+     * GET /api/sessions/:id/stats - per-session rollups for the detail page.
+     *
+     * Aggregate metrics scoped to a single session (token/tool/cost rollups and
+     * similar), rendered in the session detail header/summary cards.
+     *
+     * @param id The session id.
+     * @returns {@link SessionStats} for that one session.
+     */
     stats: (id: string) => request<SessionStats>(`/sessions/${encodeURIComponent(id)}/stats`),
-    /** GET /api/sessions/:id/transcripts - the picker list of available
-     *  transcripts (main agent, subagents, compaction markers) for this session. */
+    /**
+     * GET /api/sessions/:id/transcripts - the picker list of available
+     * transcripts (main agent, subagents, compaction markers) for this session.
+     *
+     * Returns the *catalog* of transcripts attached to a session so the UI can
+     * offer a dropdown/picker (the main-agent transcript, each subagent's own
+     * transcript, and any compaction boundary markers). The actual message
+     * content for a chosen transcript is then fetched via
+     * {@link api.sessions.transcript}.
+     *
+     * @param id The session id.
+     * @returns {@link TranscriptListResult} — the selectable transcript entries.
+     */
     transcripts: (id: string) =>
       request<TranscriptListResult>(`/sessions/${encodeURIComponent(id)}/transcripts`),
-    /** GET /api/sessions/:id/transcript - a page of parsed transcript messages.
-     *  Paginate with `after`/`before` (JSONL line numbers from the previous
-     *  page's `first_line`/`last_line`) rather than `offset` for a live file.
-     *  Pass `agent_id`/`run_id` to read a subagent's transcript instead of the
-     *  main session's. */
+    /**
+     * GET /api/sessions/:id/transcript - a page of parsed transcript messages.
+     * Paginate with `after`/`before` (JSONL line numbers from the previous
+     * page's `first_line`/`last_line`) rather than `offset` for a live file.
+     * Pass `agent_id`/`run_id` to read a subagent's transcript instead of the
+     * main session's.
+     *
+     * Why line-number cursors instead of `offset`: the transcript is a JSONL
+     * file that is still being appended to while the user reads it. A numeric
+     * `offset` would shift as new lines arrive, causing skips/duplicates; the
+     * `after`/`before` line-number cursors are stable anchors into the file.
+     * `limit`/`offset` are still accepted (and forwarded) for callers that want
+     * simple windowing, but the `after`/`before` cursors are the live-safe path.
+     * `after`/`before` use a `!= null` guard so line number `0` is still sent.
+     *
+     * @param id     The session id (owning session of the transcript).
+     * @param params Optional selectors/pagination.
+     * @param params.agent_id Read a specific subagent's transcript.
+     * @param params.run_id   Read a specific Workflow-tool run's transcript.
+     * @param params.limit    Max messages to return in this page.
+     * @param params.offset   Legacy numeric offset (prefer after/before live).
+     * @param params.after    Return messages after this JSONL line number.
+     * @param params.before   Return messages before this JSONL line number.
+     * @returns {@link TranscriptResult} — the page of messages plus the
+     *   `first_line`/`last_line` cursors to feed the next/previous page.
+     */
     transcript: (
       id: string,
       params?: {
@@ -166,6 +392,7 @@ export const api = {
       if (params?.run_id) qs.set("run_id", params.run_id);
       if (params?.limit) qs.set("limit", String(params.limit));
       if (params?.offset) qs.set("offset", String(params.offset));
+      // `!= null` so a legitimate line number of 0 is forwarded (0 is falsy).
       if (params?.after != null) qs.set("after", String(params.after));
       if (params?.before != null) qs.set("before", String(params.before));
       const q = qs.toString();
@@ -175,8 +402,23 @@ export const api = {
     },
   },
 
+  // ──────────────────────────────── Agents API ────────────────────────────────
   agents: {
-    /** GET /api/agents - agent list, optionally filtered by status/session. */
+    /**
+     * GET /api/agents - agent list, optionally filtered by status/session.
+     *
+     * Returns spawned agents across the fleet, optionally narrowed to a single
+     * `session_id` and/or lifecycle `status`, with `limit`/`offset` paging.
+     * Only supplied params are serialized. Backs the global Agents view and the
+     * per-session agent lists.
+     *
+     * @param params Optional filters/paging.
+     * @param params.status     Lifecycle filter for the agents.
+     * @param params.session_id Restrict to agents of one session.
+     * @param params.limit      Page size.
+     * @param params.offset     Row offset.
+     * @returns `{ agents }` — the matching agents (note: no `total` here).
+     */
     list: (params?: { status?: string; session_id?: string; limit?: number; offset?: number }) => {
       const qs = new URLSearchParams();
       if (params?.status) qs.set("status", params.status);
@@ -188,10 +430,33 @@ export const api = {
     },
   },
 
+  // ──────────────────────────────── Events API ────────────────────────────────
   events: {
-    /** GET /api/events - the global cross-session event feed. Array-valued
-     *  filters (`event_type`/`tool_name`/`agent_id`) are OR'd server-side via
-     *  comma-joined query params. */
+    /**
+     * GET /api/events - the global cross-session event feed. Array-valued
+     * filters (`event_type`/`tool_name`/`agent_id`) are OR'd server-side via
+     * comma-joined query params.
+     *
+     * This is the firehose view across all sessions. The multi-valued filters
+     * are flattened to a single comma-separated query param each (via the local
+     * `csv` helper); the server treats the members of one param as an OR set.
+     * `session_id` is special-cased: it accepts either a single string or an
+     * array (arrays get the same comma-join treatment; a lone string is sent
+     * as-is). `q` is free-text; `from`/`to` bound the time window. `limit`/
+     * `offset` use `!= null` guards so `0` is still forwarded.
+     *
+     * @param params Optional filters/paging.
+     * @param params.event_type Event-type names to include (OR'd).
+     * @param params.tool_name  Tool names to include (OR'd).
+     * @param params.agent_id   Agent ids to include (OR'd).
+     * @param params.session_id One session id, or an array of them (OR'd).
+     * @param params.q          Free-text search across events.
+     * @param params.from       Start of the time window (server-parsed).
+     * @param params.to         End of the time window (server-parsed).
+     * @param params.limit      Page size (0 allowed/forwarded).
+     * @param params.offset     Row offset (0 allowed/forwarded).
+     * @returns `{ events, limit, offset, total }` — the page and paging metadata.
+     */
     list: (params?: {
       event_type?: string[];
       tool_name?: string[];
@@ -204,10 +469,13 @@ export const api = {
       offset?: number;
     }) => {
       const qs = new URLSearchParams();
+      // Collapse a string[] filter into a single comma-joined value, or undefined
+      // when empty/absent so it is skipped entirely below.
       const csv = (v?: string[]) => (v && v.length > 0 ? v.join(",") : undefined);
       const et = csv(params?.event_type);
       const tn = csv(params?.tool_name);
       const ag = csv(params?.agent_id);
+      // session_id may be a single id or an array; only arrays go through `csv`.
       const sid = Array.isArray(params?.session_id) ? csv(params?.session_id) : params?.session_id;
       if (et) qs.set("event_type", et);
       if (tn) qs.set("tool_name", tn);
@@ -216,6 +484,7 @@ export const api = {
       if (params?.q) qs.set("q", params.q);
       if (params?.from) qs.set("from", params.from);
       if (params?.to) qs.set("to", params.to);
+      // `!= null` so an explicit 0 page size / offset is still sent.
       if (params?.limit != null) qs.set("limit", String(params.limit));
       if (params?.offset != null) qs.set("offset", String(params.offset));
       const q = qs.toString();
@@ -226,22 +495,58 @@ export const api = {
         total: number;
       }>(`/events${q ? `?${q}` : ""}`);
     },
-    /** GET /api/events/facets - distinct event/tool names for filter dropdowns. */
+    /**
+     * GET /api/events/facets - distinct event/tool names for filter dropdowns.
+     *
+     * Supplies the option lists for the Events page's event-type and tool-name
+     * multi-selects, so the filter UI only offers values that actually occur.
+     *
+     * @returns `{ event_types, tool_names }` — the distinct values for each filter.
+     */
     facets: () => request<{ event_types: string[]; tool_names: string[] }>("/events/facets"),
   },
 
+  // ─────────────────────────────── Analytics API ──────────────────────────────
   /** Chart-oriented usage analytics for the Analytics page. */
   analytics: {
-    /** GET /api/analytics. `tz_offset` shifts the daily buckets to local time,
-     *  same convention as {@link api.stats.get}. */
+    /**
+     * GET /api/analytics. `tz_offset` shifts the daily buckets to local time,
+     * same convention as {@link api.stats.get}.
+     *
+     * Returns the full analytics bundle (time-series and aggregate breakdowns)
+     * that the Analytics page renders as charts. Because the data is grouped by
+     * day, the viewer's timezone offset is sent so the daily buckets align to
+     * the user's local midnight.
+     *
+     * @returns {@link Analytics} — the chart-ready analytics payload.
+     */
     get: () => request<Analytics>(`/analytics?tz_offset=${new Date().getTimezoneOffset()}`),
   },
 
+  // ─────────────────────────────── Settings API ───────────────────────────────
   /** Server/DB introspection and destructive maintenance operations for the
    *  Settings page (info, hooks reinstall, data reset, pricing reset, cleanup). */
   settings: {
-    /** GET /api/settings/info - DB size/pragmas, hook install status, server
-     *  process stats, and transcript-cache stats, all in one call. */
+    /**
+     * GET /api/settings/info - DB size/pragmas, hook install status, server
+     * process stats, and transcript-cache stats, all in one call.
+     *
+     * A single diagnostics snapshot for the Settings page. The large inline
+     * response type documents exactly what the server reports:
+     *   - `db`: SQLite file path/size, per-table row `counts`, the effective
+     *     `pragmas` (journal mode, synchronous level, auto-vacuum, encoding,
+     *     foreign-key enforcement, busy timeout), and short-window write
+     *     `load_stats` (5-/15-/60-minute rates).
+     *   - `hooks`: whether the dashboard's Claude Code hooks are installed, the
+     *     settings.json path, and a per-hook installed map.
+     *   - `server`: process uptime, Node version, platform/arch, live WebSocket
+     *     connection count, process memory, CPU load averages, and host memory/
+     *     cpu counts.
+     *   - `transcript_cache`: LRU cache occupancy, capacity, hit/miss counts,
+     *     and the currently-cached keys.
+     *
+     * @returns The combined diagnostics object described above.
+     */
     info: () =>
       request<{
         db: {
@@ -279,47 +584,114 @@ export const api = {
           keys: string[];
         };
       }>("/settings/info"),
-    /** Get/set the `~/.claude` root the server reads config from. */
+    /** Get/set the `~/.claude` root the server reads config from. Lets an
+     *  operator point the dashboard at a non-default Claude Code home (e.g. a
+     *  different user profile) without restarting. */
     claudeHome: {
+      /**
+       * GET /api/settings/claude-home - the currently configured Claude home path.
+       * @returns `{ claude_home }` — the absolute path the server reads config from.
+       */
       get: () => request<{ claude_home: string }>("/settings/claude-home"),
+      /**
+       * PUT /api/settings/claude-home - repoint the server at a new Claude home.
+       * @param path New absolute `~/.claude` root the server should read from.
+       * @returns `{ ok, claude_home }` — success flag and the accepted path.
+       */
       set: (path: string) =>
         request<{ ok: boolean; claude_home: string }>("/settings/claude-home", {
           method: "PUT",
           body: JSON.stringify({ path }),
         }),
     },
-    /** POST /api/settings/clear-data - DESTRUCTIVE: wipes sessions/agents/
-     *  events/etc. from the dashboard DB. Returns per-table row counts deleted. */
+    /**
+     * POST /api/settings/clear-data - DESTRUCTIVE: wipes sessions/agents/
+     * events/etc. from the dashboard DB. Returns per-table row counts deleted.
+     *
+     * Empties the dashboard's own SQLite tables (it does not touch the user's
+     * on-disk Claude Code transcripts). Guarded behind an explicit confirmation
+     * in the Settings UI. Sent as a bodyless POST.
+     *
+     * @returns `{ ok, cleared }` where `cleared` maps each table name to the
+     *   number of rows deleted from it.
+     */
     clearData: () =>
       request<{ ok: boolean; cleared: Record<string, number> }>("/settings/clear-data", {
         method: "POST",
       }),
-    /** POST /api/settings/reimport - re-scan `~/.claude/projects` and
-     *  backfill anything not already in the DB. */
+    /**
+     * POST /api/settings/reimport - re-scan `~/.claude/projects` and
+     * backfill anything not already in the DB.
+     *
+     * Additive counterpart to `clearData`: re-reads the on-disk project
+     * transcripts and inserts anything missing, leaving existing rows in place.
+     *
+     * @returns `{ ok, imported, skipped, errors }` — counts of newly imported
+     *   rows, already-present rows skipped, and parse/import failures.
+     */
     reimport: () =>
       request<{ ok: boolean; imported: number; skipped: number; errors: number }>(
         "/settings/reimport",
         { method: "POST" }
       ),
-    /** POST /api/settings/reinstall-hooks - re-write the dashboard's Claude
-     *  Code hook entries into `~/.claude/settings.json`. */
+    /**
+     * POST /api/settings/reinstall-hooks - re-write the dashboard's Claude
+     * Code hook entries into `~/.claude/settings.json`.
+     *
+     * Repairs/re-applies the hook wiring that feeds this dashboard (used when a
+     * user has edited settings.json or the install drifted). Returns the
+     * post-install hook status so the UI can reflect the new state.
+     *
+     * @returns `{ ok, hooks }` where `hooks.installed` and `hooks.hooks`
+     *   describe the resulting per-hook install state.
+     */
     reinstallHooks: () =>
       request<{ ok: boolean; hooks: { installed: boolean; hooks: Record<string, boolean> } }>(
         "/settings/reinstall-hooks",
         { method: "POST" }
       ),
-    /** POST /api/settings/reset-pricing - restore the built-in default
-     *  {@link ModelPricing} rules, discarding any custom edits. */
+    /**
+     * POST /api/settings/reset-pricing - restore the built-in default
+     * {@link ModelPricing} rules, discarding any custom edits.
+     *
+     * Wipes user-customized pricing rules and reseeds the shipped defaults;
+     * returns the resulting rule set so the Pricing UI can re-render.
+     *
+     * @returns `{ ok, pricing }` — the full default rule list now in effect.
+     */
     resetPricing: () =>
       request<{ ok: boolean; pricing: ModelPricing[] }>("/settings/reset-pricing", {
         method: "POST",
       }),
-    /** Direct download URL for GET /api/settings/export (a full DB dump);
-     *  not fetched via {@link request} since it's used as an `<a href>`. */
+    /**
+     * Direct download URL for GET /api/settings/export (a full DB dump);
+     * not fetched via {@link request} since it's used as an `<a href>`.
+     *
+     * Returns a *string*, not a promise: this is the one endpoint the client
+     * navigates to (an anchor download) rather than XHR-fetching, so no auth
+     * header can be attached here — the export route is expected to be reachable
+     * with the same-origin session the page already has.
+     *
+     * @returns The absolute-on-origin URL (`/api/settings/export`) to link to.
+     */
     exportData: () => `${BASE}/settings/export`,
-    /** POST /api/settings/cleanup - DESTRUCTIVE: marks sessions idle longer
-     *  than `abandon_hours` as "abandoned", and purges rows older than
-     *  `purge_days`. Returns counts of what was abandoned/purged. */
+    /**
+     * POST /api/settings/cleanup - DESTRUCTIVE: marks sessions idle longer
+     * than `abandon_hours` as "abandoned", and purges rows older than
+     * `purge_days`. Returns counts of what was abandoned/purged.
+     *
+     * Maintenance sweep with two independent knobs, both optional: sessions that
+     * have been idle beyond `abandon_hours` are transitioned to the "abandoned"
+     * state, and any rows older than `purge_days` are hard-deleted. The params
+     * object is always sent (it's required by the signature) so the server can
+     * apply its own defaults for any omitted field.
+     *
+     * @param params Retention thresholds.
+     * @param params.abandon_hours Idle-hours cutoff after which a session is abandoned.
+     * @param params.purge_days    Age-in-days cutoff after which rows are purged.
+     * @returns `{ ok, abandoned, purged_sessions, purged_events, purged_agents }`
+     *   — how many records each part of the sweep affected.
+     */
     cleanup: (params: { abandon_hours?: number; purge_days?: number }) =>
       request<{
         ok: boolean;
@@ -330,19 +702,51 @@ export const api = {
       }>("/settings/cleanup", { method: "POST", body: JSON.stringify(params) }),
   },
 
+  // ─────────────────────────────── Workflows API ──────────────────────────────
   /** Events-derived workflow intelligence (`get`/`session`) plus Workflow-tool
    *  fleet runs ingested from on-disk journals (`runs`/`run`). */
   workflows: {
-    /** GET /api/workflows - the full {@link WorkflowData} panel bundle,
-     *  optionally filtered to "active"/"completed" sessions. */
+    /**
+     * GET /api/workflows - the full {@link WorkflowData} panel bundle,
+     * optionally filtered to "active"/"completed" sessions.
+     *
+     * The `status` filter is only appended when it is set *and* not the sentinel
+     * "all" (which means "no filter"), keeping the default URL param-free.
+     *
+     * @param status Optional lifecycle filter; "all" (or omitted) means no filter.
+     * @returns {@link WorkflowData} — the aggregated workflow-intelligence panel.
+     */
     get: (status?: string) =>
       request<WorkflowData>(`/workflows${status && status !== "all" ? `?status=${status}` : ""}`),
-    /** GET /api/workflows/session/:id - single-session drill-in (agent tree,
-     *  tool timeline, swim lanes). */
+    /**
+     * GET /api/workflows/session/:id - single-session drill-in (agent tree,
+     * tool timeline, swim lanes).
+     *
+     * Detailed per-session workflow reconstruction derived from that session's
+     * events, powering the drill-in visualizations.
+     *
+     * @param id The session id to reconstruct.
+     * @returns {@link SessionDrillIn} — the agent tree, tool timeline, and lanes.
+     */
     session: (id: string) =>
       request<SessionDrillIn>(`/workflows/session/${encodeURIComponent(id)}`),
     // Workflow-tool runs (issue #167) - fleets ingested from on-disk journals.
-    /** GET /api/workflows/runs - paginated Workflow-tool run list. */
+    // These two endpoints cover fleets that emit no hooks: the server reads their
+    // run journals off disk (see server/lib/workflow-ingest.js) instead of the
+    // usual hook -> event pipeline, so they live under their own routes.
+    /**
+     * GET /api/workflows/runs - paginated Workflow-tool run list.
+     *
+     * Same "skip "all"" convention for `status` as {@link api.workflows.get};
+     * `limit`/`offset` use `!= null` guards so `0` is forwarded.
+     *
+     * @param params Optional filters/paging.
+     * @param params.status     Lifecycle filter; "all"/omitted means no filter.
+     * @param params.session_id Restrict to runs of one session.
+     * @param params.limit      Page size (0 allowed).
+     * @param params.offset     Row offset (0 allowed).
+     * @returns {@link WorkflowRunsResponse} — the page of runs plus paging info.
+     */
     runs: (params?: { status?: string; session_id?: string; limit?: number; offset?: number }) => {
       const qs = new URLSearchParams();
       if (params?.status && params.status !== "all") qs.set("status", params.status);
@@ -352,47 +756,104 @@ export const api = {
       const q = qs.toString();
       return request<WorkflowRunsResponse>(`/workflows/runs${q ? `?${q}` : ""}`);
     },
-    /** GET /api/workflows/runs/:runId - one run with its inner agents/events. */
+    /**
+     * GET /api/workflows/runs/:runId - one run with its inner agents/events.
+     *
+     * The Workflow-tool analog of {@link api.sessions.get}: expands a single
+     * ingested run into its nested agents and events for a detail view.
+     *
+     * @param runId The Workflow-tool run id.
+     * @returns {@link WorkflowRunDetail} — the run plus its agents and events.
+     */
     run: (runId: string) =>
       request<WorkflowRunDetail>(`/workflows/runs/${encodeURIComponent(runId)}`),
   },
 
+  // ─────────────────────────────── Pricing API ────────────────────────────────
   /** {@link ModelPricing} rule CRUD, plus computed cost totals. */
   pricing: {
-    /** GET /api/pricing - all configured pricing rules. */
+    /**
+     * GET /api/pricing - all configured pricing rules.
+     * @returns `{ pricing }` — the full list of {@link ModelPricing} rules.
+     */
     list: () => request<{ pricing: ModelPricing[] }>("/pricing"),
-    /** PUT /api/pricing - create a new rule or overwrite the one matching
-     *  `data.model_pattern` (the primary key). */
+    /**
+     * PUT /api/pricing - create a new rule or overwrite the one matching
+     * `data.model_pattern` (the primary key).
+     *
+     * Upsert semantics keyed on `model_pattern`: an existing rule with the same
+     * pattern is replaced, otherwise a new one is created. The `updated_at`
+     * field is server-managed, hence it is `Omit`ted from the argument type.
+     *
+     * @param data A {@link ModelPricing} rule minus its server-set `updated_at`.
+     * @returns `{ pricing }` — the single upserted rule as persisted.
+     */
     upsert: (data: Omit<ModelPricing, "updated_at">) =>
       request<{ pricing: ModelPricing }>("/pricing", {
         method: "PUT",
         body: JSON.stringify(data),
       }),
-    /** DELETE /api/pricing/:pattern - remove a rule; usage matching it then
-     *  falls through to a less-specific rule or `unpriced_models`. */
+    /**
+     * DELETE /api/pricing/:pattern - remove a rule; usage matching it then
+     * falls through to a less-specific rule or `unpriced_models`.
+     *
+     * The pattern is URL-encoded because model patterns can contain characters
+     * (slashes, brackets) that are unsafe in a path segment.
+     *
+     * @param pattern The `model_pattern` primary key of the rule to delete.
+     * @returns `{ ok }` — success flag.
+     */
     delete: (pattern: string) =>
       request<{ ok: boolean }>(`/pricing/${encodeURIComponent(pattern)}`, {
         method: "DELETE",
       }),
-    /** GET /api/pricing/cost - total cost across every session, priced with
-     *  each day's rate (respects time-limited intro pricing). */
+    /**
+     * GET /api/pricing/cost - total cost across every session, priced with
+     * each day's rate (respects time-limited intro pricing).
+     *
+     * Because pricing rules can carry date-bounded intro rates, the server
+     * prices each day's usage with that day's effective rate; `tz_offset` keeps
+     * the day boundaries aligned to the viewer's timezone.
+     *
+     * @returns {@link CostResult} — the aggregate cost breakdown across sessions.
+     */
     totalCost: () =>
       request<CostResult>(`/pricing/cost?tz_offset=${new Date().getTimezoneOffset()}`),
-    /** GET /api/pricing/cost/:sessionId - cost for one session, priced as of
-     *  the session's start date. */
+    /**
+     * GET /api/pricing/cost/:sessionId - cost for one session, priced as of
+     * the session's start date.
+     *
+     * Single-session cost, priced using the rate in effect on that session's
+     * start date. `tz_offset` again aligns date handling to the viewer.
+     *
+     * @param sessionId The session to price.
+     * @returns {@link CostResult} — the cost breakdown for that one session.
+     */
     sessionCost: (sessionId: string) =>
       request<CostResult>(
         `/pricing/cost/${encodeURIComponent(sessionId)}?tz_offset=${new Date().getTimezoneOffset()}`
       ),
   },
 
+  // ──────────────────────────────── Import API ────────────────────────────────
   /** Transcript import: on-disk scan/rescan, an explicit path scan, or a
    *  browser file upload - all three converge on the same {@link ImportResult}
    *  shape and stream progress via the `import.progress` WS message. */
   import: {
-    /** GET /api/import/guide - platform-specific instructions and constraints
-     *  (default projects dir, supported extensions, upload limits) shown on
-     *  first run / in the Import wizard. */
+    /**
+     * GET /api/import/guide - platform-specific instructions and constraints
+     * (default projects dir, supported extensions, upload limits) shown on
+     * first run / in the Import wizard.
+     *
+     * Returns everything the Import wizard needs to render its guidance without
+     * hard-coding platform details in the client: the OS `platform`, the
+     * default projects directory (raw + display form + existence + a quick
+     * `{ projects, jsonl_files }` count), the recommended `archive_command`,
+     * the accepted file extensions, upload size/count caps, and an ordered list
+     * of wizard `steps`.
+     *
+     * @returns The import-guide payload described above.
+     */
     guide: () =>
       request<{
         platform: string;
@@ -406,22 +867,59 @@ export const api = {
         max_upload_files: number;
         steps: { id: string; title: string; body: string }[];
       }>("/import/guide"),
-    /** POST /api/import/rescan - re-scan the default projects directory. */
+    /**
+     * POST /api/import/rescan - re-scan the default projects directory.
+     *
+     * Kicks off an import over the server's default `~/.claude/projects` dir.
+     * Progress is pushed live over the `import.progress` WebSocket message; the
+     * returned {@link ImportResult} is the final tally (`source: "default"`).
+     *
+     * @returns {@link ImportResult} — the completed-scan summary.
+     */
     rescan: () => request<ImportResult>("/import/rescan", { method: "POST" }),
-    /** POST /api/import/scan-path - scan an arbitrary directory for
-     *  Claude Code project transcripts. */
+    /**
+     * POST /api/import/scan-path - scan an arbitrary directory for
+     * Claude Code project transcripts.
+     *
+     * Like `rescan` but over a user-provided directory (`source: "path"`),
+     * useful for importing an archive extracted somewhere non-default.
+     *
+     * @param path Absolute directory to scan for transcripts.
+     * @returns {@link ImportResult} — the completed-scan summary for that path.
+     */
     scanPath: (path: string) =>
       request<ImportResult>("/import/scan-path", {
         method: "POST",
         body: JSON.stringify({ path }),
       }),
-    /** POST /api/import/upload (multipart) - import a set of user-selected
-     *  transcript files. Bypasses {@link request} to use `FormData`. */
+    /**
+     * POST /api/import/upload (multipart) - import a set of user-selected
+     * transcript files. Bypasses {@link request} to use `FormData`.
+     *
+     * This is one of the two deliberate escapes from {@link request}: a
+     * `multipart/form-data` body must be built with `FormData` and must let the
+     * browser set its own `Content-Type` (with the multipart boundary), so this
+     * hand-rolls `fetch` and reproduces `request`'s error-normalization inline.
+     * Each selected `File` is appended under the field name "files" (preserving
+     * its original filename). Result `source` is "upload".
+     *
+     * Note: no auth token is attached here (unlike {@link request}); the upload
+     * route is used in the local/zero-config import flow.
+     *
+     * @param files The user-selected transcript files to upload.
+     * @returns {@link ImportResult} — the completed-upload summary.
+     * @throws {Error} On a non-2xx response, mirroring {@link request}: the
+     *   server's `error.message` if present, else `HTTP <status>`.
+     */
     upload: async (files: File[]): Promise<ImportResult> => {
       const form = new FormData();
+      // Append each file under the repeated "files" field, keeping its filename.
       for (const f of files) form.append("files", f, f.name);
+      // Do NOT set Content-Type manually: the browser adds the multipart boundary.
       const res = await fetch(`${BASE}/import/upload`, { method: "POST", body: form });
       if (!res.ok) {
+        // Same error-shaping contract as request(), duplicated because this call
+        // intentionally does not route through the JSON wrapper.
         const body = await res.json().catch(() => ({}));
         throw new Error(body?.error?.message || `HTTP ${res.status}`);
       }
@@ -429,111 +927,277 @@ export const api = {
     },
   },
 
+  // ─────────────────────────────── CC-Config API ──────────────────────────────
   /** Read/write access to on-disk Claude Code configuration - skills, agents,
    *  commands, output styles, plugins, MCP servers, hooks, settings.json,
    *  CLAUDE.md/auto-memory, marketplaces, keybindings, and the statusline
    *  script - for the dashboard's "CC Config" explorer/editor pages. */
   ccConfig: {
-    /** GET /api/cc-config/overview - counts of every artifact kind, for the
-     *  explorer's landing page. */
+    /**
+     * GET /api/cc-config/overview - counts of every artifact kind, for the
+     * explorer's landing page.
+     * @returns {@link CcOverview} — filesystem roots plus per-kind counts.
+     */
     overview: () => request<CcOverview>("/cc-config/overview"),
-    /** GET /api/cc-config/skills - user and/or project SKILL.md files. */
+    /**
+     * GET /api/cc-config/skills - user and/or project SKILL.md files.
+     *
+     * The optional `scope` is appended as `?scope=` only when provided; omitting
+     * it lets the server apply its default scope. Same pattern for the sibling
+     * list endpoints below (`agents`, `commands`, `outputStyles`).
+     *
+     * @param scope Optional {@link CcScope} ("user"|"project"|"all") filter.
+     * @returns `{ items }` — the {@link CcMdItem} summaries for each skill.
+     */
     skills: (scope?: CcScope) =>
       request<{ items: CcMdItem[] }>(`/cc-config/skills${scope ? `?scope=${scope}` : ""}`),
-    /** GET /api/cc-config/agents - user and/or project subagent definitions. */
+    /**
+     * GET /api/cc-config/agents - user and/or project subagent definitions.
+     * @param scope Optional {@link CcScope} filter.
+     * @returns `{ items }` — {@link CcMdItem} summaries for each subagent.
+     */
     agents: (scope?: CcScope) =>
       request<{ items: CcMdItem[] }>(`/cc-config/agents${scope ? `?scope=${scope}` : ""}`),
-    /** GET /api/cc-config/commands - user and/or project slash commands. */
+    /**
+     * GET /api/cc-config/commands - user and/or project slash commands.
+     * @param scope Optional {@link CcScope} filter.
+     * @returns `{ items }` — {@link CcMdItem} summaries for each command.
+     */
     commands: (scope?: CcScope) =>
       request<{ items: CcMdItem[] }>(`/cc-config/commands${scope ? `?scope=${scope}` : ""}`),
-    /** GET /api/cc-config/output-styles. */
+    /**
+     * GET /api/cc-config/output-styles.
+     * @param scope Optional {@link CcScope} filter.
+     * @returns `{ items }` — {@link CcMdItem} summaries for each output style.
+     */
     outputStyles: (scope?: CcScope) =>
       request<{ items: CcMdItem[] }>(`/cc-config/output-styles${scope ? `?scope=${scope}` : ""}`),
-    /** GET /api/cc-config/plugins - installed marketplace plugins and what
-     *  each one contributes (skills/agents/commands/hooks counts). */
+    /**
+     * GET /api/cc-config/plugins - installed marketplace plugins and what
+     * each one contributes (skills/agents/commands/hooks counts).
+     * @returns {@link CcPluginsResponse} — the manifest path/status plus plugins.
+     */
     plugins: () => request<CcPluginsResponse>("/cc-config/plugins"),
-    /** GET /api/cc-config/mcp - configured MCP servers, user and project-scoped. */
+    /**
+     * GET /api/cc-config/mcp - configured MCP servers, user and project-scoped.
+     * @returns {@link CcMcpResponse} — servers split into `user`/`projectScoped`.
+     */
     mcp: () => request<CcMcpResponse>("/cc-config/mcp"),
-    /** GET /api/cc-config/hooks - hook entries from every settings.json layer. */
+    /**
+     * GET /api/cc-config/hooks - hook entries from every settings.json layer.
+     * @returns `{ items }` — one {@link CcHookSource} per settings layer.
+     */
     hooks: () => request<{ items: CcHookSource[] }>("/cc-config/hooks"),
-    /** GET /api/cc-config/settings - raw settings.json files by scope. */
+    /**
+     * GET /api/cc-config/settings - raw settings.json files by scope.
+     * @returns `{ items }` — one {@link CcSettingsSource} per scope layer.
+     */
     settings: () => request<{ items: CcSettingsSource[] }>("/cc-config/settings"),
-    /** GET /api/cc-config/memory - CLAUDE.md files plus per-project auto-memory. */
+    /**
+     * GET /api/cc-config/memory - CLAUDE.md files plus per-project auto-memory.
+     * @returns `{ items }` — {@link CcMemoryItem}s for CLAUDE.md + auto-memory.
+     */
     memory: () => request<{ items: CcMemoryItem[] }>("/cc-config/memory"),
-    /** GET /api/cc-config/file - raw contents of one config file by absolute path. */
+    /**
+     * GET /api/cc-config/file - raw contents of one config file by absolute path.
+     *
+     * The absolute path is passed as a URL-encoded `path` query param (not a
+     * path segment) so arbitrary filesystem paths survive intact.
+     *
+     * @param absPath Absolute path of the config file to read.
+     * @returns {@link CcFileResponse} — file text (possibly truncated) + metadata.
+     */
     file: (absPath: string) =>
       request<CcFileResponse>(`/cc-config/file?path=${encodeURIComponent(absPath)}`),
-    /** PUT /api/cc-config/file - create/overwrite a config artifact; the
-     *  server writes a backup of any previous content first. */
+    /**
+     * PUT /api/cc-config/file - create/overwrite a config artifact; the
+     * server writes a backup of any previous content first.
+     *
+     * The write is always preceded server-side by a timestamped backup (see
+     * {@link api.ccConfig.backups}), so edits are reversible.
+     *
+     * @param args {@link CcWriteArgs} — scope/type/name/content (+project for auto-memory).
+     * @returns {@link CcMutationResult} — the written path, backup path, and
+     *   whether a new file was `created`.
+     */
     write: (args: CcWriteArgs) =>
       request<CcMutationResult>("/cc-config/file", {
         method: "PUT",
         body: JSON.stringify(args),
       }),
-    /** DELETE /api/cc-config/file - remove a config artifact (also backed up). */
+    /**
+     * DELETE /api/cc-config/file - remove a config artifact (also backed up).
+     *
+     * Note the DELETE carries a JSON body ({@link CcDeleteArgs}) identifying the
+     * artifact by scope/type/name rather than encoding it in the URL.
+     *
+     * @param args {@link CcDeleteArgs} — which artifact to delete.
+     * @returns {@link CcMutationResult} — the deleted path and its backup path.
+     */
     delete: (args: CcDeleteArgs) =>
       request<CcMutationResult>("/cc-config/file", {
         method: "DELETE",
         body: JSON.stringify(args),
       }),
-    /** GET /api/cc-config/marketplaces - registered plugin marketplaces. */
+    /**
+     * GET /api/cc-config/marketplaces - registered plugin marketplaces.
+     * @returns {@link CcMarketplacesResponse} — the registry path/status + items.
+     */
     marketplaces: () => request<CcMarketplacesResponse>("/cc-config/marketplaces"),
-    /** GET /api/cc-config/keybindings - parsed `keybindings.json`. */
+    /**
+     * GET /api/cc-config/keybindings - parsed `keybindings.json`.
+     * @returns {@link CcKeybindings} — grouped key/action bindings + file metadata.
+     */
     keybindings: () => request<CcKeybindings>("/cc-config/keybindings"),
-    /** GET /api/cc-config/statusline - active statusline config + scripts. */
+    /**
+     * GET /api/cc-config/statusline - active statusline config + scripts.
+     * @returns {@link CcStatusline} — the active config plus discovered scripts.
+     */
     statusline: () => request<CcStatusline>("/cc-config/statusline"),
-    /** GET /api/cc-config/hook-scripts - shell scripts referenced by hooks. */
+    /**
+     * GET /api/cc-config/hook-scripts - shell scripts referenced by hooks.
+     * @returns {@link CcHookScripts} — the hooks dir and the scripts found in it.
+     */
     hookScripts: () => request<CcHookScripts>("/cc-config/hook-scripts"),
-    /** GET /api/cc-config/backups - timestamped backups written by `write`/
-     *  `delete`, optionally filtered by scope/artifact type. */
+    /**
+     * GET /api/cc-config/backups - timestamped backups written by `write`/
+     * `delete`, optionally filtered by scope/artifact type.
+     *
+     * Delegates query-string building to the module-level
+     * {@link requestBackupsHelper} (extracted purely so its logic is
+     * independently unit-referenceable).
+     *
+     * @param params Optional `{ scope, type }` filter.
+     * @returns `{ items }` — the matching {@link CcBackup} entries.
+     */
     backups: (params?: { scope?: "user" | "project"; type?: CcArtifactType }) =>
       requestBackupsHelper(params),
   },
 
+  // ────────────────────────────────── Run API ─────────────────────────────────
   /** Spawn/manage headless or conversational `claude` CLI child processes
    *  launched from the dashboard's Run page, and stream their output. */
   run: {
-    /** GET /api/run - currently tracked runs (in-memory handles) plus
-     *  concurrency limits. */
+    /**
+     * GET /api/run - currently tracked runs (in-memory handles) plus
+     * concurrency limits.
+     * @returns {@link RunListResponse} — live handles + `maxConcurrent`/`activeCount`.
+     */
     list: () => request<RunListResponse>("/run"),
-    /** GET /api/run/history - persisted run history from the `dashboard_runs`
-     *  table, including runs whose in-memory handle has since been reaped. */
+    /**
+     * GET /api/run/history - persisted run history from the `dashboard_runs`
+     * table, including runs whose in-memory handle has since been reaped.
+     *
+     * `limit` defaults to 50 when the caller omits it and is always sent as a
+     * query param (this endpoint has no other params).
+     *
+     * @param limit Max history rows to return (default 50).
+     * @returns `{ items }` — {@link DashboardRunHistoryItem} rows, newest-first.
+     */
     history: (limit = 50) =>
       request<{ items: DashboardRunHistoryItem[] }>(`/run/history?limit=${limit}`),
-    /** GET /api/run/binary - whether a `claude` executable was found on PATH. */
+    /**
+     * GET /api/run/binary - whether a `claude` executable was found on PATH.
+     *
+     * Lets the Run page disable/enable the "start" affordance and show where the
+     * CLI resolved from (or that it's missing).
+     *
+     * @returns `{ found, path }` — whether a binary was located and its path.
+     */
     binary: () => request<{ found: boolean; path: string | null }>("/run/binary"),
-    /** GET /api/run/cwds - suggested working directories for the cwd picker. */
+    /**
+     * GET /api/run/cwds - suggested working directories for the cwd picker.
+     * @returns `{ items }` — {@link CwdSuggestion} entries (dashboard/home/recent).
+     */
     cwds: () => request<{ items: CwdSuggestion[] }>("/run/cwds"),
-    /** GET /api/run/files - path-completion suggestions under `cwd`, filtered
-     *  by an optional query fragment `q`. */
+    /**
+     * GET /api/run/files - path-completion suggestions under `cwd`, filtered
+     * by an optional query fragment `q`.
+     *
+     * Backs the file/@-mention autocomplete when composing a run prompt: `cwd`
+     * is always sent; `q` is appended only when non-empty to narrow matches.
+     *
+     * @param cwd The directory to complete paths within.
+     * @param q   Optional partial fragment to filter suggestions by.
+     * @returns `{ items }` — matching path strings under `cwd`.
+     */
     files: (cwd: string, q?: string) => {
       const qs = new URLSearchParams({ cwd });
       if (q) qs.set("q", q);
       return request<{ items: string[] }>(`/run/files?${qs.toString()}`);
     },
-    /** POST /api/run - spawn a new `claude` child process. */
+    /**
+     * POST /api/run - spawn a new `claude` child process.
+     *
+     * Sends {@link RunStartArgs} (prompt, mode, and optional cwd/model/
+     * permission-mode/resume/effort). The server spawns the CLI and returns the
+     * initial {@link RunHandle}; subsequent output is streamed over the
+     * `run_stream` WebSocket message rather than this response.
+     *
+     * @param args The spawn parameters.
+     * @returns {@link RunHandle} — the freshly created run's handle.
+     */
     start: (args: RunStartArgs) =>
       request<RunHandle>("/run", { method: "POST", body: JSON.stringify(args) }),
-    /** GET /api/run/:id - one run's current handle; pass `envelopes: true` to
-     *  also include its buffered stream-json envelopes (for a page refresh
-     *  mid-run, since the WS `run_stream` history isn't otherwise replayed). */
+    /**
+     * GET /api/run/:id - one run's current handle; pass `envelopes: true` to
+     * also include its buffered stream-json envelopes (for a page refresh
+     * mid-run, since the WS `run_stream` history isn't otherwise replayed).
+     *
+     * The `envelopes` flag is translated to `?envelopes=1`. Use it when
+     * re-hydrating the Run page after a reload: the WebSocket only pushes *new*
+     * envelopes, so the buffered ones must be pulled once to backfill the view.
+     *
+     * @param id   The run id.
+     * @param opts Optional `{ envelopes }` — include buffered stream-json envelopes.
+     * @returns {@link RunHandle} — the run's handle (with `envelopes` when requested).
+     */
     get: (id: string, opts?: { envelopes?: boolean }) =>
       request<RunHandle>(`/run/${encodeURIComponent(id)}${opts?.envelopes ? "?envelopes=1" : ""}`),
-    /** POST /api/run/:id/message - write `text` to the run's stdin (conversation
-     *  mode only); acked via the `run_input_ack` WS message. */
+    /**
+     * POST /api/run/:id/message - write `text` to the run's stdin (conversation
+     * mode only); acked via the `run_input_ack` WS message.
+     *
+     * Only meaningful for a run started in "conversation" mode (stdin left
+     * open). The HTTP response returns just the `messageId`; the actual
+     * delivery/echo is confirmed asynchronously over the WebSocket.
+     *
+     * @param id   The run id to send input to.
+     * @param text The user's follow-up message written to the CLI's stdin.
+     * @returns `{ messageId }` — id correlating this input with its `run_input_ack`.
+     */
     send: (id: string, text: string) =>
       request<{ messageId: string }>(`/run/${encodeURIComponent(id)}/message`, {
         method: "POST",
         body: JSON.stringify({ text }),
       }),
-    /** DELETE /api/run/:id - forcibly terminate a running process. */
+    /**
+     * DELETE /api/run/:id - forcibly terminate a running process.
+     *
+     * @param id The run id to kill.
+     * @returns `{ ok: true }` — acknowledgement that termination was requested.
+     */
     kill: (id: string) =>
       request<{ ok: true }>(`/run/${encodeURIComponent(id)}`, { method: "DELETE" }),
   },
 
+  // ────────────────────────────────── Alerts API ──────────────────────────────
   /** Alert rule CRUD plus the fired-alert feed and acknowledgement. */
   alerts: {
-    /** GET /api/alerts - fired-alert feed, newest first. */
+    /**
+     * GET /api/alerts - fired-alert feed, newest first.
+     *
+     * `unacked` is sent as the literal string "true" only when truthy (to show
+     * just the outstanding alerts); `limit`/`offset` page the feed and are only
+     * appended when set.
+     *
+     * @param params Optional filters/paging.
+     * @param params.unacked When true, return only unacknowledged alerts.
+     * @param params.limit   Page size.
+     * @param params.offset  Row offset.
+     * @returns `{ alerts, total, unacked, limit, offset }` — the page plus the
+     *   total and outstanding-unacked counts for badge rendering.
+     */
     list: (params?: { unacked?: boolean; limit?: number; offset?: number }) => {
       const qs = new URLSearchParams();
       if (params?.unacked) qs.set("unacked", "true");
@@ -548,14 +1212,41 @@ export const api = {
         offset: number;
       }>(`/alerts${q ? `?${q}` : ""}`);
     },
-    /** POST /api/alerts/:id/ack - acknowledge a single fired alert. */
+    /**
+     * POST /api/alerts/:id/ack - acknowledge a single fired alert.
+     *
+     * Note the id is a numeric alert-event id interpolated directly into the
+     * path (fired-alert ids are numeric, unlike the string ids used elsewhere).
+     *
+     * @param id Numeric id of the fired alert to acknowledge.
+     * @returns `{ alert }` — the updated {@link AlertEvent} (now acknowledged).
+     */
     ack: (id: number) => request<{ alert: AlertEvent }>(`/alerts/${id}/ack`, { method: "POST" }),
-    /** POST /api/alerts/ack-all - acknowledge every unacked alert at once. */
+    /**
+     * POST /api/alerts/ack-all - acknowledge every unacked alert at once.
+     * @returns `{ ok: true, acknowledged }` — count of alerts just acknowledged.
+     */
     ackAll: () =>
       request<{ ok: true; acknowledged: number }>("/alerts/ack-all", { method: "POST" }),
-    /** CRUD for the alert rule definitions themselves (not the fired events). */
+    /** CRUD for the alert rule definitions themselves (not the fired events).
+     *  Rules describe *when* to fire; the endpoints above deal with alerts that
+     *  have already fired. */
     rules: {
+      /**
+       * GET /api/alerts/rules - list every configured alert rule.
+       * @returns `{ rules }` — the full set of {@link AlertRule} definitions.
+       */
       list: () => request<{ rules: AlertRule[] }>("/alerts/rules"),
+      /**
+       * POST /api/alerts/rules - create a new alert rule.
+       *
+       * `rule_type` and `config` are typed against {@link AlertRule} so the body
+       * matches the rule kind; `enabled` and `cooldown_seconds` are optional and
+       * server-defaulted when omitted.
+       *
+       * @param rule The new rule definition (name, type, config, optional flags).
+       * @returns `{ rule }` — the created {@link AlertRule} as persisted.
+       */
       create: (rule: {
         name: string;
         rule_type: AlertRule["rule_type"];
@@ -567,6 +1258,17 @@ export const api = {
           method: "POST",
           body: JSON.stringify(rule),
         }),
+      /**
+       * PATCH /api/alerts/rules/:id - partially update an existing rule.
+       *
+       * Accepts any subset of the mutable fields (`name`/`config`/`enabled`/
+       * `cooldown_seconds`); unspecified fields are left unchanged. Note
+       * `rule_type` is intentionally not patchable (a rule's kind is fixed).
+       *
+       * @param id    The rule id to update.
+       * @param patch Partial set of mutable fields to change.
+       * @returns `{ rule }` — the updated {@link AlertRule}.
+       */
       update: (
         id: string,
         patch: Partial<Pick<AlertRule, "name" | "config" | "enabled" | "cooldown_seconds">>
@@ -575,20 +1277,50 @@ export const api = {
           method: "PATCH",
           body: JSON.stringify(patch),
         }),
+      /**
+       * DELETE /api/alerts/rules/:id - remove an alert rule.
+       * @param id The rule id to delete.
+       * @returns `{ ok: true }` — success flag.
+       */
       remove: (id: string) =>
         request<{ ok: true }>(`/alerts/rules/${encodeURIComponent(id)}`, { method: "DELETE" }),
     },
   },
 
+  // ───────────────────────────────── Webhooks API ─────────────────────────────
   /** Outbound webhook target CRUD, provider metadata, test sends, and the
    *  per-target delivery log. */
   webhooks: {
-    /** GET /api/webhooks - configured targets (secrets/URLs redacted). */
+    /**
+     * GET /api/webhooks - configured targets (secrets/URLs redacted).
+     *
+     * Sensitive fields (secret, and often the full URL) are redacted server-side
+     * before being returned to the UI list.
+     *
+     * @returns `{ targets }` — the configured {@link WebhookTarget}s (redacted).
+     */
     list: () => request<{ targets: WebhookTarget[] }>("/webhooks"),
-    /** GET /api/webhooks/providers - supported provider types and their
-     *  form-field schemas, for the "Add webhook" dialog. */
+    /**
+     * GET /api/webhooks/providers - supported provider types and their
+     * form-field schemas, for the "Add webhook" dialog.
+     *
+     * Drives a dynamic form: each {@link WebhookProvider} advertises which
+     * fields (url/secret/headers/config) it needs so the dialog can render the
+     * right inputs per provider type.
+     *
+     * @returns `{ providers }` — the supported provider descriptors.
+     */
     providers: () => request<{ providers: WebhookProvider[] }>("/webhooks/providers"),
-    /** POST /api/webhooks - create a new target. */
+    /**
+     * POST /api/webhooks - create a new target.
+     *
+     * `type` selects the {@link WebhookType} provider; `url`/`secret`/`headers`/
+     * `config` supply provider-specific delivery settings; `rule_ids` scopes the
+     * target to fire only for those alert rules (all optional except name/type).
+     *
+     * @param target The new target definition.
+     * @returns `{ target }` — the created {@link WebhookTarget} (redacted).
+     */
     create: (target: {
       name: string;
       type: WebhookType;
@@ -603,6 +1335,17 @@ export const api = {
         method: "POST",
         body: JSON.stringify(target),
       }),
+    /**
+     * PATCH /api/webhooks/:id - partially update a target.
+     *
+     * All fields optional; only supplied ones change. `secret` accepts `null`
+     * (distinct from omitted) to explicitly clear a stored secret. `type` is not
+     * patchable here — a target's provider kind is fixed at creation.
+     *
+     * @param id    The target id to update.
+     * @param patch Partial set of fields to change (`secret: null` clears it).
+     * @returns `{ target }` — the updated {@link WebhookTarget} (redacted).
+     */
     update: (
       id: string,
       patch: {
@@ -619,14 +1362,36 @@ export const api = {
         method: "PATCH",
         body: JSON.stringify(patch),
       }),
-    /** DELETE /api/webhooks/:id - remove a target. */
+    /**
+     * DELETE /api/webhooks/:id - remove a target.
+     * @param id The target id to delete.
+     * @returns `{ ok: true }` — success flag.
+     */
     remove: (id: string) =>
       request<{ ok: true }>(`/webhooks/${encodeURIComponent(id)}`, { method: "DELETE" }),
-    /** POST /api/webhooks/:id/test - send a synchronous test payload; not
-     *  recorded in the delivery log. */
+    /**
+     * POST /api/webhooks/:id/test - send a synchronous test payload; not
+     * recorded in the delivery log.
+     *
+     * Fires an immediate test delivery so the user can validate credentials/URL
+     * from the config dialog; the result is returned inline and deliberately
+     * excluded from the persisted delivery history.
+     *
+     * @param id The target id to test.
+     * @returns {@link WebhookTestResult} — the synchronous send outcome.
+     */
     test: (id: string) =>
       request<WebhookTestResult>(`/webhooks/${encodeURIComponent(id)}/test`, { method: "POST" }),
-    /** GET /api/webhooks/:id/deliveries - paginated delivery history for one target. */
+    /**
+     * GET /api/webhooks/:id/deliveries - paginated delivery history for one target.
+     *
+     * The persisted log of real (non-test) deliveries for one target, paged with
+     * `limit`/`offset` (appended only when provided).
+     *
+     * @param id     The target id whose history to read.
+     * @param params Optional `{ limit, offset }` paging.
+     * @returns `{ deliveries, limit, offset }` — the page of {@link WebhookDelivery}s.
+     */
     deliveries: (id: string, params?: { limit?: number; offset?: number }) => {
       const qs = new URLSearchParams();
       if (params?.limit) qs.set("limit", String(params.limit));
@@ -639,8 +1404,18 @@ export const api = {
   },
 };
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Module-level helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
 /** Backs `api.ccConfig.backups` - a plain function (not inlined into the `api`
- *  object literal) purely so its query-building logic can be unit-referenced. */
+ *  object literal) purely so its query-building logic can be unit-referenced.
+ *
+ *  Builds an optional `?scope=&type=` query string (each part appended only when
+ *  present) and calls {@link request} for GET /api/cc-config/backups.
+ *
+ *  @param params Optional `{ scope, type }` filter for the backup listing.
+ *  @returns `{ items }` — the matching {@link CcBackup} entries. */
 function requestBackupsHelper(params?: { scope?: "user" | "project"; type?: CcArtifactType }) {
   const qs = new URLSearchParams();
   if (params?.scope) qs.set("scope", params.scope);
@@ -648,6 +1423,14 @@ function requestBackupsHelper(params?: { scope?: "user" | "project"; type?: CcAr
   const q = qs.toString();
   return request<{ items: CcBackup[] }>(`/cc-config/backups${q ? `?${q}` : ""}`);
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CC-Config types — request/response shapes for the "CC Config" explorer/editor.
+// These describe on-disk Claude Code configuration artifacts (skills, agents,
+// commands, output styles, memory, plugins, MCP servers, hooks, settings,
+// marketplaces, keybindings, statusline) as surfaced by the /api/cc-config/*
+// routes. They live in this client because they are specific to the explorer UI.
+// ─────────────────────────────────────────────────────────────────────────────
 
 /** Kind of Claude Code config artifact manageable via `api.ccConfig.write`/
  *  `delete` - each maps to a distinct on-disk location under `.claude/`. */
@@ -673,7 +1456,8 @@ export interface CcWriteArgs {
   project?: string;
 }
 
-/** Body for DELETE /api/cc-config/file - remove one artifact. */
+/** Body for DELETE /api/cc-config/file - remove one artifact. Mirrors the
+ *  identifying fields of {@link CcWriteArgs} (minus `content`). */
 export interface CcDeleteArgs {
   scope: "user" | "project" | "auto-memory";
   type: CcArtifactType;
@@ -717,7 +1501,9 @@ export interface CcBackup {
 export type CcScope = "user" | "project" | "all";
 
 /** One markdown-based config artifact (skill/agent/command/output-style),
- *  as summarized by the `ccConfig` list endpoints. */
+ *  as summarized by the `ccConfig` list endpoints. The list endpoints return
+ *  a lightweight summary (frontmatter + a preview) rather than full contents;
+ *  the full text is fetched on demand via {@link api.ccConfig.file}. */
 export interface CcMdItem {
   scope: "user" | "project";
   /** Artifact name, derived from its filename/frontmatter. */
@@ -791,7 +1577,10 @@ export interface CcPluginsResponse {
   plugins: CcPlugin[];
 }
 
-/** One configured MCP server entry, from GET /api/cc-config/mcp. */
+/** One configured MCP server entry, from GET /api/cc-config/mcp. Fields are
+ *  conditionally present depending on `kind` (stdio vs http). Note that only
+ *  env-var/header *names* are surfaced, never their values, to avoid leaking
+ *  secrets into the dashboard. */
 export interface CcMcpServer {
   name: string;
   /** Which config file this entry came from (e.g. a `.mcp.json` path). */
@@ -980,6 +1769,12 @@ export interface CcHookScripts {
   items: { name: string; file: string; size: number; mtime: number }[];
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Run types — request/response shapes for the Run page's `claude` process
+// spawning/management. `RunMode`/`RunStatus`/`PermissionMode`/`EffortLevel`
+// mirror the CLI's own vocabulary so the dashboard can drive the CLI faithfully.
+// ─────────────────────────────────────────────────────────────────────────────
+
 /** "headless" runs to completion unattended and streams only output;
  *  "conversation" keeps stdin open so the user can send follow-up messages. */
 export type RunMode = "headless" | "conversation";
@@ -1008,7 +1803,10 @@ export interface RunStartArgs {
 }
 
 /** In-memory (or freshly-fetched) handle for one spawned `claude` process,
- *  from POST/GET /api/run - the live counterpart to {@link DashboardRunHistoryItem}. */
+ *  from POST/GET /api/run - the live counterpart to {@link DashboardRunHistoryItem}.
+ *  Where {@link DashboardRunHistoryItem} is the persisted DB row (snake_case,
+ *  survives handle reaping), this is the richer live handle (camelCase, carries
+ *  argv/tails/envelope counters) that only exists while the server tracks it. */
 export interface RunHandle {
   id: string;
   /** OS process id; null before the process has actually spawned. */
@@ -1055,6 +1853,10 @@ export interface RunListResponse {
  * A row from the persistent `dashboard_runs` sqlite table - every run ever
  * spawned via /api/run, including completed / errored / killed ones long
  * after the in-memory handle has been reaped.
+ *
+ * Field names are snake_case here (they mirror the DB columns) whereas the live
+ * {@link RunHandle} uses camelCase; the `isLive` flag bridges the two by telling
+ * the UI whether a matching live handle still exists for this row.
  */
 export interface DashboardRunHistoryItem {
   id: string;
@@ -1104,6 +1906,9 @@ export interface EffortChoice {
   hint?: string;
 }
 
+// Curated `--effort` options rendered by the Run page's effort picker, ordered
+// from least to most reasoning budget. The empty-id entry omits the flag so the
+// model's own default applies. This is UI-facing static data, not fetched.
 export const RUN_EFFORT_CHOICES: EffortChoice[] = [
   { id: "", label: "Default (model decides)", hint: "No --effort flag" },
   { id: "low", label: "Low", hint: "Fast, minimal thinking" },
@@ -1114,6 +1919,8 @@ export const RUN_EFFORT_CHOICES: EffortChoice[] = [
 ];
 
 // Curated model list. "" means "inherit from settings.json" - no --model flag.
+// Static UI data for the Run page's model picker; the first entry inherits the
+// configured default and the rest map to concrete `--model` values.
 export const RUN_MODEL_CHOICES: ModelChoice[] = [
   { id: "", label: "Inherit from settings", hint: "Use whatever your settings.json model is" },
   {
@@ -1132,7 +1939,9 @@ export const RUN_MODEL_CHOICES: ModelChoice[] = [
 
 /** Result of a transcript import run - returned by `api.import.rescan`,
  *  `scanPath`, and `upload`, and mirrored by the final `import.progress`
- *  WebSocket message (`phase: "complete"`). */
+ *  WebSocket message (`phase: "complete"`). The core counters (`imported`/
+ *  `skipped`/`errors`) are always present; the remaining fields are extra
+ *  telemetry populated depending on which import flow produced the result. */
 export interface ImportResult {
   ok: boolean;
   /** Which import flow produced this result. */

--- a/client/src/lib/event-grouping.ts
+++ b/client/src/lib/event-grouping.ts
@@ -6,10 +6,40 @@
  * the muted "{project} › {session} › {agent}" prefix. (The historical
  * tool-call grouping view was removed; the timeline now renders flat only.)
  *
+ * ## Event shape
+ * Every helper here operates on a {@link DashboardEvent}. The fields that
+ * matter for titling and attribution are:
+ * - `event_type`  — the hook lifecycle name ("PreToolUse", "PostToolUse",
+ *   "Stop", "SubagentStop", "Compaction", "Notification", "SessionStart",
+ *   "SessionEnd", "TurnDuration", "APIError", …). Drives
+ *   {@link statusFromEventType}.
+ * - `tool_name`   — set only on tool events (e.g. "Bash", "Edit", "Read", or an
+ *   MCP name like "mcp__github__create_issue"). Absent for lifecycle events, in
+ *   which case {@link buildEventTitle} falls back to `summary`.
+ * - `summary`     — an optional server-provided one-liner used as a fallback.
+ * - `data`        — a JSON *string* holding the raw hook payload. When parsed it
+ *   typically exposes `tool_input` (the arguments passed to the tool) and `cwd`
+ *   (the working directory, used to derive the project label).
+ * - `agent_id`    — identifies which agent (main or subagent) emitted the event;
+ *   drives the {@link shortAgentLabel} / {@link agentOriginLabel} labels.
+ *
+ * ## Design philosophy
+ * Titles are produced *algorithmically* — there is deliberately no per-tool or
+ * per-MCP-server lookup table to maintain. New tools and MCP servers therefore
+ * render sensibly on day one: MCP names are decoded from their namespaced
+ * `mcp__<server>__<tool>` structure, and unknown native tools fall back to the
+ * first short string found in their payload. Every parser is defensive — bad
+ * JSON, missing fields, and unexpected types degrade to a plain label instead of
+ * throwing, because this code runs on live hook data of varying vintage.
+ *
  * @author Son Nguyen <hoangson091104@gmail.com>
  */
 
 import type { DashboardEvent } from "./types";
+
+// ════════════════════════════════════════════════════════════════════════════
+// Status mapping
+// ════════════════════════════════════════════════════════════════════════════
 
 /** Best-effort status tag per event_type - drives the status badge shown on
  *  each row in the ActivityFeed / SessionDetail event streams.
@@ -18,91 +48,177 @@ import type { DashboardEvent } from "./types";
  *   than throwing, since new hook event types should degrade gracefully. */
 export function statusFromEventType(type: string): "working" | "waiting" | "completed" | "error" {
   switch (type) {
+    // A tool is about to run: the agent is actively doing work.
     case "PreToolUse":
       return "working";
+    // The tool finished, or the turn stopped: the agent is idle / awaiting the
+    // next step. "waiting" (not "completed") because more activity usually
+    // follows a PostToolUse within the same turn.
     case "PostToolUse":
     case "Stop":
       return "waiting";
+    // Terminal-ish milestones: a subagent handed control back, or the transcript
+    // was compacted. Both read as a finished unit of work.
     case "SubagentStop":
     case "Compaction":
       return "completed";
+    // Explicit failure signals surface as the red "error" badge.
     case "error":
     case "APIError":
       return "error";
+    // Unknown / newer event types shouldn't blow up the badge — treat them as a
+    // neutral "waiting" so future hook additions render gracefully.
     default:
       return "waiting";
   }
 }
 
-// ───────── Dynamic humanizers (no per-tool static tables) ─────────
+// ════════════════════════════════════════════════════════════════════════════
+// Dynamic humanizers (no per-tool static tables)
+//
+// These small string helpers turn machine-shaped identifiers — MCP server slugs,
+// snake_case tool names, shell commands, file paths, URLs — into short
+// human-readable fragments. None of them carry a hard-coded catalogue of known
+// tools; they rely purely on the *structure* of the input, so a brand-new MCP
+// server or CLI renders acceptably without a code change.
+// ════════════════════════════════════════════════════════════════════════════
 
 /** Purely algorithmic: split on _/-, dedupe consecutive tokens, take last,
- *  capitalize-first if all lowercase. Handles any MCP server slug. */
+ *  capitalize-first if all lowercase. Handles any MCP server slug.
+ *
+ *  The goal is a compact, recognizable server name. The *last* meaningful token
+ *  is usually the brand (e.g. "claude_ai_Slack" → "Slack"), and consecutive
+ *  duplicate tokens (from slugs like "github_github") are collapsed so they
+ *  don't read twice. Capitalization is only forced when the token is entirely
+ *  lowercase, preserving already-cased brands like "GitLab" or "PagerDuty".
+ * @param raw The raw server slug (the `<server>` piece of an MCP tool name).
+ * @returns A short, display-ready server label.
+ * @example humanizeMcpServer("claude_ai_Slack") // "Slack"
+ * @example humanizeMcpServer("github")           // "Github"
+ * @example humanizeMcpServer("atlassian")        // "Atlassian"
+ */
 function humanizeMcpServer(raw: string): string {
+  // Split on underscores/hyphens into candidate tokens, dropping empties.
   const tokens = raw.split(/[_-]+/).filter(Boolean);
+  // Collapse *consecutive* duplicate tokens ("github_github" → ["github"]).
   const dedup: string[] = [];
   for (const t of tokens) {
     if (dedup[dedup.length - 1] !== t) dedup.push(t);
   }
+  // The trailing token is the most brand-identifying part; fall back to the
+  // untouched input if the slug somehow had no usable tokens.
   const last = dedup[dedup.length - 1] ?? raw;
+  // Only capitalize purely-lowercase tokens so existing mixed-case brands
+  // (GitLab, PagerDuty) are left untouched.
   return last.toLowerCase() === last ? last.charAt(0).toUpperCase() + last.slice(1) : last;
 }
 
-/** snake_case → lowercase words with spaces (e.g. "get_merge_request" → "get merge request"). */
+/** snake_case → lowercase words with spaces (e.g. "get_merge_request" → "get merge request").
+ *
+ *  Runs of underscores collapse to a single space, surrounding whitespace is
+ *  trimmed, and the result is lowercased so tool actions read as a short verb
+ *  phrase in the title (e.g. "Github · create pull request").
+ * @param raw The `<tool>` portion of an MCP tool name (may contain several
+ *   `_`-joined words).
+ * @returns The spaced, lowercased action phrase.
+ */
 function humanizeMcpTool(raw: string): string {
   return raw.replace(/_+/g, " ").trim().toLowerCase();
 }
 
 /** Splits an `mcp__<server>__<tool...>` tool name into its humanized server
  *  and tool parts. Returns null for anything that isn't a well-formed MCP
- *  tool name (no `mcp__` prefix, or fewer than 3 `__`-separated segments). */
+ *  tool name (no `mcp__` prefix, or fewer than 3 `__`-separated segments).
+ *
+ *  MCP tool names follow the convention `mcp__<server>__<tool>` where `<tool>`
+ *  may itself contain `__` if the underlying action name had underscores. The
+ *  first segment ("mcp") is the marker, the second is the server slug, and
+ *  everything after is re-joined as the action before being humanized.
+ * @param tool A raw `tool_name`, e.g. "mcp__github__create_pull_request".
+ * @returns `{ server, tool }` with both pieces humanized, or null when `tool` is
+ *   not a namespaced MCP name.
+ * @example
+ * parseMcpToolName("mcp__github__create_pull_request")
+ * //   → { server: "Github", tool: "create pull request" }
+ * parseMcpToolName("Bash") // → null (native tool, no mcp__ prefix)
+ */
 function parseMcpToolName(tool: string): { server: string; tool: string } | null {
   if (!tool.startsWith("mcp__")) return null;
+  // `filter(Boolean)` drops the empty strings produced by the doubled
+  // underscores, leaving ["mcp", <server>, ...<toolWords>].
   const parts = tool.split("__").filter(Boolean);
   if (parts.length < 3) return null;
   const rawServer = parts[1];
   const rest = parts.slice(2);
+  // Guard against malformed names like "mcp____foo" that survive the length
+  // check but leave no server or no tool segment.
   if (!rawServer || rest.length === 0) return null;
   return {
     server: humanizeMcpServer(rawServer),
+    // Re-join with "_" so humanizeMcpTool can re-split uniformly, restoring the
+    // original multi-word action (parts were split on "__", not "_").
     tool: humanizeMcpTool(rest.join("_")),
   };
 }
 
 /** First short string found in tool_input using a generic priority list, then
  *  falling back to any other short string. Applies to both MCP and native
- *  tools - no tool-specific knowledge baked in. */
+ *  tools - no tool-specific knowledge baked in.
+ *
+ *  Order matters: fields are tried top-to-bottom and the first non-empty string
+ *  wins, so the list is sorted from *most* human-meaningful ("description",
+ *  "title") down to more incidental identifiers ("id", "command"). This lets a
+ *  single lookup produce a good headline across wildly different tool payloads
+ *  without knowing which tool produced them. */
 const CONTEXT_FIELDS = [
-  "description",
-  "title",
-  "name",
-  "query",
-  "q",
-  "pattern",
-  "url",
-  "file_path",
-  "path",
-  "id",
-  "command",
+  "description", // human-authored summary — best possible headline
+  "title", // e.g. an issue / PR title
+  "name", // a resource or entity name
+  "query", // search-style tools
+  "q", // short alias some tools use for a query
+  "pattern", // grep / glob style matchers
+  "url", // web-oriented tools
+  "file_path", // file-oriented tools (absolute or relative)
+  "path", // directory / file path variant
+  "id", // last-resort identifier
+  "command", // shell command text
 ];
 
 /** Implements the {@link CONTEXT_FIELDS} lookup described above: returns the
  *  first matching field's string value, or (failing that) the first short
- *  (<120 char) string value found anywhere in `input`. Null if none qualify. */
+ *  (<120 char) string value found anywhere in `input`. Null if none qualify.
+ * @param input A parsed `tool_input` object (arbitrary tool arguments).
+ * @returns The chosen headline string, or null when nothing suitable is found.
+ * @example buildContextHeadline({ query: "auth bug", limit: 20 }) // "auth bug"
+ */
 function buildContextHeadline(input: Record<string, unknown>): string | null {
+  // Preferred pass: honor the priority order in CONTEXT_FIELDS. Any non-empty
+  // string wins here regardless of length — a named field is intentional.
   for (const field of CONTEXT_FIELDS) {
     const v = input[field];
     if (typeof v === "string" && v.length > 0) return v;
   }
+  // Fallback pass: no known field matched, so scan every value and accept the
+  // first *short* string. The <120 guard avoids surfacing a giant blob (e.g. a
+  // file's contents) as the headline.
   for (const v of Object.values(input)) {
     if (typeof v === "string" && v.length > 0 && v.length < 120) return v;
   }
   return null;
 }
 
+// ════════════════════════════════════════════════════════════════════════════
+// Shell command parsing
+// ════════════════════════════════════════════════════════════════════════════
+
 /** Parses a Bash/PowerShell command string into "<binary> <subcommand>" when
  *  the binary is something with common subcommands (git, npm, docker, etc.).
- *  For curl/wget we surface the host. Falls back to the bare binary name. */
+ *  For curl/wget we surface the host. Falls back to the bare binary name.
+ *
+ *  The set below is the allow-list of binaries whose *first argument* is a
+ *  meaningful subcommand worth showing ("git commit", "npm install", "docker
+ *  build"). For anything not in the set, showing a lone argument would be noise,
+ *  so {@link parseShellHeadline} keeps just the binary name. */
 const SUBCOMMAND_BINARIES = new Set([
   "git",
   "npm",
@@ -128,6 +244,16 @@ const SUBCOMMAND_BINARIES = new Set([
   "az",
 ]);
 
+/** Extracts a compact headline from a raw shell command string.
+ * @param command The full command line (e.g. "git commit -m 'wip' && npm test").
+ * @returns "<binary> <subcommand>" for known multi-command binaries, "<curl|wget>
+ *   <host>" for downloads, the bare binary otherwise, or null for an empty
+ *   command.
+ * @example parseShellHeadline("git commit -m x")       // "git commit"
+ * @example parseShellHeadline("docker compose up -d")  // "docker compose up"
+ * @example parseShellHeadline("curl https://api.x/y")  // "curl api.x"
+ * @example parseShellHeadline("./run.sh --fast")       // "run.sh"
+ */
 function parseShellHeadline(command: string): string | null {
   const cmd = command.trim();
   if (!cmd) return null;
@@ -136,14 +262,20 @@ function parseShellHeadline(command: string): string | null {
   const compose = cmd.match(/^docker\s+compose\s+([A-Za-z0-9_-]+)/);
   if (compose) return `docker compose ${compose[1]}`;
 
+  // Capture group 1 = the binary (path chars allowed so "./x", "/usr/bin/git"
+  // and "C:\\tool.exe" all match); optional group 2 = the first bare argument.
   const match = cmd.match(/^([A-Za-z0-9_.\-/\\]+)(?:\s+([A-Za-z0-9_-]+))?/);
   if (!match) return null;
   const binPath = match[1] ?? "";
+  // Reduce any path to just the executable name so "/usr/local/bin/git" → "git".
   const bin = binPath.split(/[/\\]/).pop() || binPath;
   const sub = match[2];
 
+  // Only show the subcommand for binaries where it's genuinely informative.
   if (SUBCOMMAND_BINARIES.has(bin) && sub) return `${bin} ${sub}`;
 
+  // Downloads: the destination host is far more useful than a "-fsSL" flag, so
+  // pull the first http(s) URL out of the command and show its host.
   if (bin === "curl" || bin === "wget") {
     const urlMatch = cmd.match(/https?:\/\/[^\s"']+/);
     if (urlMatch) {
@@ -156,12 +288,24 @@ function parseShellHeadline(command: string): string | null {
     return bin;
   }
 
+  // Everything else: just the binary name (a lone arg would usually be noise).
   return bin;
 }
 
+// ════════════════════════════════════════════════════════════════════════════
+// Path and URL helpers
+// ════════════════════════════════════════════════════════════════════════════
+
 /** Last path segment (POSIX or Windows separators). Returns `path` unchanged
- *  if it has no separators. */
+ *  if it has no separators.
+ * @param path An absolute or relative path using "/" and/or "\" separators.
+ * @returns The final segment (file or directory name).
+ * @example basename("/a/b/c.ts") // "c.ts"
+ * @example basename("solo")      // "solo"
+ */
 function basename(path: string): string {
+  // Split on either separator and drop empties so trailing slashes don't yield
+  // an empty final element.
   const parts = path.split(/[/\\]/).filter(Boolean);
   return parts.length > 0 ? (parts[parts.length - 1] ?? path) : path;
 }
@@ -169,36 +313,67 @@ function basename(path: string): string {
 /** Compact path label - last 2 segments (e.g. "tasks/base.py" for a long
  *  absolute path ending in tasks/base.py), so the user sees the immediate
  *  parent directory in addition to the filename. Falls back to basename for
- *  single-segment paths. */
+ *  single-segment paths.
+ *
+ *  Two segments strike a balance: the filename alone can be ambiguous (many
+ *  "index.ts"), while the full absolute path is too long for a one-line title.
+ * @param path An absolute or relative path.
+ * @returns The last two segments joined with "/", or the sole segment.
+ * @example shortPath("/repo/client/src/lib/types.ts") // "lib/types.ts"
+ * @example shortPath("README.md")                     // "README.md"
+ */
 function shortPath(path: string): string {
   const parts = path.split(/[/\\]/).filter(Boolean);
+  // 0 or 1 segments: nothing to shorten — return what we have.
   if (parts.length <= 1) return parts[0] ?? path;
+  // Always normalize the joiner to "/" even for Windows-style inputs.
   return parts.slice(-2).join("/");
 }
 
 /** Extracts the host from a URL string (e.g. WebFetch's target), falling back
- *  to the raw string if it doesn't parse as a URL. */
+ *  to the raw string if it doesn't parse as a URL.
+ * @param url A URL string; may be malformed.
+ * @returns The host (e.g. "api.github.com"), or the original string on parse
+ *   failure so the caller still shows *something*.
+ * @example hostFromUrl("https://api.github.com/repos") // "api.github.com"
+ * @example hostFromUrl("not a url")                    // "not a url"
+ */
 function hostFromUrl(url: string): string {
   try {
     return new URL(url).host;
   } catch {
+    // `new URL` throws on relative / garbage input — degrade to the raw string.
     return url;
   }
 }
 
+// ════════════════════════════════════════════════════════════════════════════
+// Event title builder
+// ════════════════════════════════════════════════════════════════════════════
+
 /** Parses `event.data` and pulls out its `tool_input` object, if any. Returns
  *  null when there's no data, it isn't valid JSON, or `tool_input` isn't a
- *  plain object (e.g. absent, or an array). */
+ *  plain object (e.g. absent, or an array).
+ *
+ *  `event.data` is stored as a JSON string, so it must be parsed at read time.
+ *  A representative payload looks like:
+ *  `{"tool_input":{"file_path":"/a/b.ts"},"cwd":"/a"}`.
+ * @param event The event whose payload should be inspected.
+ * @returns The `tool_input` record, or null when it's missing / invalid.
+ */
 function extractToolInput(event: DashboardEvent): Record<string, unknown> | null {
   if (!event.data) return null;
   try {
     const parsed = JSON.parse(event.data);
+    // Only read `tool_input` when the payload itself is a truthy object.
     const maybeInput = parsed && typeof parsed === "object" ? parsed.tool_input : null;
+    // Require a *plain* object — arrays and primitives aren't valid inputs and
+    // would break the field lookups downstream.
     if (maybeInput && typeof maybeInput === "object" && !Array.isArray(maybeInput)) {
       return maybeInput as Record<string, unknown>;
     }
   } catch {
-    /* ignore */
+    /* ignore — malformed JSON simply yields no input */
   }
   return null;
 }
@@ -212,26 +387,42 @@ function extractToolInput(event: DashboardEvent): Record<string, unknown> | null
  *   (or `event_type` if there's no summary either).
  * @returns A one-line title, never empty. */
 export function buildEventTitle(event: DashboardEvent): string {
+  // Lifecycle (non-tool) events have no tool_name — use the server summary, or
+  // the raw event_type as a last resort. Never returns empty.
   if (!event.tool_name) return event.summary || event.event_type;
 
   const input = extractToolInput(event);
+  // Local coercion helper: read a field as a string, or "" if it's absent or a
+  // non-string. Keeps the per-tool branches below terse.
   const s = (v: unknown): string => (typeof v === "string" ? v : "");
+  // Local truncator: clamp long values (commands, descriptions) so a single
+  // title never blows out the row. Default cap is 80 chars.
   const trunc = (text: string, max = 80): string =>
     text.length > max ? text.slice(0, max) + "..." : text;
 
   // ── MCP tools - fully dynamic dispatch ─────────────────────────────
+  // Any "mcp__server__tool" name is decoded structurally (no per-server table).
+  // When the payload yields a context headline we append it: "Github · create
+  // pull request · Fix flaky test".
   const mcp = parseMcpToolName(event.tool_name);
   if (mcp) {
     const ctx = input ? buildContextHeadline(input) : null;
     return ctx ? `${mcp.server} · ${mcp.tool} · ${trunc(ctx)}` : `${mcp.server} · ${mcp.tool}`;
   }
 
+  // No parseable input (missing / invalid data): fall back to the tool name plus
+  // any server summary. The native per-tool logic below all needs `input`.
   if (!input) return `${event.tool_name}${event.summary ? `: ${event.summary}` : ""}`;
 
   // ── Native tools - per-tool smart titles ───────────────────────────
+  // Each case surfaces the single most useful fact from that tool's arguments.
+  // A `break` (rather than return) falls through to the generic tail at the
+  // bottom, used when the expected field was absent.
   switch (event.tool_name) {
     case "Bash":
     case "PowerShell": {
+      // Prefer "<tool> · <bin sub> - <description>"; degrade gracefully as
+      // fields drop out (headline only, description only, then raw command).
       const desc = s(input.description);
       const cmd = s(input.command);
       const headline = parseShellHeadline(cmd);
@@ -242,11 +433,13 @@ export function buildEventTitle(event: DashboardEvent): string {
       break;
     }
     case "Read": {
+      // Show the compact two-segment path so the file is identifiable.
       const path = s(input.file_path);
       if (path) return `Read · ${shortPath(path)}`;
       break;
     }
     case "Write": {
+      // Same treatment as Read — the destination path is the key fact.
       const path = s(input.file_path);
       if (path) return `Write · ${shortPath(path)}`;
       break;
@@ -255,12 +448,14 @@ export function buildEventTitle(event: DashboardEvent): string {
     case "NotebookEdit": {
       const path = s(input.file_path);
       if (path) {
+        // Flag global replacements so a sweeping edit is visually distinct.
         const suffix = input.replace_all === true ? " (all)" : "";
         return `${event.tool_name} · ${shortPath(path)}${suffix}`;
       }
       break;
     }
     case "Grep": {
+      // Lead with the search pattern; append the scope directory when present.
       const pattern = s(input.pattern);
       const path = s(input.path);
       if (pattern) {
@@ -271,17 +466,21 @@ export function buildEventTitle(event: DashboardEvent): string {
       break;
     }
     case "Glob": {
+      // The glob pattern *is* the action; show it verbatim (already short).
       const pattern = s(input.pattern);
       if (pattern) return `Glob · "${pattern}"`;
       break;
     }
     case "WebFetch": {
+      // Only the host is meaningful at a glance; the full URL is often huge.
       const url = s(input.url);
       if (url) return `WebFetch · ${hostFromUrl(url)}`;
       break;
     }
     case "Agent":
     case "Task": {
+      // Subagent spawns: identify the agent kind and/or its task description,
+      // e.g. "Task · frontend-reviewer - audit the new modal".
       const desc = s(input.description);
       const subtype = s(input.subagent_type);
       if (desc && subtype) return `${event.tool_name} · ${subtype} - ${trunc(desc, 60)}`;
@@ -289,6 +488,8 @@ export function buildEventTitle(event: DashboardEvent): string {
       if (subtype) return `${event.tool_name} · ${subtype}`;
       break;
     }
+    // Task-management tools all share the same shape: prefer a human
+    // description, else the task id.
     case "TaskCreate":
     case "TaskUpdate":
     case "TaskGet":
@@ -302,6 +503,7 @@ export function buildEventTitle(event: DashboardEvent): string {
       break;
     }
     case "ScheduleWakeup": {
+      // Show the delay in seconds and, when given, the reason for the wakeup.
       const delay = input.delaySeconds;
       const reason = s(input.reason);
       if (typeof delay === "number") {
@@ -310,6 +512,7 @@ export function buildEventTitle(event: DashboardEvent): string {
       break;
     }
     case "AskUserQuestion": {
+      // `questions` is an array of objects; surface the first question's text.
       const qs = input.questions;
       if (Array.isArray(qs) && qs.length > 0) {
         const first = qs[0];
@@ -321,29 +524,48 @@ export function buildEventTitle(event: DashboardEvent): string {
       break;
     }
     case "Monitor": {
+      // Monitor watches a shell command; show the (truncated) command text.
       const cmd = s(input.command);
       if (cmd) return `Monitor · ${trunc(cmd)}`;
       break;
     }
     case "ToolSearch": {
+      // The search query is the action being performed.
       const q = s(input.query);
       if (q) return `ToolSearch · ${trunc(q, 60)}`;
       break;
     }
     default: {
-      // Generic fallback - first short string from the payload.
+      // Unknown native tool: reuse the generic CONTEXT_FIELDS headline so even
+      // never-before-seen tools get a meaningful title instead of "Using tool".
       const ctx = buildContextHeadline(input);
       if (ctx) return `${event.tool_name} · ${trunc(ctx)}`;
     }
   }
 
+  // Tail fallback: reached when a matched case `break`s because its expected
+  // field was missing. Show the tool name plus any server summary.
   return `${event.tool_name}${event.summary ? ` · ${event.summary}` : ""}`;
 }
 
+// ════════════════════════════════════════════════════════════════════════════
+// Agent attribution labels
+//
+// These helpers turn an `agent_id` (and optional AgentInfo) into the short
+// labels shown next to events. A session has one "main" agent plus zero or more
+// nested subagents; the goal is to identify *which* agent acted without adding
+// noise for the common main-agent case.
+// ════════════════════════════════════════════════════════════════════════════
+
 /** Returns a short agent label for display next to an event, or null when the
- *  event belongs to the session's main agent (no disambiguation needed). */
+ *  event belongs to the session's main agent (no disambiguation needed).
+ * @param agentId The event's `agent_id`, or null.
+ * @returns The last-8 of the id for subagents, the whole id when short, or null
+ *   for the main agent / a missing id.
+ */
 export function shortAgentLabel(agentId: string | null): string | null {
   if (!agentId) return null;
+  // Main-agent ids end in "-main"; those need no pill (they're the default).
   if (agentId.endsWith("-main")) return null;
   // Last 8 chars of the UUID is enough to distinguish subagents on the same row.
   return agentId.length > 8 ? agentId.slice(-8) : agentId;
@@ -353,14 +575,24 @@ export function shortAgentLabel(agentId: string | null): string | null {
  *  walk the parent chain (so events from a nested subagent can render the
  *  full "main › coder › explorer" attribution). */
 export type AgentInfo = {
+  /** "main" for the session's root agent, "subagent" for any spawned agent. */
   type: "main" | "subagent";
+  /** The subagent's kind (e.g. "frontend-reviewer"); null for main agents. */
   subagent_type: string | null;
+  /** A human name / label for the agent; used when `subagent_type` is empty. */
   name: string;
+  /** Parent agent's id, enabling the chain walk in {@link agentOriginLabel}. */
   parent_agent_id?: string | null;
 };
 
 /** Single-segment label for an agent - the pill text. Returns null when the
- *  agent is the session's main agent (pill is noise in that case). */
+ *  agent is the session's main agent (pill is noise in that case).
+ *
+ *  Preference order: the descriptive `subagent_type` (most meaningful), then the
+ *  agent's `name`, then null when neither is populated.
+ * @param info The agent record to label.
+ * @returns One label segment, or null for main / unlabeled agents.
+ */
 function singleAgentSegment(info: AgentInfo): string | null {
   if (info.type === "main") return null;
   if (info.subagent_type && info.subagent_type.length > 0) return info.subagent_type;
@@ -371,14 +603,21 @@ function singleAgentSegment(info: AgentInfo): string | null {
 /** Resolves the pill label for an event's agent. Returns null when the event
  *  comes from the session's main agent (the pill is noise in that case) or
  *  when no info is available. Prefers subagent_type (e.g. "frontend-reviewer"),
- *  then the agent's name, and finally the last-8 short ID fallback. */
+ *  then the agent's name, and finally the last-8 short ID fallback.
+ * @param agentId The event's `agent_id`; null yields null.
+ * @param info Optional {@link AgentInfo} for that agent, when known.
+ * @returns The pill text, or null when nothing worth showing exists.
+ */
 export function agentPillLabel(agentId: string | null, info: AgentInfo | undefined): string | null {
   if (!agentId) return null;
   if (info) {
     const seg = singleAgentSegment(info);
+    // A concrete subagent label wins outright.
     if (seg !== null) return seg;
+    // Known main agent with no segment → deliberately no pill.
     if (info.type === "main") return null;
   }
+  // No usable info: fall back to the id-derived short label.
   return shortAgentLabel(agentId);
 }
 
@@ -405,6 +644,8 @@ export function agentOriginLabel(
   infoOrMap: AgentInfo | Map<string, AgentInfo> | undefined
 ): string | null {
   if (!agentId) return null;
+  // Overload detection: a Map enables the parent-chain walk; a bare AgentInfo
+  // (or undefined) keeps the legacy single-segment path.
   const map = infoOrMap instanceof Map ? infoOrMap : null;
   const info = map ? map.get(agentId) : (infoOrMap as AgentInfo | undefined);
 
@@ -416,27 +657,34 @@ export function agentOriginLabel(
       const seg = singleAgentSegment(info);
       if (seg) return seg;
     }
+    // Without info, infer "main" from the id suffix, else use the short id.
     if (agentId.endsWith("-main")) return "main";
     return shortAgentLabel(agentId);
   }
 
   // Map provided - walk parent chain so nested subagents read "main › coder".
   const segments: string[] = [];
+  // `seen` guards against a corrupt parent cycle causing an infinite loop.
   const seen = new Set<string>();
   let cursor: string | null = agentId;
   while (cursor && !seen.has(cursor)) {
     seen.add(cursor);
     const node = map.get(cursor);
+    // Missing node: the chain is broken — stop and use whatever we gathered.
     if (!node) break;
     if (node.type === "main") {
+      // Reached the root; prepend "main" and stop climbing.
       segments.unshift("main");
       break;
     }
+    // `unshift` builds the chain root-first so it reads top-down.
     const seg = singleAgentSegment(node);
     if (seg) segments.unshift(seg);
     cursor = node.parent_agent_id ?? null;
   }
 
+  // Walk produced nothing usable (e.g. id absent from the map): fall back the
+  // same way the map-less branch does.
   if (segments.length === 0) {
     if (agentId.endsWith("-main")) return "main";
     return shortAgentLabel(agentId);
@@ -444,12 +692,21 @@ export function agentOriginLabel(
   return segments.join(" › ");
 }
 
+// ════════════════════════════════════════════════════════════════════════════
+// Origin prefix and project derivation
+// ════════════════════════════════════════════════════════════════════════════
+
 /** Builds the muted origin prefix shown before a row's action title, e.g.
  *  "datapilot › DataPilot › frontend-reviewer". Returns null when nothing
  *  identifying is available. Any of the three segments may be null - pages
  *  already scoped to a single session pass null for sessionName, etc. When a
  *  segment equals the previous one (e.g. project name == session name), it
- *  is dropped to avoid visual duplication. */
+ *  is dropped to avoid visual duplication.
+ * @param projectName Leading segment (usually the working-directory name).
+ * @param sessionName Middle segment; dropped when identical to projectName.
+ * @param agentLabel Trailing segment (from {@link agentOriginLabel}).
+ * @returns The " › "-joined prefix, or null when every segment was empty.
+ */
 export function buildOriginLabel(
   projectName: string | null | undefined,
   sessionName: string | null | undefined,
@@ -457,6 +714,7 @@ export function buildOriginLabel(
 ): string | null {
   const parts: string[] = [];
   if (projectName) parts.push(projectName);
+  // Skip the session name when it just repeats the project name.
   if (sessionName && sessionName !== projectName) parts.push(sessionName);
   if (agentLabel) parts.push(agentLabel);
   return parts.length > 0 ? parts.join(" › ") : null;
@@ -465,7 +723,11 @@ export function buildOriginLabel(
 /** Last path segment of a working directory - the project/dir name shown as the
  *  leading origin segment. Null for an empty or missing cwd. Use this to derive
  *  a fallback project for events whose own payload carries no `cwd` (e.g.
- *  TurnDuration), by passing the owning session's cwd. */
+ *  TurnDuration), by passing the owning session's cwd.
+ * @param cwd An absolute working-directory path, or null/undefined.
+ * @returns The final path segment, or null when there's no usable cwd.
+ * @example projectFromCwd("/Users/me/dev/datapilot") // "datapilot"
+ */
 export function projectFromCwd(cwd: string | null | undefined): string | null {
   if (typeof cwd !== "string" || cwd.length === 0) return null;
   return basename(cwd);
@@ -474,17 +736,21 @@ export function projectFromCwd(cwd: string | null | undefined): string | null {
 /** Reads `cwd` out of an event's payload and returns the last path segment
  *  (the project/directory name). Null when the payload doesn't include cwd
  *  (e.g. TurnDuration events, or events from a very old client) - callers can
- *  fall back to `projectFromCwd(session.cwd)` in that case. */
+ *  fall back to `projectFromCwd(session.cwd)` in that case.
+ * @param event The event whose JSON `data` payload may carry a `cwd`.
+ * @returns The derived project name, or null when no `cwd` is present / valid.
+ */
 export function projectFromEvent(event: DashboardEvent): string | null {
   if (!event.data) return null;
   try {
     const parsed = JSON.parse(event.data);
+    // Only a plain-object payload can carry a top-level `cwd` string.
     if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
       const cwd = (parsed as Record<string, unknown>).cwd;
       if (typeof cwd === "string" && cwd.length > 0) return projectFromCwd(cwd);
     }
   } catch {
-    /* ignore */
+    /* ignore — no parseable cwd means the caller uses its session fallback */
   }
   return null;
 }

--- a/client/src/lib/event-summary.ts
+++ b/client/src/lib/event-summary.ts
@@ -6,6 +6,28 @@
  * null for events where a summary would add nothing (e.g. unknown tools with
  * empty payloads).
  *
+ * ## Output
+ * The single public entry point, {@link buildEventSummary}, returns an
+ * {@link EventSummary} — an `{ icon, headline, bullets }` triple. The icon is an
+ * emoji chosen per event/tool kind, the headline is a one-line description, and
+ * the bullets are optional supporting facts (diff stats, line counts, error
+ * flags). It returns null only when there is genuinely nothing to show.
+ *
+ * ## How it differs from event-grouping.ts
+ * `event-grouping.ts` produces the *collapsed* one-line title for a timeline
+ * row. This file produces the *expanded* detail summary and therefore also
+ * parses `tool_response` (not just `tool_input`) to report on outcomes — how
+ * many lines a command printed, how many hunks an edit touched, how many matches
+ * a search found, and so on.
+ *
+ * ## Event shape
+ * Each helper reads a {@link DashboardEvent}. Relevant fields: `event_type`
+ * (lifecycle name), `tool_name` (present only on tool events), and `data` — a
+ * JSON *string* whose parsed form usually holds `tool_input` (arguments) and
+ * `tool_response` (result). All parsing is defensive: malformed JSON, missing
+ * fields, and unexpected types degrade to a smaller summary or null rather than
+ * throwing.
+ *
  * @author Son Nguyen <hoangson091104@gmail.com>
  */
 
@@ -22,54 +44,111 @@ export type EventSummary = {
   bullets: string[];
 };
 
+// ════════════════════════════════════════════════════════════════════════════
+// Small value / formatting helpers
+// ════════════════════════════════════════════════════════════════════════════
+
+/** Coerces an unknown value to a string, returning "" for non-strings.
+ * @param v Any value pulled out of a parsed payload.
+ * @returns The value when it's a string, otherwise "".
+ */
 function str(v: unknown): string {
   return typeof v === "string" ? v : "";
 }
 
+/** Narrows an unknown value to a plain object (not null, not an array).
+ * @param v Any value (typically from `JSON.parse`).
+ * @returns The value typed as a record, or null when it isn't a plain object.
+ */
 function obj(v: unknown): Record<string, unknown> | null {
   return v && typeof v === "object" && !Array.isArray(v) ? (v as Record<string, unknown>) : null;
 }
 
+/** Compact two-segment path label (parent dir + filename), mirroring the helper
+ *  of the same name in event-grouping.ts. Falls back to the sole segment.
+ * @param path An absolute or relative path (POSIX or Windows separators).
+ * @returns The last two segments joined with "/", or the single segment.
+ * @example shortPath("/repo/src/lib/x.ts") // "lib/x.ts"
+ */
 function shortPath(path: string): string {
   const parts = path.split(/[/\\]/).filter(Boolean);
   if (parts.length <= 1) return parts[0] ?? path;
   return parts.slice(-2).join("/");
 }
 
+/** Truncates `text` to `max` chars, appending an ellipsis when it was clipped.
+ * @param text The string to clamp.
+ * @param max Maximum length before truncation (exclusive of the "...").
+ * @returns The original string, or its first `max` chars followed by "...".
+ */
 function trunc(text: string, max: number): string {
   return text.length > max ? text.slice(0, max) + "..." : text;
 }
 
-/** Parses `event.data` (JSON) into a plain object, or null on empty/invalid data. */
+/** Parses `event.data` (JSON) into a plain object, or null on empty/invalid data.
+ * @param event The event whose JSON `data` string should be decoded.
+ * @returns The parsed payload object, or null when data is absent, invalid JSON,
+ *   or not a plain object.
+ */
 function parseData(event: DashboardEvent): Record<string, unknown> | null {
   if (!event.data) return null;
   try {
     const v = JSON.parse(event.data);
+    // Reuse `obj` so arrays / primitives (never valid payloads here) yield null.
     return obj(v);
   } catch {
+    // Malformed JSON — no summary data available.
     return null;
   }
 }
 
-/** Counts hunks and +/- lines in an Edit tool response's `structuredPatch`. */
+// ════════════════════════════════════════════════════════════════════════════
+// Tool-response analyzers
+// ════════════════════════════════════════════════════════════════════════════
+
+/** Counts hunks and +/- lines in an Edit tool response's `structuredPatch`.
+ *
+ *  Claude Code's Edit/NotebookEdit responses include a `structuredPatch`: an
+ *  array of hunks, each with a `lines: string[]` where every entry is prefixed
+ *  by " ", "+", or "-" (unified-diff style). This tallies additions / removals
+ *  so the summary can show "3 hunks · +12 −4".
+ * @param structuredPatch The `tool_response.structuredPatch` value (untyped).
+ * @returns `{ hunks, added, removed }`; all zero when the input isn't an array.
+ * @example
+ * countHunks([{ lines: ["+new", "-old", " ctx"] }]) // { hunks:1, added:1, removed:1 }
+ */
 function countHunks(structuredPatch: unknown): { hunks: number; added: number; removed: number } {
+  // Non-array (missing / failed patch) → nothing to count.
   if (!Array.isArray(structuredPatch)) return { hunks: 0, added: 0, removed: 0 };
   let added = 0;
   let removed = 0;
   for (const raw of structuredPatch) {
     const r = obj(raw);
+    // Skip malformed hunks that lack a `lines` array.
     if (!r || !Array.isArray(r.lines)) continue;
     for (const line of r.lines) {
       if (typeof line !== "string") continue;
+      // Leading "+" = added line, leading "-" = removed line; " " = context.
       if (line.startsWith("+")) added++;
       else if (line.startsWith("-")) removed++;
     }
   }
+  // Hunk count is simply the number of patch entries.
   return { hunks: structuredPatch.length, added, removed };
 }
 
 /** Finds the nearest function/class/const definition line surrounding an
- *  Edit hunk, so the summary can show "Inside: function foo(...)". */
+ *  Edit hunk, so the summary can show "Inside: function foo(...)".
+ *
+ *  Scans the patch's lines for the first one matching a definition-like shape.
+ *  The pattern intentionally requires a leading space (`^\s+`) so it matches
+ *  *context* lines (unchanged surroundings) rather than the "+"/"-" changed
+ *  lines — the enclosing definition is usually context, not the edit itself. It
+ *  recognizes JS/TS `function` / `const|let|var` / `name = (`, Python `def`, and
+ *  `class` across languages.
+ * @param structuredPatch The `tool_response.structuredPatch` value (untyped).
+ * @returns The trimmed definition line, or null when none is found.
+ */
 function firstEnclosingContext(structuredPatch: unknown): string | null {
   // Look for a context line that looks like a function/class/const definition.
   if (!Array.isArray(structuredPatch)) return null;
@@ -79,6 +158,7 @@ function firstEnclosingContext(structuredPatch: unknown): string | null {
     const r = obj(raw);
     if (!r || !Array.isArray(r.lines)) continue;
     for (const line of r.lines) {
+      // First matching line wins; trim the diff indentation for display.
       if (typeof line === "string" && defPattern.test(line)) {
         return line.trim();
       }
@@ -87,13 +167,29 @@ function firstEnclosingContext(structuredPatch: unknown): string | null {
   return null;
 }
 
-/** Counts lines in `text` (empty string counts as 0, not 1). */
+/** Counts lines in `text` (empty string counts as 0, not 1).
+ *
+ *  Splits on LF or CRLF. The empty-string guard matters: `"".split(/\n/)`
+ *  returns `[""]` (length 1), which would wrongly report an empty output as
+ *  "1 line".
+ * @param text The text whose lines to count.
+ * @returns The number of newline-separated lines, or 0 for empty input.
+ */
 function lineCount(text: string): number {
   if (!text) return 0;
   return text.split(/\r?\n/).length;
 }
 
-/** Formats a millisecond duration as "Nms" / "N.Ns" / "Nm Ns", for TurnDuration events. */
+/** Formats a millisecond duration as "Nms" / "N.Ns" / "Nm Ns", for TurnDuration events.
+ *
+ *  Three tiers keep the label readable at any scale: raw milliseconds under a
+ *  second, one-decimal seconds under a minute, and "Xm Ys" beyond that.
+ * @param ms A non-negative duration in milliseconds.
+ * @returns A compact human-readable duration string.
+ * @example formatDuration(450)    // "450ms"
+ * @example formatDuration(1500)   // "1.5s"
+ * @example formatDuration(95000)  // "1m 35s"
+ */
 function formatDuration(ms: number): string {
   if (ms < 1000) return `${ms}ms`;
   if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
@@ -115,11 +211,17 @@ export function buildEventSummary(event: DashboardEvent): EventSummary | null {
   const data = parseData(event);
 
   // ── Non-tool events first ──────────────────────────────────────────
+  // Lifecycle events have no tool payload; each maps to a fixed icon / headline
+  // plus any incidental detail carried in `data`.
+
+  // Stop / SubagentStop: a turn (or subagent turn) ended. Optionally note the
+  // stop-hook flag and the first line of the last assistant message.
   if (event.event_type === "Stop" || event.event_type === "SubagentStop") {
     const stopHookActive = data?.stop_hook_active === true;
     const msg = str(data?.last_assistant_message);
     const bullets: string[] = [];
     if (stopHookActive) bullets.push("stop hook active");
+    // Only the first line keeps the bullet compact for multi-line messages.
     if (msg) bullets.push(`Last message: ${trunc(msg.split(/\r?\n/)[0] ?? "", 80)}`);
     return {
       icon: "🛑",
@@ -128,6 +230,7 @@ export function buildEventSummary(event: DashboardEvent): EventSummary | null {
     };
   }
 
+  // TurnDuration: synthetic event carrying how long the turn took, in ms.
   if (event.event_type === "TurnDuration") {
     const durationMs = typeof data?.durationMs === "number" ? data.durationMs : null;
     return {
@@ -137,6 +240,7 @@ export function buildEventSummary(event: DashboardEvent): EventSummary | null {
     };
   }
 
+  // Compaction: the transcript was summarized to reclaim context window.
   if (event.event_type === "Compaction") {
     return {
       icon: "🗜️",
@@ -145,6 +249,7 @@ export function buildEventSummary(event: DashboardEvent): EventSummary | null {
     };
   }
 
+  // Notification: a user-facing message from the agent; show text + optional type.
   if (event.event_type === "Notification") {
     const msg = str(data?.message);
     const type = str(data?.notification_type);
@@ -155,6 +260,8 @@ export function buildEventSummary(event: DashboardEvent): EventSummary | null {
     };
   }
 
+  // SessionStart / SessionEnd: bracket a session; surface its source and model
+  // when the payload includes them. The `.filter(Boolean)` drops empty bullets.
   if (event.event_type === "SessionStart" || event.event_type === "SessionEnd") {
     const source = str(data?.source);
     const model = str(data?.model);
@@ -167,6 +274,7 @@ export function buildEventSummary(event: DashboardEvent): EventSummary | null {
     };
   }
 
+  // APIError: a provider / API failure was recorded for this event.
   if (event.event_type === "APIError") {
     return {
       icon: "⚠️",
@@ -176,20 +284,26 @@ export function buildEventSummary(event: DashboardEvent): EventSummary | null {
   }
 
   // ── Tool events ────────────────────────────────────────────────────
+  // Past the lifecycle branches, only tool events remain. Without a tool_name
+  // there's nothing to summarize.
   const tool = event.tool_name;
   if (!tool) return null;
+  // Both may be null: `tool_input` is the arguments, `tool_response` the result.
   const input = obj(data?.tool_input);
   const response = obj(data?.tool_response);
 
-  // MCP tools - generic summary
+  // MCP tools - generic summary. Any "mcp__" tool is summarized structurally,
+  // pulling the most relevant field out of the call args and the response.
   if (tool.startsWith("mcp__")) {
     const headline = humanizeMcp(tool);
     const bullets: string[] = [];
     if (input) {
+      // Surface the most identifying call argument, if any.
       const top = firstStringField(input, ["title", "query", "q", "url", "name", "id"]);
       if (top) bullets.push(`Called with: ${trunc(top, 80)}`);
     }
     if (response) {
+      // Prefer a recognizable response field; otherwise report its field count.
       const resTop = firstStringField(response, ["title", "name", "state", "status", "url"]);
       if (resTop) bullets.push(`Response: ${trunc(resTop, 80)}`);
       else bullets.push(`Returned ${Object.keys(response).length} fields`);
@@ -197,9 +311,13 @@ export function buildEventSummary(event: DashboardEvent): EventSummary | null {
     return { icon: "🧩", headline, bullets };
   }
 
+  // ── Native tools ───────────────────────────────────────────────────
+  // Each case builds an icon + headline + outcome bullets from that tool's
+  // specific input / response shape.
   switch (tool) {
     case "Bash":
     case "PowerShell": {
+      // Report the command plus stdout/stderr line counts and interruption.
       const cmd = str(input?.command);
       const desc = str(input?.description);
       const stdout = str(response?.stdout);
@@ -209,10 +327,13 @@ export function buildEventSummary(event: DashboardEvent): EventSummary | null {
       if (desc) bullets.push(`"${desc}"`);
       if (stdout) bullets.push(`${lineCount(stdout)} lines stdout`);
       if (stderr) bullets.push(`${lineCount(stderr)} lines stderr`);
+      // Distinguish "empty stderr" (we have a response) from "unknown" (no
+      // response yet) — only claim "no stderr" once some output / response exists.
       else if (stdout || response) bullets.push("no stderr");
       if (interrupted) bullets.push("⚠ interrupted");
       return {
         icon: "💻",
+        // Headline leads with the binary, then the full (clamped) command.
         headline: cmd ? `Ran ${trunc(firstWord(cmd), 40)}: ${trunc(cmd, 80)}` : `${tool} call`,
         bullets,
       };
@@ -220,12 +341,15 @@ export function buildEventSummary(event: DashboardEvent): EventSummary | null {
 
     case "Edit":
     case "NotebookEdit": {
+      // Summarize the diff: enclosing definition, hunk / line counts, and whether
+      // it was a global replace_all.
       const path = str(input?.file_path);
       const { hunks, added, removed } = countHunks(response?.structuredPatch);
       const ctx = firstEnclosingContext(response?.structuredPatch);
       const replaceAll = input?.replace_all === true;
       const bullets: string[] = [];
       if (ctx) bullets.push(`Inside: ${trunc(ctx, 80)}`);
+      // Pluralize "hunk" and show the "+added −removed" tally.
       if (hunks > 0) bullets.push(`${hunks} hunk${hunks === 1 ? "" : "s"} · +${added} −${removed}`);
       if (replaceAll) bullets.push("replace_all mode");
       return {
@@ -236,6 +360,7 @@ export function buildEventSummary(event: DashboardEvent): EventSummary | null {
     }
 
     case "Write": {
+      // Report the size of the written content in lines and bytes.
       const path = str(input?.file_path);
       const content = str(input?.content);
       const bullets: string[] = [];
@@ -248,11 +373,14 @@ export function buildEventSummary(event: DashboardEvent): EventSummary | null {
     }
 
     case "Read": {
+      // Note whether a partial range (offset/limit) or the full file was read,
+      // plus how many lines came back.
       const path = str(input?.file_path);
       const offset = input?.offset;
       const limit = input?.limit;
       const bullets: string[] = [];
       if (offset != null || limit != null) {
+        // A range read — describe whichever bounds were provided.
         const parts: string[] = [];
         if (offset != null) parts.push(`offset ${offset}`);
         if (limit != null) parts.push(`limit ${limit}`);
@@ -260,6 +388,7 @@ export function buildEventSummary(event: DashboardEvent): EventSummary | null {
       } else {
         bullets.push("Full file");
       }
+      // Read responses come back as a raw string of file contents.
       if (typeof response === "string") {
         bullets.push(`${lineCount(response)} lines returned`);
       }
@@ -271,10 +400,12 @@ export function buildEventSummary(event: DashboardEvent): EventSummary | null {
     }
 
     case "Grep": {
+      // Headline the search pattern (+ scope); bullet the match count.
       const pattern = str(input?.pattern);
       const path = str(input?.path);
       const bullets: string[] = [];
       const matchCount = countGrepMatches(response);
+      // Pluralize "match" / "matches" based on the count.
       if (matchCount != null) bullets.push(`${matchCount} match${matchCount === 1 ? "" : "es"}`);
       return {
         icon: "🔍",
@@ -286,6 +417,7 @@ export function buildEventSummary(event: DashboardEvent): EventSummary | null {
     }
 
     case "Glob": {
+      // Headline the glob pattern; bullet how many files matched.
       const pattern = str(input?.pattern);
       const bullets: string[] = [];
       const fileCount = countFiles(response);
@@ -298,6 +430,7 @@ export function buildEventSummary(event: DashboardEvent): EventSummary | null {
     }
 
     case "WebFetch": {
+      // Headline the fetched host; bullet the extraction prompt and response size.
       const url = str(input?.url);
       const prompt = str(input?.prompt);
       const bullets: string[] = [];
@@ -307,6 +440,7 @@ export function buildEventSummary(event: DashboardEvent): EventSummary | null {
       try {
         host = new URL(url).host;
       } catch {
+        // Malformed / relative URL — show the raw string instead of the host.
         host = url;
       }
       return {
@@ -318,6 +452,7 @@ export function buildEventSummary(event: DashboardEvent): EventSummary | null {
 
     case "Task":
     case "Agent": {
+      // Detail the spawned subagent's kind, task, and output size.
       const subtype = str(input?.subagent_type);
       const desc = str(input?.description);
       const bullets: string[] = [];
@@ -328,6 +463,7 @@ export function buildEventSummary(event: DashboardEvent): EventSummary | null {
     }
 
     case "TaskCreate": {
+      // A task was created — headline its description.
       const d = str(input?.description);
       return {
         icon: "✅",
@@ -336,6 +472,7 @@ export function buildEventSummary(event: DashboardEvent): EventSummary | null {
       };
     }
     case "TaskUpdate": {
+      // A task was updated — prefer its description, falling back to its id.
       const d = str(input?.description) || str(input?.id);
       return {
         icon: "🔄",
@@ -345,6 +482,7 @@ export function buildEventSummary(event: DashboardEvent): EventSummary | null {
     }
 
     case "AskUserQuestion": {
+      // Headline the first question's text from the `questions` array.
       const qs = Array.isArray(input?.questions) ? input?.questions : null;
       const first = qs && qs.length > 0 ? obj(qs[0]) : null;
       const q = first ? str(first.question) : "";
@@ -356,6 +494,7 @@ export function buildEventSummary(event: DashboardEvent): EventSummary | null {
     }
 
     case "ScheduleWakeup": {
+      // Headline the delay; bullet the reason when supplied.
       const delay = input?.delaySeconds;
       const reason = str(input?.reason);
       return {
@@ -366,43 +505,66 @@ export function buildEventSummary(event: DashboardEvent): EventSummary | null {
     }
 
     default: {
-      // Unknown native tool - minimal summary.
+      // Unknown native tool - minimal summary. With neither input nor response
+      // there is nothing worth showing, so return null (no summary card).
       if (!input && !response) return null;
       return {
         icon: "🔧",
         headline: `${tool} call`,
+        // At least report how many input fields were passed.
         bullets: input ? [`${Object.keys(input).length} input fields`] : [],
       };
     }
   }
 }
 
+// ════════════════════════════════════════════════════════════════════════════
+// MCP name + field extraction helpers
+// ════════════════════════════════════════════════════════════════════════════
+
 /** Turns an `mcp__server__tool_name` tool name into "Server · tool name" for
  *  the MCP-tool summary headline (duplicates the dedupe/casing logic in
- *  event-grouping.ts's `humanizeMcpServer`, kept local to avoid a cross-import). */
+ *  event-grouping.ts's `humanizeMcpServer`, kept local to avoid a cross-import).
+ * @param toolName A namespaced MCP tool name, e.g. "mcp__github__list_issues".
+ * @returns "Server · tool name" (e.g. "Github · list issues"), or the raw name
+ *   when it doesn't have the expected 3+ `__`-separated segments.
+ * @example humanizeMcp("mcp__claude_ai_Slack__send_message") // "Slack · send message"
+ */
 function humanizeMcp(toolName: string): string {
   const parts = toolName.split("__").filter(Boolean);
+  // Not a well-formed MCP name — return it untouched.
   if (parts.length < 3) return toolName;
   const rawServer = parts[1] ?? "";
+  // Everything past the server is the (possibly multi-word) action.
   const rest = parts.slice(2).join(" ");
   // Reuse the same server-humanization logic as elsewhere: split, dedupe, last token.
   const tokens = rawServer.split(/[_-]+/).filter(Boolean);
   const dedup: string[] = [];
   for (const t of tokens) if (dedup[dedup.length - 1] !== t) dedup.push(t);
   const last = dedup[dedup.length - 1] ?? rawServer;
+  // Capitalize only when the token is all-lowercase (preserves "GitLab" etc.).
   const server = last.toLowerCase() === last ? last.charAt(0).toUpperCase() + last.slice(1) : last;
+  // Normalize the action to lowercase spaced words.
   const toolPart = rest.replace(/_+/g, " ").trim().toLowerCase();
   return `${server} · ${toolPart}`;
 }
 
-/** Extracts the first whitespace-delimited token of a shell command (the binary). */
+/** Extracts the first whitespace-delimited token of a shell command (the binary).
+ * @param command The full command string.
+ * @returns The first non-whitespace run, or the original string if none.
+ * @example firstWord("  npm run build") // "npm"
+ */
 function firstWord(command: string): string {
   const m = command.trim().match(/^(\S+)/);
   return m ? (m[1] ?? command) : command;
 }
 
 /** Returns the first non-empty string value found in `obj` among `priority`
- *  keys, in order - used to surface the most relevant MCP call/response field. */
+ *  keys, in order - used to surface the most relevant MCP call/response field.
+ * @param obj The object to inspect (a parsed input or response).
+ * @param priority Keys to try, most-preferred first.
+ * @returns The first matching non-empty string, or null when none match.
+ */
 function firstStringField(obj: Record<string, unknown>, priority: string[]): string | null {
   for (const k of priority) {
     const v = obj[k];
@@ -412,12 +574,20 @@ function firstStringField(obj: Record<string, unknown>, priority: string[]): str
 }
 
 /** Best-effort match count from a Grep tool response, checking a few
- *  known response shapes (array, `.matches`, `.files`, `.count`, `.numFiles`). */
+ *  known response shapes (array, `.matches`, `.files`, `.count`, `.numFiles`).
+ *
+ *  Grep results have varied over time and by output mode, so each known shape is
+ *  probed in turn and the first that fits wins.
+ * @param response The `tool_response` value (untyped).
+ * @returns The match / file count, or null when no known shape applies.
+ */
 function countGrepMatches(response: unknown): number | null {
   if (!response) return null;
+  // Plain array of matches.
   if (Array.isArray(response)) return response.length;
   const r = obj(response);
   if (!r) return null;
+  // Object wrappers seen across Grep output modes.
   if (Array.isArray(r.matches)) return r.matches.length;
   if (Array.isArray(r.files)) return r.files.length;
   if (typeof r.count === "number") return r.count;
@@ -425,7 +595,10 @@ function countGrepMatches(response: unknown): number | null {
   return null;
 }
 
-/** Best-effort file count from a Glob tool response (array, `.files`, or `.paths`). */
+/** Best-effort file count from a Glob tool response (array, `.files`, or `.paths`).
+ * @param response The `tool_response` value (untyped).
+ * @returns The number of matched files, or null when no known shape applies.
+ */
 function countFiles(response: unknown): number | null {
   if (Array.isArray(response)) return response.length;
   const r = obj(response);

--- a/client/src/lib/eventBus.ts
+++ b/client/src/lib/eventBus.ts
@@ -1,6 +1,30 @@
 /**
  * @file eventBus.ts
  * @description Implements a simple event bus for managing WebSocket messages and connection status in the agent dashboard application. It allows components to subscribe to real-time updates from the server and react to changes in WebSocket connectivity. The event bus maintains a list of handlers for incoming messages and connection status changes, providing a clean interface for publishing events and managing subscriptions.
+ *
+ * ## Design
+ * This is a module-level singleton (there is exactly one bus per browser tab) built on
+ * two `Set`s of callbacks. It exists to break the one-to-many coupling between the single
+ * WebSocket connection and the many UI components that care about it:
+ *   - The producer side is the `useWebSocket` hook, which owns the actual socket and calls
+ *     {@link eventBus.publish} for every inbound frame and {@link eventBus.setConnected}
+ *     on open/close.
+ *   - The consumer side is any component that calls {@link eventBus.subscribe} (for message
+ *     data) or {@link eventBus.onConnection} (for a connectivity indicator), typically from
+ *     a `useEffect`, and calls the returned unsubscribe function on cleanup.
+ *
+ * ## Why `Set` (not array)?
+ * A `Set` gives O(1) add/delete and, crucially, natural idempotency: subscribing the same
+ * handler reference twice registers it once, and the returned disposer removes exactly that
+ * reference. Handlers are notified in insertion order (Set iteration order).
+ *
+ * ## Delivery semantics
+ * Dispatch is synchronous and fire-and-forget: {@link eventBus.publish} iterates the current
+ * handler set and calls each in turn. There is no error isolation, so a handler that throws
+ * will abort the remaining handlers for that message - subscribers should keep their work
+ * cheap and defensive. There is also no buffering: a message published while nobody is
+ * subscribed is simply dropped.
+ *
  * @author Son Nguyen <hoangson091104@gmail.com>
  */
 
@@ -11,8 +35,12 @@ type Handler = (msg: WSMessage) => void;
 /** Callback invoked whenever the WebSocket connection state changes. */
 type ConnectionHandler = (connected: boolean) => void;
 
+// --- Module-private subscription state (the single source of truth per tab) ---
+/** All active message subscribers; iterated on every {@link eventBus.publish}. */
 const handlers = new Set<Handler>();
+/** All active connection-state subscribers; iterated on every {@link eventBus.setConnected}. */
 const connectionHandlers = new Set<ConnectionHandler>();
+/** Latest known socket state; the backing store for the {@link eventBus.connected} getter. */
 let wsConnected = false;
 
 /**
@@ -31,15 +59,16 @@ export const eventBus = {
    *   to stop receiving messages and avoid a memory leak.
    */
   subscribe(handler: Handler): () => void {
-    handlers.add(handler);
-    return () => handlers.delete(handler);
+    handlers.add(handler); // idempotent: re-adding the same reference is a no-op
+    return () => handlers.delete(handler); // disposer removes exactly this handler
   },
 
   /** Broadcasts `msg` to every currently-subscribed {@link Handler}. Called by
    *  `useWebSocket` on each parsed inbound frame - not intended to be called
-   *  directly by UI code. */
+   *  directly by UI code. Dispatch is synchronous and in subscription order; a
+   *  throwing handler aborts delivery to the handlers after it. */
   publish(msg: WSMessage): void {
-    handlers.forEach((handler) => handler(msg));
+    handlers.forEach((handler) => handler(msg)); // notify each subscriber in turn
   },
 
   /** Current WebSocket connection state, as last reported via {@link setConnected}. */
@@ -50,8 +79,8 @@ export const eventBus = {
   /** Updates the shared connection flag and notifies every {@link onConnection}
    *  listener. Called by `useWebSocket` on socket open/close. */
   setConnected(value: boolean): void {
-    wsConnected = value;
-    connectionHandlers.forEach((handler) => handler(value));
+    wsConnected = value; // update the shared flag first so late reads see the new state
+    connectionHandlers.forEach((handler) => handler(value)); // then fan out the transition
   },
 
   /**
@@ -59,9 +88,12 @@ export const eventBus = {
    * "reconnecting…" indicator).
    * @param handler Called with the new connected state on every change.
    * @returns An unsubscribe function.
+   * @remarks The handler fires only on subsequent {@link eventBus.setConnected} calls, not
+   *   immediately with the current value - read {@link eventBus.connected} once up front if
+   *   the initial state matters.
    */
   onConnection(handler: ConnectionHandler): () => void {
-    connectionHandlers.add(handler);
-    return () => connectionHandlers.delete(handler);
+    connectionHandlers.add(handler); // idempotent add (Set semantics)
+    return () => connectionHandlers.delete(handler); // disposer for useEffect cleanup
   },
 };

--- a/client/src/lib/format.ts
+++ b/client/src/lib/format.ts
@@ -1,56 +1,121 @@
 /**
  * @file format.ts
  * @description Provides utility functions for formatting dates, times, durations, and numbers in the agent dashboard application. It includes functions to parse ISO timestamp strings while normalizing UTC, format time and date-time strings for display, calculate and format durations between timestamps, and format large numbers with appropriate suffixes (K/M/B) for better readability. These utilities help ensure consistent and user-friendly presentation of temporal and numerical data throughout the application.
+ *
+ * ## Two cross-cutting concerns
+ * 1. **UTC normalization.** The backend stores timestamps via SQLite's
+ *    `datetime('now')`, which yields a naive `'YYYY-MM-DD HH:MM:SS'` string with no
+ *    timezone. `new Date()` would interpret that as *local* time and silently shift it
+ *    by the viewer's UTC offset. Every date helper here therefore routes its input
+ *    through {@link parseDate}, which appends a `Z` when no timezone is present so the
+ *    value is unambiguously UTC, then relies on `toLocale*` to render it back in the
+ *    viewer's local zone. Timestamps that already carry a `Z` or `±HH:MM` offset are
+ *    parsed as-is.
+ * 2. **Locale awareness.** The dashboard ships four UI languages (English, Chinese,
+ *    Vietnamese, Korean). {@link getCurrentLocale} maps the active i18next language to a
+ *    BCP-47 tag (`en-US`, `zh-CN`, `vi-VN`, `ko-KR`) that the `Intl`/`toLocale*` APIs
+ *    understand, so month names, AM/PM vs. 24-hour clocks, digit grouping and currency
+ *    punctuation all follow the chosen language. Relative-time strings ("5m ago") are
+ *    instead produced from translated i18next keys rather than `Intl.RelativeTimeFormat`.
+ *
+ * Number/cost helpers ({@link fmt}, {@link fmtCost}, {@link fmtCostFull}) guard against
+ * non-finite and negative input, and abbreviate large magnitudes with K/M/B suffixes for
+ * compact stat tiles while a full comma-grouped form is available for tooltips.
+ *
  * @author Son Nguyen <hoangson091104@gmail.com>
  */
 
 import i18n from "../i18n";
+
+// ===========================================================================
+// Timestamp parsing + locale resolution (shared internals)
+// ===========================================================================
 
 /**
  * Parse a timestamp string into a Date, normalizing UTC.
  * SQLite datetime('now') returns 'YYYY-MM-DD HH:MM:SS' (no timezone).
  * JS treats that as local time, causing offset bugs. This ensures
  * timestamps without a timezone indicator are treated as UTC.
+ * @param iso An ISO-8601 string, or SQLite's space-separated `'YYYY-MM-DD HH:MM:SS'`.
+ * @returns A `Date`. Callers that pass malformed input get an `Invalid Date` (whose
+ *   `getTime()` is `NaN`); several formatters below guard for that explicitly.
+ * @example
+ *   parseDate("2026-04-18 08:49:13")     // treated as UTC (Z appended)
+ *   parseDate("2026-04-18T08:49:13Z")    // parsed as-is
+ *   parseDate("2026-04-18T08:49:13-04:00") // parsed as-is (explicit offset)
  */
 function parseDate(iso: string): Date {
   // Already has timezone info (Z or +/- offset) - parse directly
+  // (`/[+-]\d{2}:\d{2}$/` catches trailing `+04:00`-style offsets).
   if (/[Zz]$/.test(iso) || /[+-]\d{2}:\d{2}$/.test(iso)) {
     return new Date(iso);
   }
   // No timezone - treat as UTC by appending Z
   // Handle both 'YYYY-MM-DD HH:MM:SS' and 'YYYY-MM-DDTHH:MM:SS' formats
+  // (the single space -> "T" swap makes the SQLite form valid ISO before adding Z).
   return new Date(iso.replace(" ", "T") + "Z");
 }
 
+/** The four UI languages the dashboard localizes formatting for. */
 type SupportedLanguage = "en" | "zh" | "vi" | "ko";
 
+/**
+ * Resolve the active i18next language down to one of the four {@link SupportedLanguage}
+ * codes, defaulting to English for anything unrecognized.
+ * @returns `"en" | "zh" | "vi" | "ko"`.
+ * @remarks Reads `resolvedLanguage` first (the language i18next actually settled on after
+ *   detection/fallback), then `language`, then `"en"`. The value is lowercased and its
+ *   region subtag stripped (`split("-")[0]`), so `"en-US"`, `"zh-Hans-CN"` etc. collapse
+ *   to their base language before the whitelist check.
+ */
 function getCurrentLanguage(): SupportedLanguage {
   const language = (i18n.resolvedLanguage ?? i18n.language ?? "en").toLowerCase().split("-")[0];
   if (language === "zh" || language === "vi" || language === "ko" || language === "en") {
     return language;
   }
-  return "en";
+  return "en"; // any other/undetected language -> English
 }
 
-/** Maps the active i18next language to a `toLocaleString` BCP-47 locale tag,
- *  so date/number formatting matches the UI's chosen language. Falls back to
- *  "en-US" for any language not explicitly supported. */
+/**
+ * Maps the active i18next language to a `toLocaleString` BCP-47 locale tag,
+ * so date/number formatting matches the UI's chosen language. Falls back to
+ * "en-US" for any language not explicitly supported.
+ * @returns One of `"zh-CN" | "vi-VN" | "ko-KR" | "en-US"`.
+ * @remarks The region subtag matters: it drives clock convention (English/Korean use
+ *   12-hour AM/PM here via the `hour: "2-digit"` options, Chinese/Vietnamese lean 24-hour),
+ *   month-name localization, and digit-group/decimal separators used by {@link fmtCostFull}.
+ */
 export function getCurrentLocale(): string {
   const language = getCurrentLanguage();
-  if (language === "zh") return "zh-CN";
-  if (language === "vi") return "vi-VN";
-  if (language === "ko") return "ko-KR";
-  return "en-US";
+  if (language === "zh") return "zh-CN"; // Simplified Chinese (mainland)
+  if (language === "vi") return "vi-VN"; // Vietnamese
+  if (language === "ko") return "ko-KR"; // Korean
+  return "en-US"; // default: US English
 }
 
-/** Formats an ISO/SQLite timestamp as a locale-aware clock time, e.g. "8:49 AM". */
+// ===========================================================================
+// Date / time formatters (all locale-aware, all UTC-normalized via parseDate)
+// ===========================================================================
+
+/**
+ * Formats an ISO/SQLite timestamp as a locale-aware clock time, e.g. "8:49 AM".
+ * @param iso Timestamp string (see {@link parseDate}).
+ * @returns The time-of-day only, using the current locale's clock convention.
+ */
 export function formatTime(iso: string): string {
   const d = parseDate(iso);
   return d.toLocaleTimeString(getCurrentLocale(), { hour: "2-digit", minute: "2-digit" });
 }
 
-/** Formats an ISO/SQLite timestamp as "Apr 18, 8:49 AM" - the default compact
- *  timestamp used across list rows. */
+/**
+ * Formats an ISO/SQLite timestamp as "Apr 18, 8:49 AM" - the default compact
+ * timestamp used across list rows.
+ * @param iso Timestamp string (see {@link parseDate}).
+ * @returns Abbreviated month + day + clock time in the current locale.
+ * @remarks Deliberately omits the year to stay compact; use {@link formatDateTimeFull}
+ *   when the year/seconds/timezone matter. Does not guard against invalid dates, so a
+ *   malformed input renders as the locale's "Invalid Date" string.
+ */
 export function formatDateTime(iso: string): string {
   const d = parseDate(iso);
   return d.toLocaleString(getCurrentLocale(), {
@@ -61,19 +126,31 @@ export function formatDateTime(iso: string): string {
   });
 }
 
-/** Date only, e.g. "Apr 18" - paired with formatTime as a small second line in
- *  narrow list rows (timeline, activity feed) so the date is visible too. */
+/**
+ * Date only, e.g. "Apr 18" - paired with formatTime as a small second line in
+ * narrow list rows (timeline, activity feed) so the date is visible too.
+ * @param iso Timestamp string (see {@link parseDate}).
+ * @returns Abbreviated month + day, or `""` when the timestamp is unparseable
+ *   (so an empty second line simply collapses rather than showing "Invalid Date").
+ */
 export function formatDateShort(iso: string): string {
   const d = parseDate(iso);
-  if (isNaN(d.getTime())) return "";
+  if (isNaN(d.getTime())) return ""; // hide rather than render garbage
   return d.toLocaleString(getCurrentLocale(), { month: "short", day: "numeric" });
 }
 
-/** Fully detailed timestamp with weekday, full date, seconds, and timezone -
- *  e.g. "Sat, Apr 18, 2026, 08:49:13 AM PDT". For detail panels. */
+/**
+ * Fully detailed timestamp with weekday, full date, seconds, and timezone -
+ * e.g. "Sat, Apr 18, 2026, 08:49:13 AM PDT". For detail panels.
+ * @param iso Timestamp string (see {@link parseDate}).
+ * @returns The fully-qualified localized timestamp, or the original `iso` string
+ *   unchanged when it can't be parsed (preserving whatever the backend sent).
+ * @remarks `timeZoneName: "short"` renders the viewer's local zone abbreviation (PDT,
+ *   KST, …) - a reminder that the underlying value was normalized from UTC to local.
+ */
 export function formatDateTimeFull(iso: string): string {
   const d = parseDate(iso);
-  if (isNaN(d.getTime())) return iso;
+  if (isNaN(d.getTime())) return iso; // fall back to the raw string on bad input
   return d.toLocaleString(getCurrentLocale(), {
     weekday: "short",
     year: "numeric",
@@ -86,30 +163,58 @@ export function formatDateTimeFull(iso: string): string {
   });
 }
 
-/** Formats the elapsed time between two ISO/SQLite timestamps as "Nh Nm" /
- *  "Nm Ns" / "Ns" (see {@link formatMs}). Negative spans (end before start,
- *  e.g. clock skew) clamp to "0s". */
+// ===========================================================================
+// Duration + relative-time formatters
+// ===========================================================================
+
+/**
+ * Formats the elapsed time between two ISO/SQLite timestamps as "Nh Nm" /
+ * "Nm Ns" / "Ns" (see {@link formatMs}). Negative spans (end before start,
+ * e.g. clock skew) clamp to "0s".
+ * @param start Earlier timestamp (see {@link parseDate}).
+ * @param end Later timestamp (see {@link parseDate}).
+ * @returns The formatted duration (delegated to {@link formatMs}).
+ */
 export function formatDuration(start: string, end: string): string {
   const ms = parseDate(end).getTime() - parseDate(start).getTime();
   return formatMs(ms);
 }
 
-/** Formats a millisecond duration as the coarsest two-unit representation:
- *  "Nh Nm" once >= 1 hour, "Nm Ns" once >= 1 minute, else "Ns". */
+/**
+ * Formats a millisecond duration as the coarsest two-unit representation:
+ * "Nh Nm" once >= 1 hour, "Nm Ns" once >= 1 minute, else "Ns".
+ * @param ms Duration in milliseconds.
+ * @returns A compact two-unit string; sub-second and negative inputs both render as `"0s"`.
+ * @remarks Only ever shows the two most-significant units - hours never spill into days
+ *   (a 26-hour span reads "26h 0m"), matching the dashboard's short session lifetimes.
+ * @example
+ *   formatMs(3_930_000) // "1h 5m"
+ *   formatMs(65_000)    // "1m 5s"
+ *   formatMs(4_000)     // "4s"
+ *   formatMs(-10)       // "0s"
+ */
 export function formatMs(ms: number): string {
-  if (ms < 0) return "0s";
+  if (ms < 0) return "0s"; // clamp negative spans (clock skew) to zero
   const totalSec = Math.floor(ms / 1000);
-  const hours = Math.floor(totalSec / 3600);
-  const minutes = Math.floor((totalSec % 3600) / 60);
-  const seconds = totalSec % 60;
+  const hours = Math.floor(totalSec / 3600); // whole hours
+  const minutes = Math.floor((totalSec % 3600) / 60); // leftover whole minutes
+  const seconds = totalSec % 60; // leftover whole seconds
 
-  if (hours > 0) return `${hours}h ${minutes}m`;
-  if (minutes > 0) return `${minutes}m ${seconds}s`;
-  return `${seconds}s`;
+  if (hours > 0) return `${hours}h ${minutes}m`; // >= 1h: hours + minutes
+  if (minutes > 0) return `${minutes}m ${seconds}s`; // >= 1m: minutes + seconds
+  return `${seconds}s`; // < 1m: seconds only
 }
 
-/** Formats how long ago an ISO/SQLite timestamp was, as a translated relative
- *  string ("just now", "5m ago", "3h ago", "2d ago") using {@link i18n}. */
+/**
+ * Formats how long ago an ISO/SQLite timestamp was, as a translated relative
+ * string ("just now", "5m ago", "3h ago", "2d ago") using {@link i18n}.
+ * @param iso A past timestamp (see {@link parseDate}).
+ * @returns A localized relative-time phrase; i18next handles pluralization via `count`.
+ * @remarks Thresholds cascade seconds -> minutes -> hours -> days (days is the largest
+ *   bucket, so a 40-day-old event reads "40d ago"). Under a minute collapses to the
+ *   "just now" key. Uses translated keys, not `Intl.RelativeTimeFormat`, so the exact
+ *   wording is controlled by the `common:time.*` translation resources.
+ */
 export function timeAgo(iso: string): string {
   const ms = Date.now() - parseDate(iso).getTime();
   const seconds = Math.floor(ms / 1000);
@@ -122,58 +227,137 @@ export function timeAgo(iso: string): string {
   return i18n.t("common:time.dAgo", { count: days });
 }
 
-/** Truncates `str` to at most `max` characters, appending an ellipsis ("\u2026")
- *  in place of the last character when truncation occurs. */
+// ===========================================================================
+// String + number formatters
+// ===========================================================================
+
+/**
+ * Truncates `str` to at most `max` characters, appending an ellipsis ("\u2026")
+ * in place of the last character when truncation occurs.
+ * @param str Source string.
+ * @param max Maximum length of the returned string, *including* the ellipsis.
+ * @returns `str` unchanged when it already fits; otherwise its first `max - 1`
+ *   characters followed by a single "\u2026" so the result is exactly `max` chars long.
+ * @remarks Counts UTF-16 code units, not grapheme clusters, so a `max` that lands inside
+ *   a surrogate pair or combining sequence could split it - fine for the ASCII-ish labels
+ *   this is used on.
+ */
 export function truncate(str: string, max: number): string {
   if (str.length <= max) return str;
-  return str.slice(0, max - 1) + "\u2026";
+  return str.slice(0, max - 1) + "\u2026"; // reserve one slot for the ellipsis
 }
 
-/** Format large numbers with B/M/K suffixes. */
+/**
+ * Format large numbers with B/M/K suffixes.
+ * @param n The number to abbreviate (typically a token count or event tally).
+ * @returns A compact magnitude string: `"1.2B"`, `"3.4M"`, `"5.6K"`, or the number
+ *   verbatim below 1,000. Non-finite input (`NaN`/`±Infinity`) yields `"0"`.
+ * @remarks Thresholds are checked largest-first so exactly one suffix applies. Values
+ *   under 1,000 are returned unabbreviated via `String(n)` (no forced decimals), so
+ *   `fmt(42)` is `"42"` and `fmt(999)` is `"999"`. One decimal place is kept for the
+ *   abbreviated tiers (`toFixed(1)`). Negative numbers are passed through unabbreviated.
+ * @example fmt(1_500) // "1.5K"   fmt(2_400_000) // "2.4M"   fmt(950) // "950"
+ */
 export function fmt(n: number): string {
-  if (!Number.isFinite(n)) return "0";
-  if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)}B`;
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
-  return String(n);
+  if (!Number.isFinite(n)) return "0"; // NaN / Infinity guard
+  if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)}B`; // billions
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`; // millions
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`; // thousands
+  return String(n); // < 1000: show as-is
 }
 
-/** Format dollar amounts with K/M suffixes. */
+/**
+ * Format dollar amounts with K/M suffixes.
+ * @param n A dollar amount (e.g. accumulated API spend).
+ * @returns A compact currency string with two decimals: `"$1.23M"`, `"$4.56K"`, or
+ *   `"$7.89"`. Non-finite *or negative* input yields `"$0.00"`.
+ * @remarks Unlike {@link fmt}, negatives are clamped (a cost is never shown below zero)
+ *   and the abbreviated tiers keep two decimals to preserve cents-level precision. Caps
+ *   at the millions suffix - there is no billions tier for costs.
+ * @example fmtCost(12_500) // "$12.50K"   fmtCost(3.5) // "$3.50"   fmtCost(-1) // "$0.00"
+ */
 export function fmtCost(n: number): string {
-  if (!Number.isFinite(n) || n < 0) return "$0.00";
-  if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(2)}M`;
-  if (n >= 1_000) return `$${(n / 1_000).toFixed(2)}K`;
-  return `$${n.toFixed(2)}`;
+  if (!Number.isFinite(n) || n < 0) return "$0.00"; // guard NaN/Infinity/negative
+  if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(2)}M`; // millions
+  if (n >= 1_000) return `$${(n / 1_000).toFixed(2)}K`; // thousands
+  return `$${n.toFixed(2)}`; // < $1000: full cents
 }
 
-/** Format dollar amounts with commas (for tooltips / full display). */
+/**
+ * Format dollar amounts with commas (for tooltips / full display).
+ * @param n A dollar amount.
+ * @param decimals Fixed number of fraction digits to show (default 2).
+ * @returns The un-abbreviated amount with locale-aware digit grouping, e.g.
+ *   `"$1,234,567.89"` (en-US) or the locale's equivalent separators. `"$0.00"` for
+ *   non-finite/negative input.
+ * @remarks Complements {@link fmtCost}: that one is compact for stat tiles, this one is
+ *   exact for tooltips/detail views. Grouping and decimal marks come from
+ *   {@link getCurrentLocale}, so the same value renders `1,234.50` in en-US and `1.234,50`
+ *   in locales that swap the separators. `minimumFractionDigits === maximumFractionDigits`
+ *   forces exactly `decimals` places (no trimming, no rounding drift beyond `toLocaleString`).
+ */
 export function fmtCostFull(n: number, decimals = 2): string {
-  if (!Number.isFinite(n) || n < 0) return "$0.00";
+  if (!Number.isFinite(n) || n < 0) return "$0.00"; // guard NaN/Infinity/negative
   return `$${n.toLocaleString(getCurrentLocale(), {
     minimumFractionDigits: decimals,
     maximumFractionDigits: decimals,
   })}`;
 }
 
-/** Strip the date suffix from a Claude model ID:
- *  "claude-opus-4-7-20260101" → "opus-4-7". Returns the original string
- *  when the pattern doesn't match, and null/undefined unchanged. */
+// ===========================================================================
+// Model-name + path formatters
+// ===========================================================================
+
+/**
+ * Strip the date suffix from a Claude model ID:
+ * "claude-opus-4-7-20260101" → "opus-4-7". Returns the original string
+ * when the pattern doesn't match, and null/undefined unchanged.
+ * @param model A raw model identifier, or null/undefined.
+ * @returns The captured `tier-major(-minor)` slug (e.g. `"opus-4-7"`), the original
+ *   string if it isn't a `claude-…` id, or `null` for falsy input.
+ * @remarks The capture group `([a-z]+-\d+(?:-\d+)?)` grabs the family plus a one- or
+ *   two-segment version (`sonnet-4`, `opus-4-7`) but stops before the trailing
+ *   `-YYYYMMDD` date. This is the terse form; {@link formatModelName} is the pretty one.
+ */
 export function shortModel(model: string | null | undefined): string | null {
   if (!model) return null;
   const m = model.match(/claude-([a-z]+-\d+(?:-\d+)?)/i);
-  return m?.[1] ?? model;
+  return m?.[1] ?? model; // captured slug, else the input unchanged
 }
 
+/**
+ * Lookup from a lowercased leading token to its display brand. Drives the
+ * brand-specific formatting branches in {@link formatModelName}; a token absent
+ * here just gets generic title-casing.
+ */
 const MODEL_BRANDS: Record<string, string> = {
   claude: "Claude",
   gpt: "GPT",
   gemini: "Gemini",
 };
 
-/** Human-friendly model name:
+/**
+ * Human-friendly model name:
  *  "claude-opus-4-7-20260101" → "Claude Opus 4.7"
  *  "gpt-4o-mini"              → "GPT-4o Mini"
- *  Returns null for falsy input. */
+ *  Returns null for falsy input.
+ * @param model A raw model id, optionally provider-prefixed and/or context-tagged.
+ * @returns A display name, or `null` for falsy input.
+ * @remarks Normalization runs in fixed stages:
+ *   1. Drop any provider prefix before the last `/` (`anthropic/claude-…` -> `claude-…`).
+ *   2. Peel a trailing bracketed context-window tag `[1m]`/`[200k]` off and remember it
+ *      as a parenthesized upper-cased suffix (` (1M)`), re-appended at the very end.
+ *   3. Strip a trailing `-YYYYMMDD` snapshot date and a trailing `-latest`.
+ *   4. Split on `-` and branch by brand:
+ *      - **GPT**: keep the brand glued to its version token (`GPT-4o`) and title-case the
+ *        remaining words (`mini` -> `Mini`), because GPT versions read as one unit.
+ *      - **Claude/Gemini/generic**: title-case each word, but join *runs of numeric
+ *        segments* with dots so `4-7` becomes `4.7`; alphanumerics like `4o` pass through.
+ * @example
+ *   formatModelName("anthropic/claude-opus-4-7-20260101[1m]") // "Claude Opus 4.7 (1M)"
+ *   formatModelName("gpt-4o-mini")                            // "GPT-4o Mini"
+ *   formatModelName("gemini-1-5-pro")                         // "Gemini 1.5 Pro"
+ */
 export function formatModelName(model: string | null | undefined): string | null {
   if (!model) return null;
 
@@ -184,23 +368,24 @@ export function formatModelName(model: string | null | undefined): string | null
   let ctxSuffix = "";
   const ctxMatch = name.match(/\[(\d+[mk])\]$/i);
   if (ctxMatch) {
-    ctxSuffix = ` (${(ctxMatch[1] as string).toUpperCase()})`;
-    name = name.slice(0, -ctxMatch[0].length);
+    ctxSuffix = ` (${(ctxMatch[1] as string).toUpperCase()})`; // "[1m]" -> " (1M)"
+    name = name.slice(0, -ctxMatch[0].length); // remove the bracketed tag from `name`
   }
 
   // Strip date suffix and "-latest"
   name = name.replace(/-\d{8}$/, "").replace(/-latest$/i, "");
 
   const parts: string[] = name.split("-");
-  const first = parts[0] ?? name;
-  const brand = MODEL_BRANDS[first.toLowerCase()];
+  const first = parts[0] ?? name; // family/brand token (e.g. "claude", "gpt")
+  const brand = MODEL_BRANDS[first.toLowerCase()]; // undefined if not a known brand
 
   // GPT-style names keep the brand hyphenated with the version token:
   // "gpt-4o-mini" → "GPT-4o Mini"
   if (brand === "GPT" && parts.length >= 2) {
-    const versionToken = parts[1] as string;
-    const rest = parts.slice(2);
+    const versionToken = parts[1] as string; // e.g. "4o" - stays glued to the brand
+    const rest = parts.slice(2); // trailing qualifiers, e.g. ["mini"]
     const suffix = rest
+      // Numeric segments stay as-is; word segments get title-cased.
       .map((seg) => (/^\d+$/.test(seg) ? seg : seg.charAt(0).toUpperCase() + seg.slice(1)))
       .join(" ");
     const base = suffix ? `${brand}-${versionToken} ${suffix}` : `${brand}-${versionToken}`;
@@ -208,12 +393,15 @@ export function formatModelName(model: string | null | undefined): string | null
   }
 
   // Claude / Gemini / generic: title-case words, dot-join version digits
+  // Seed with the known brand, or a title-cased first token when the brand is unknown.
   const result: string[] = [brand ?? first.charAt(0).toUpperCase() + first.slice(1)];
 
   let i = 1;
   while (i < parts.length) {
     const seg = parts[i] as string;
     if (/^\d+$/.test(seg)) {
+      // Purely numeric segment: greedily absorb following numeric segments and
+      // join them with dots so "4-7" -> "4.7", "1-5" -> "1.5".
       const ver = [seg];
       while (i + 1 < parts.length && /^\d+$/.test(parts[i + 1] as string)) {
         i++;
@@ -221,21 +409,31 @@ export function formatModelName(model: string | null | undefined): string | null
       }
       result.push(ver.join("."));
     } else if (/^\d+\w+$/.test(seg)) {
+      // Alphanumeric like "4o"/"3b": keep verbatim (don't title-case or split).
       result.push(seg);
     } else {
+      // Plain word: title-case it ("opus" -> "Opus", "pro" -> "Pro").
       result.push(seg.charAt(0).toUpperCase() + seg.slice(1));
     }
     i++;
   }
 
-  return result.join(" ") + ctxSuffix;
+  return result.join(" ") + ctxSuffix; // re-attach the context-window suffix, if any
 }
 
-/** Last segment of a filesystem path. POSIX-only - fine for cwd display.
- *  "/Users/dav/code/my-project" → "my-project". */
+/**
+ * Last segment of a filesystem path. POSIX-only - fine for cwd display.
+ * "/Users/dav/code/my-project" → "my-project".
+ * @param p An absolute or relative POSIX path, or null/undefined.
+ * @returns The final path segment, or `null` for falsy input.
+ * @remarks Trailing slashes are stripped first (`/a/b/` -> `b`). A path with no `/`
+ *   returns unchanged. The `|| trimmed` fallback guards the degenerate case where the
+ *   input is just slashes (e.g. `"/"`), returning the trimmed value rather than `""`.
+ *   Backslash-separated (Windows) paths are not handled.
+ */
 export function pathBasename(p: string | null | undefined): string | null {
   if (!p) return null;
-  const trimmed = p.replace(/\/+$/, "");
+  const trimmed = p.replace(/\/+$/, ""); // drop trailing slash(es)
   const idx = trimmed.lastIndexOf("/");
   return idx === -1 ? trimmed : trimmed.slice(idx + 1) || trimmed;
 }

--- a/client/src/lib/highlight.ts
+++ b/client/src/lib/highlight.ts
@@ -9,45 +9,118 @@
  * The goal is "good enough to scan", not full lexical correctness - we accept the
  * occasional mis-tokenization in favour of small bundle size and zero deps.
  *
+ * ## Why a hand-rolled highlighter?
+ * Full-featured highlighters (Prism, highlight.js, Shiki) each pull in tens to hundreds
+ * of kilobytes and a grammar loader. The dashboard only ever renders short code fences
+ * pasted into a transcript, so absolute lexical fidelity is unnecessary; a compact,
+ * synchronous, allocation-light tokenizer keeps the bundle small and avoids async grammar
+ * loading on first paint. Mis-tokenizations (e.g. a JS label mistaken for a property) are
+ * acceptable because the reader still gets legible, colour-cued code.
+ *
+ * ## Pipeline / data flow
+ * `CodeBlock.tsx` -> {@link highlight}(source, lang) -> {@link Token}[] -> one <span> per
+ * token whose className comes from {@link tokenClass}. The language tag on the fence is
+ * first funnelled through {@link canonicalLang} to collapse aliases (jsx/mjs -> "js",
+ * yml -> "yaml", …) down to the ten canonical keys this module actually implements.
+ *
+ * ## Two tokenizer families
+ * 1. Rule-driven scanners (JS/TS, Python, JSON, shell, CSS, SQL) share {@link tokenizeWith},
+ *    a tiny engine that walks the source left-to-right and, at each cursor position, tries
+ *    an ordered list of sticky (`/y`) regex {@link Rule}s. The first rule that matches at
+ *    the cursor wins; unmatched characters accrete into "plain" tokens. Because identifier
+ *    and keyword shapes overlap, these scanners first tag every identifier as "keyword" and
+ *    then run a post-pass ({@link refineIdentifiers} for JS/Python, inline loops for shell
+ *    and SQL) that re-classifies each word into keyword/builtin/boolean/plain using the
+ *    per-language word sets below.
+ * 2. Hand-written scanners (HTML, YAML, diff) bypass {@link tokenizeWith} because their
+ *    structure is line- or multi-group-oriented rather than a flat token stream: HTML needs
+ *    grouped tag/attribute matches, while YAML and diff are line-prefix driven.
+ *
+ * ## Ordering matters
+ * Within every {@link Rule} list the order encodes precedence: comments and strings come
+ * first so that keyword/number/operator patterns can never "reach into" a comment or a
+ * quoted literal. Likewise the JSON scanner lists the key-string rule (a string followed by
+ * `:`) before the plain value-string rule so object keys get their own colour.
+ *
  * @author Son Nguyen <hoangson091104@gmail.com>
  */
+
+// ---------------------------------------------------------------------------
+// Core token model
+//
+// Everything downstream (the tokenizers, the refinement passes, CodeBlock.tsx)
+// speaks in terms of these three shapes: the closed set of colour categories
+// ({@link TokenType}), the (type, text) pair a scan emits ({@link Token}), and
+// the sticky-regex rule the shared engine consumes ({@link Rule}).
+// ---------------------------------------------------------------------------
 
 /** Syntax category assigned to a {@link Token}. Not every tokenizer emits
  *  every type - e.g. "tag"/"attr" are HTML-only, "diff-*" are diff-only,
  *  "variable" is shell-only. {@link tokenClass} maps each to a colour class. */
 export type TokenType =
-  | "plain"
-  | "comment"
-  | "string"
-  | "number"
-  | "keyword"
-  | "builtin"
-  | "function"
-  | "operator"
-  | "punctuation"
-  | "property"
-  | "tag"
-  | "attr"
-  | "variable"
-  | "boolean"
-  | "diff-add"
-  | "diff-del"
-  | "diff-meta";
+  // Shared across (almost) every language.
+  | "plain" // uncoloured text: whitespace, unmatched chars, disabled languages
+  | "comment" // `//`, `#`, `/* */`, `--`, `<!-- -->` depending on language
+  | "string" // quoted literals (and HTML attribute values)
+  | "number" // integer / float / hex / binary / octal / unit-suffixed literals
+  | "keyword" // reserved words (see the per-language *_KEYWORDS sets)
+  | "builtin" // well-known globals / commands (see the *_BUILTINS sets)
+  | "function" // an identifier immediately followed by `(` (a call/def site)
+  | "operator" // `=>`, `===`, `&&`, arithmetic/comparison/bitwise operators
+  | "punctuation" // brackets, braces, commas, semicolons, colons, dots
+  | "property" // object/JSON keys and YAML keys; CSS property names
+  // Language-specific categories (only emitted by the tokenizer named).
+  | "tag" // HTML element names; CSS selectors
+  | "attr" // HTML attribute names
+  | "variable" // shell variable expansions (`$foo`, `${bar}`, `$?`)
+  | "boolean" // literal constants: true/false/null/None/undefined/…
+  | "diff-add" // a unified-diff added line (`+…`)
+  | "diff-del" // a unified-diff removed line (`-…`)
+  | "diff-meta"; // a unified-diff header line (`@@`, `+++`, `---`, `diff …`)
 
 /** One lexical unit produced by {@link highlight} - a run of source text
- *  tagged with the colour category it should render as. */
+ *  tagged with the colour category it should render as. A whole highlighted
+ *  code block is simply an ordered `Token[]`; concatenating every `text` in
+ *  order always reproduces the original `source` byte-for-byte (the tokenizers
+ *  never drop or rewrite characters, only classify them). */
 export interface Token {
+  /** Which colour category this run of text belongs to. */
   type: TokenType;
+  /** The exact source substring this token covers (never normalized). */
   text: string;
 }
 
 /** One entry in a per-language tokenizer's ordered rule list: match `pattern`
- *  (a sticky `/y` regex) at the cursor and, if it wins, tag the match `type`. */
+ *  (a sticky `/y` regex) at the cursor and, if it wins, tag the match `type`.
+ *  The sticky flag is essential - it lets {@link tokenizeWith} anchor each
+ *  attempt to the current cursor via `pattern.lastIndex` instead of scanning
+ *  forward, so a rule only ever matches text that starts exactly at the cursor. */
 interface Rule {
+  /** The category to tag the matched text with when this rule wins. */
   type: TokenType;
+  /** A sticky (`/y`) regex; must be able to match starting at `lastIndex`. */
   pattern: RegExp;
 }
 
+// ===========================================================================
+// Per-language word sets
+//
+// The rule-driven scanners can't tell a reserved word from an ordinary
+// identifier with a regex alone (both look like `[a-zA-Z_$][\w$]*`), so each
+// language tags every bare identifier as "keyword" during the scan and then a
+// post-pass consults these Sets to reclassify it:
+//   - in *_KEYWORDS  -> stays "keyword" (reserved word)
+//   - in *_BUILTINS  -> becomes "builtin" (well-known global / command)
+//   - in *_LITERALS  -> becomes "boolean" (true/false/null-style constant)
+//   - otherwise      -> demoted to "plain" (a user-defined name)
+// Membership tests are O(1) `Set.has`, and case-sensitive except for SQL (whose
+// set lives inside {@link tokenizeSQL} and is matched case-insensitively).
+// ===========================================================================
+
+/** JavaScript/TypeScript reserved words (incl. TS-only ones like `interface`,
+ *  `type`, `enum`, `readonly`, `declare`, `abstract`, `override`). Words here
+ *  render as "keyword". Note `type`/`interface`/`namespace` are contextual in
+ *  real TS but are always coloured as keywords here for simplicity. */
 const JS_KEYWORDS = new Set([
   "const",
   "let",
@@ -101,6 +174,10 @@ const JS_KEYWORDS = new Set([
   "override",
 ]);
 
+/** Well-known JS/TS globals and Node.js ambient names. Words here render as
+ *  "builtin" (a distinct colour from keywords) so calls like `JSON.parse` or
+ *  `console.log` read at a glance. Not exhaustive - just the common ones seen
+ *  in transcripts; anything missing simply falls through to "plain". */
 const JS_BUILTINS = new Set([
   "console",
   "window",
@@ -129,8 +206,14 @@ const JS_BUILTINS = new Set([
   "__filename",
 ]);
 
+/** JS/TS literal constants. These are coloured "boolean" (which shares the
+ *  orange number colour) rather than "keyword" so they visually group with the
+ *  values they are, not the control-flow words. */
 const JS_LITERALS = new Set(["true", "false", "null", "undefined", "NaN", "Infinity"]);
 
+/** Python reserved words. Includes `self`/`cls` (conventionally the first
+ *  parameter of methods) so they colour like keywords even though they are
+ *  technically ordinary identifiers in the language grammar. */
 const PY_KEYWORDS = new Set([
   "def",
   "class",
@@ -166,6 +249,8 @@ const PY_KEYWORDS = new Set([
   "cls",
 ]);
 
+/** Python built-in functions/types (the subset commonly seen). `Exception` is
+ *  included as a representative built-in exception. Rendered as "builtin". */
 const PY_BUILTINS = new Set([
   "print",
   "len",
@@ -197,8 +282,14 @@ const PY_BUILTINS = new Set([
   "Exception",
 ]);
 
+/** Python literal constants. Case matters - these are capitalized, unlike the
+ *  lowercase JS literals - so `true` in Python source stays "plain". */
 const PY_LITERALS = new Set(["True", "False", "None"]);
 
+/** Shell/bash control-flow and declaration words. Rendered as "keyword". The
+ *  shell scanner deliberately keeps this list separate from {@link SH_BUILTINS}
+ *  so that structural words (`if`/`fi`/`for`/`done`) colour differently from
+ *  the commands you actually invoke. */
 const SH_KEYWORDS = new Set([
   "if",
   "then",
@@ -225,6 +316,11 @@ const SH_KEYWORDS = new Set([
   "source",
 ]);
 
+/** Common shell commands and coreutils/dev tools (git, npm, node, curl, …).
+ *  A word here renders as "builtin". In {@link tokenizeShell} an identifier is
+ *  only checked against this set when it was tagged "keyword" or "function"
+ *  (i.e. a bare command word), so `grep` used as a command highlights but a
+ *  variable that happens to be named `grep` would not (it is a "variable"). */
 const SH_BUILTINS = new Set([
   "echo",
   "cd",
@@ -265,26 +361,59 @@ const SH_BUILTINS = new Set([
   "tee",
 ]);
 
-/** Escapes regex metacharacters so `s` can be embedded in a `RegExp` literally. */
+// ===========================================================================
+// Shared scanning engine
+// ===========================================================================
+
+/**
+ * Escapes regex metacharacters so `s` can be embedded in a `RegExp` literally.
+ * @param s Arbitrary text that may contain characters special to a regex.
+ * @returns `s` with every one of `. * + ? ^ $ { } ( ) | [ ] \` backslash-escaped,
+ *   so `new RegExp(escapeRegex(s))` matches `s` verbatim. `$&` in the replacement
+ *   is the matched metacharacter itself.
+ * @example escapeRegex("a.b(c)") // => "a\\.b\\(c\\)"
+ * @remarks Currently only re-exported (as {@link _escapeRegex}) for consumers/tests;
+ *   the built-in tokenizers use literal regexes and don't call it.
+ */
 function escapeRegex(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-/** Apply an ordered list of rules to source. Earlier rules win. Any character
- *  matched by no rule is appended as/into a "plain" token. */
+/**
+ * The heart of every rule-driven tokenizer: walk `source` left-to-right and, at
+ * each cursor position, try the `rules` in order until one matches exactly at
+ * the cursor. This is a classic "maximal-munch by priority" lexer - priority is
+ * the array order, munch length is whatever the winning regex consumed.
+ *
+ * @param source Raw source text to scan.
+ * @param rules Ordered rule list; earlier rules win ties, so put comments and
+ *   strings first and the greedy identifier/number rules last.
+ * @returns A gap-free `Token[]` whose concatenated `text` equals `source`.
+ *
+ * @remarks
+ * - Each rule's `pattern` must carry the sticky flag (`/y`). Setting
+ *   `pattern.lastIndex = i` and calling `exec` then only matches if the pattern
+ *   starts at `i`; the extra `m.index === i` guard is belt-and-braces in case a
+ *   non-sticky regex ever sneaks in.
+ * - Any character matched by no rule becomes (or extends) a "plain" token. We
+ *   append single unmatched chars one at a time but coalesce consecutive ones
+ *   into the previous "plain" token, which keeps the token array short (fewer
+ *   React spans) without changing the rendered output.
+ */
 function tokenizeWith(source: string, rules: Rule[]): Token[] {
   const tokens: Token[] = [];
-  let i = 0;
+  let i = 0; // current scan cursor (byte index into `source`)
   while (i < source.length) {
     let matched = false;
     for (const rule of rules) {
+      // Anchor this rule's sticky regex to the cursor so it can only match here.
       rule.pattern.lastIndex = i;
       const m = rule.pattern.exec(source);
       if (m && m.index === i) {
         tokens.push({ type: rule.type, text: m[0] });
-        i += m[0].length;
+        i += m[0].length; // advance past the whole matched run
         matched = true;
-        break;
+        break; // first rule wins; don't let later rules re-match the same text
       }
     }
     if (!matched) {
@@ -299,17 +428,49 @@ function tokenizeWith(source: string, rules: Rule[]): Token[] {
   return tokens;
 }
 
-/** Tokenizer for JavaScript/TypeScript ("js"/"ts" canonical languages). */
+// ===========================================================================
+// Per-language tokenizers
+//
+// Each `tokenizeX` builds an ordered {@link Rule} list and (for the rule-driven
+// ones) feeds it to {@link tokenizeWith}. Rule order is precedence: comments and
+// strings must precede the identifier/number/operator rules so those greedy
+// patterns can't reach into a comment or a quoted literal. Identifier-heavy
+// languages then run a refinement pass to split the catch-all "keyword" tag.
+// ===========================================================================
+
+/**
+ * Tokenizer for JavaScript/TypeScript ("js"/"ts" canonical languages).
+ * @param source JS/TS source text.
+ * @returns Tokens with identifiers already refined into keyword/builtin/boolean/plain.
+ * @remarks Rule order (first match wins):
+ *   1. comment  - `//` to EOL, or `/* … *\/` (non-greedy, spans newlines).
+ *   2. string   - double / single (no raw newline) or backtick template (may span
+ *      lines); template interpolations are not parsed, they stay inside the string.
+ *   3. number   - hex `0x…`, binary `0b…`, octal `0o…`, or decimal with optional
+ *      fraction and exponent; `\b…\b` keeps it from eating into an identifier.
+ *   4. function - an identifier immediately followed by `(` via lookahead `(?=\s*\()`;
+ *      this fires before the keyword rule so call sites colour as calls.
+ *   5. keyword  - any remaining identifier (refined afterwards).
+ *   6. operator - multi-char forms first (`=>`,`===`,`??`,`...`) so they aren't split
+ *      into single-char operators, then the single-char class.
+ *   7. punctuation - brackets/braces/parens/semicolon/comma/dot.
+ */
 function tokenizeJS(source: string): Token[] {
   const rules: Rule[] = [
+    // Line (`// …`) or block (`/* … */`, non-greedy across newlines) comments.
     { type: "comment", pattern: /\/\/[^\n]*|\/\*[\s\S]*?\*\//y },
+    // Double, single (both newline-terminated) or backtick template literals.
     { type: "string", pattern: /"(?:\\.|[^"\\\n])*"|'(?:\\.|[^'\\\n])*'|`(?:\\.|[^`\\])*`/y },
     {
+      // Hex / binary / octal / decimal (optional fraction + exponent), word-bounded.
       type: "number",
       pattern: /\b(?:0[xX][0-9a-fA-F]+|0[bB][01]+|0[oO][0-7]+|\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)\b/y,
     },
+    // Identifier directly before `(` -> a call/definition site.
     { type: "function", pattern: /\b[a-zA-Z_$][\w$]*(?=\s*\()/y },
+    // Any other identifier; refineIdentifiers() reclassifies it below.
     { type: "keyword", pattern: /\b[a-zA-Z_$][\w$]*\b/y },
+    // Multi-char operators are listed before the single-char class so they win.
     { type: "operator", pattern: /=>|===|!==|==|!=|<=|>=|&&|\|\||\?\?|\.\.\.|[+\-*/%=<>!&|^~?:]/y },
     { type: "punctuation", pattern: /[{}[\]();,.]/y },
   ];
@@ -317,25 +478,54 @@ function tokenizeJS(source: string): Token[] {
   return refineIdentifiers(tokenizeWith(source, rules), JS_KEYWORDS, JS_BUILTINS, JS_LITERALS);
 }
 
-/** Tokenizer for Python source ("python" canonical language). */
+/**
+ * Tokenizer for Python source ("python" canonical language).
+ * @param source Python source text.
+ * @returns Tokens with identifiers refined via {@link PY_KEYWORDS}/{@link PY_BUILTINS}/
+ *   {@link PY_LITERALS}.
+ * @remarks Differences from the JS scanner:
+ *   - Comments are `#`-to-EOL only (no block comments in Python).
+ *   - The string rule lists triple-quoted `"""…"""` / `'''…'''` *before* the single-line
+ *     quotes so a docstring is consumed whole rather than as an empty `""` then text.
+ *     f/r/b string prefixes are not modelled, so the prefix letter tokenizes separately.
+ *   - Operators include Python-specific `**` (power), `//` (floor div) and `->` (return
+ *     annotation), again longest-first so they don't split.
+ */
 function tokenizePython(source: string): Token[] {
   const rules: Rule[] = [
     { type: "comment", pattern: /#[^\n]*/y },
     {
+      // Triple-quoted (docstrings) first, then ordinary single-line strings.
       type: "string",
       pattern: /"""[\s\S]*?"""|'''[\s\S]*?'''|"(?:\\.|[^"\\\n])*"|'(?:\\.|[^'\\\n])*'/y,
     },
     { type: "number", pattern: /\b\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\b/y },
     { type: "function", pattern: /\b[a-zA-Z_][\w]*(?=\s*\()/y },
     { type: "keyword", pattern: /\b[a-zA-Z_][\w]*\b/y },
+    // `**`/`//`/`<<`/`>>`/`->` before single-char operators.
     { type: "operator", pattern: /\*\*|\/\/|<<|>>|<=|>=|==|!=|->|[+\-*/%=<>!&|^~]/y },
     { type: "punctuation", pattern: /[{}[\]():,.]/y },
   ];
   return refineIdentifiers(tokenizeWith(source, rules), PY_KEYWORDS, PY_BUILTINS, PY_LITERALS);
 }
 
-/** Tokenizer for JSON/JSONC ("json" canonical language). Object keys are
- *  re-tagged "property" (see below) instead of "string" for a distinct colour. */
+/**
+ * Tokenizer for JSON/JSONC ("json" canonical language). Object keys are
+ * re-tagged "property" (see below) instead of "string" for a distinct colour.
+ * @param source JSON (or JSON-with-comments) source text.
+ * @returns Tokens where string keys are "property" and string values stay "string".
+ * @remarks
+ * - There is no comment rule, so JSONC `//`/`/* *\/` comments tokenize as plain
+ *   punctuation/text rather than as comments - acceptable for scanning.
+ * - `true`/`false`/`null` are tagged "boolean" directly by their own rule (no
+ *   identifier rule exists here, unlike JS/Python).
+ * - The two string rules look identical except the first requires a trailing `:`
+ *   lookahead; that fast-paths keys on a compact single line, but the following
+ *   loop is what robustly re-tags keys even when whitespace separates the string
+ *   and the colon (e.g. pretty-printed JSON). It scans forward past whitespace-only
+ *   "plain" tokens and, if the next meaningful token is a `:`, promotes the string
+ *   to "property".
+ */
 function tokenizeJSON(source: string): Token[] {
   const rules: Rule[] = [
     { type: "string", pattern: /"(?:\\.|[^"\\])*"(?=\s*:)/y }, // key
@@ -351,26 +541,47 @@ function tokenizeJSON(source: string): Token[] {
       // Look ahead through whitespace plain tokens
       for (let j = i + 1; j < tokens.length; j++) {
         const t = tokens[j]!;
+        // Skip pure-whitespace gaps (indentation/newlines between key and colon).
         if (t.type === "plain" && /^\s*$/.test(t.text)) continue;
+        // First non-whitespace token is a colon => this string was an object key.
         if (t.type === "punctuation" && t.text === ":") {
           tokens[i]!.type = "property";
         }
-        break;
+        break; // stop at the first meaningful token either way
       }
     }
   }
   return tokens;
 }
 
-/** Tokenizer for shell scripts ("bash" canonical language, covers sh/zsh/console). */
+/**
+ * Tokenizer for shell scripts ("bash" canonical language, covers sh/zsh/console).
+ * @param source Shell source text.
+ * @returns Tokens with command words split into keyword/builtin/plain.
+ * @remarks
+ * - Single-quoted strings are literal (`'[^']*'` - no escape processing, matching
+ *   POSIX semantics); double-quoted strings honour `\.` escapes.
+ * - The variable rule matches `${…}` (braced), `$name` (word), and the special
+ *   one-char parameters `$# $? $@ $* $$`.
+ * - Two identifier rules exist: "function" for a word followed by whitespace (the
+ *   typical command-in-command-position shape) and "keyword" for any other bareword.
+ * - The refinement loop only touches words tagged "keyword"/"function": a shell
+ *   keyword stays "keyword", a known command becomes "builtin", and any leftover
+ *   "keyword" (an unknown bareword) is demoted to "plain". A leftover "function"
+ *   (unknown word in command position) is intentionally left as "function".
+ */
 function tokenizeShell(source: string): Token[] {
   const rules: Rule[] = [
     { type: "comment", pattern: /#[^\n]*/y },
+    // Double-quoted (with escapes) or single-quoted (fully literal) strings.
     { type: "string", pattern: /"(?:\\.|[^"\\])*"|'[^']*'/y },
+    // `${braced}`, `$word`, or special params `$# $? $@ $* $$`.
     { type: "variable", pattern: /\$\{[^}]+\}|\$\w+|\$[#?@*$]/y },
     { type: "number", pattern: /\b\d+\b/y },
+    // Word followed by whitespace -> command position (tentatively "function").
     { type: "function", pattern: /\b[a-zA-Z_][\w-]*(?=\s)/y },
     { type: "keyword", pattern: /\b[a-zA-Z_][\w-]*\b/y },
+    // `&&`/`||`/`>>`/`<<` before the single-char pipe/redirect/background chars.
     { type: "operator", pattern: /&&|\|\||>>|<<|[|&;<>=!]/y },
     { type: "punctuation", pattern: /[(){}[\];]/y },
   ];
@@ -378,6 +589,9 @@ function tokenizeShell(source: string): Token[] {
   // refine: distinguish keywords vs builtins vs commands
   for (const t of tokens) {
     if (t.type === "keyword" || t.type === "function") {
+      // A shell keyword stays a keyword; a known command becomes a builtin; any
+      // other leftover "keyword" (an unknown bareword) is demoted to "plain".
+      // An unknown word already tagged "function" keeps that tag (no branch here).
       if (SH_KEYWORDS.has(t.text)) t.type = "keyword";
       else if (SH_BUILTINS.has(t.text)) t.type = "builtin";
       else if (t.type === "keyword") t.type = "plain";
@@ -386,58 +600,110 @@ function tokenizeShell(source: string): Token[] {
   return tokens;
 }
 
-/** Tokenizer for HTML/XML/SVG ("html" canonical language). Uses one regex
- *  scan (not the shared `Rule[]` engine) since tags/attrs need multi-group
- *  matches; delegates attribute parsing to {@link tokenizeHTMLAttrs}. */
+/**
+ * Tokenizer for HTML/XML/SVG ("html" canonical language). Uses one regex
+ * scan (not the shared `Rule[]` engine) since tags/attrs need multi-group
+ * matches; delegates attribute parsing to {@link tokenizeHTMLAttrs}.
+ * @param source HTML/XML/SVG source text.
+ * @returns Tokens: comments whole, tag delimiters as "punctuation", element
+ *   names as "tag", attributes via {@link tokenizeHTMLAttrs}, and text nodes as "plain".
+ * @remarks The single global (`/g`) regex alternates over four shapes, and the
+ *   capture-group index tells us which one fired:
+ *   - `m[1]` `<!-- … -->` comment (non-greedy, may span lines).
+ *   - `m[2]` opening `<` or closing `</` delimiter; `m[3]` the element name;
+ *     `m[4]` the raw attribute-list substring (parsed separately); `m[5]` the
+ *     closing `>` or self-closing `/>`.
+ *   - `m[6]` a run of text between tags (everything up to the next `<`).
+ *   Because it is a plain `/g` scan we simply advance via `re.exec` in a loop;
+ *   `lastIndex` is managed by the engine rather than by us as in {@link tokenizeWith}.
+ */
 function tokenizeHTML(source: string): Token[] {
   const tokens: Token[] = [];
+  // Alternation: (1) comment | (2..5) a tag with grouped delimiters/name/attrs | (6) text.
   const re =
     /(<!--[\s\S]*?-->)|(<\/?)([a-zA-Z][\w-]*)((?:\s+[a-zA-Z_:][\w:.-]*(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+))?)*)\s*(\/?>)|([^<]+)/g;
   let m: RegExpExecArray | null;
   while ((m = re.exec(source)) != null) {
     if (m[1]) tokens.push({ type: "comment", text: m[1] });
     else if (m[2]) {
+      // A tag: emit the `<`/`</`, the element name, its attributes, then `>`/`/>`.
       tokens.push({ type: "punctuation", text: m[2] });
       tokens.push({ type: "tag", text: m[3]! });
       if (m[4]) tokens.push(...tokenizeHTMLAttrs(m[4]));
       tokens.push({ type: "punctuation", text: m[5]! });
-    } else if (m[6]) tokens.push({ type: "plain", text: m[6] });
+    } else if (m[6]) tokens.push({ type: "plain", text: m[6] }); // text node
   }
   return tokens;
 }
 
-/** Tokenizes one HTML tag's attribute-list substring (name=value pairs) for
- *  {@link tokenizeHTML}. */
+/**
+ * Tokenizes one HTML tag's attribute-list substring (name=value pairs) for
+ * {@link tokenizeHTML}.
+ * @param src The `m[4]` capture from {@link tokenizeHTML} - the whitespace-led run
+ *   of `name`, `name=value`, or bare `name` attributes between the tag name and `>`.
+ * @returns A flat token list preserving the leading whitespace of each attribute as
+ *   "plain", the attribute name as "attr", the `=` (with any surrounding spaces) as
+ *   "operator", and the value (quoted or unquoted) as "string".
+ * @remarks Groups `m[3]` (the `=`) and `m[4]` (the value) are optional, so this also
+ *   handles valueless boolean attributes like `<input disabled>`.
+ */
 function tokenizeHTMLAttrs(src: string): Token[] {
   const tokens: Token[] = [];
+  // Per attribute: leading space(s), name, optional `=`, optional quoted/bare value.
   const re = /(\s+)([a-zA-Z_:][\w:.-]*)(\s*=\s*)?("[^"]*"|'[^']*'|[^\s>]+)?/g;
   let m: RegExpExecArray | null;
   while ((m = re.exec(src)) != null) {
-    tokens.push({ type: "plain", text: m[1]! });
-    tokens.push({ type: "attr", text: m[2]! });
-    if (m[3]) tokens.push({ type: "operator", text: m[3] });
-    if (m[4]) tokens.push({ type: "string", text: m[4] });
+    tokens.push({ type: "plain", text: m[1]! }); // separating whitespace
+    tokens.push({ type: "attr", text: m[2]! }); // attribute name
+    if (m[3]) tokens.push({ type: "operator", text: m[3] }); // the `=`
+    if (m[4]) tokens.push({ type: "string", text: m[4] }); // attribute value
   }
   return tokens;
 }
 
-/** Tokenizer for CSS ("css" canonical language, covers scss/less too). */
+/**
+ * Tokenizer for CSS ("css" canonical language, covers scss/less too).
+ * @param source CSS/SCSS/LESS source text.
+ * @returns Tokens: comments, strings, numbers (with an optional unit baked in),
+ *   property names, selectors, and punctuation.
+ * @remarks
+ * - CSS has only block comments (`/* … *\/`), no line comments.
+ * - The number rule optionally absorbs a trailing unit (`px em rem % vh vw s ms deg`),
+ *   so `12px` is one "number" token rather than a number plus an identifier.
+ * - A word followed by `:` is a "property" (declaration name); any other word - with
+ *   an optional leading `.`/`#` - is treated as a selector and tagged "tag". Property
+ *   must precede the selector rule so `color:` colours as a property, not a selector.
+ */
 function tokenizeCSS(source: string): Token[] {
   const rules: Rule[] = [
     { type: "comment", pattern: /\/\*[\s\S]*?\*\//y },
     { type: "string", pattern: /"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'/y },
+    // Signed decimal with an optional CSS unit suffix.
     { type: "number", pattern: /-?\d+(?:\.\d+)?(?:px|em|rem|%|vh|vw|s|ms|deg)?\b/y },
-    { type: "property", pattern: /[a-zA-Z-]+(?=\s*:)/y },
-    { type: "tag", pattern: /[.#]?[a-zA-Z_][\w-]*/y },
+    { type: "property", pattern: /[a-zA-Z-]+(?=\s*:)/y }, // declaration name before `:`
+    { type: "tag", pattern: /[.#]?[a-zA-Z_][\w-]*/y }, // `.class` / `#id` / element selector
     { type: "punctuation", pattern: /[{}();:,]/y },
   ];
   return tokenizeWith(source, rules);
 }
 
-/** Tokenizer for SQL ("sql" canonical language). Unlike the other tokenizers,
- *  the keyword set is local (`KW`) rather than a module-level constant, since
- *  SQL is the only language whose reserved words are checked case-insensitively. */
+/**
+ * Tokenizer for SQL ("sql" canonical language). Unlike the other tokenizers,
+ * the keyword set is local (`KW`) rather than a module-level constant, since
+ * SQL is the only language whose reserved words are checked case-insensitively.
+ * @param source SQL source text.
+ * @returns Tokens where recognized reserved words (any case) are "keyword" and every
+ *   other bareword is demoted to "plain" (table/column/alias names).
+ * @remarks
+ * - Comments are `-- to EOL` or `/* … *\/`.
+ * - Strings are single-quoted with SQL's doubled-quote escape (`''` inside a string),
+ *   captured by `'(?:''|[^'])*'`.
+ * - The scan tags every bareword "keyword", then the refinement loop lowercases each
+ *   and drops any not in `KW` down to "plain" - this is why `SELECT`, `select` and
+ *   `Select` all highlight identically.
+ */
 function tokenizeSQL(source: string): Token[] {
+  // Lowercased reserved words; membership is tested against `text.toLowerCase()`.
   const KW = new Set([
     "select",
     "from",
@@ -492,66 +758,99 @@ function tokenizeSQL(source: string): Token[] {
     "like",
   ]);
   const rules: Rule[] = [
-    { type: "comment", pattern: /--[^\n]*|\/\*[\s\S]*?\*\//y },
-    { type: "string", pattern: /'(?:''|[^'])*'/y },
+    { type: "comment", pattern: /--[^\n]*|\/\*[\s\S]*?\*\//y }, // `-- line` or `/* block */`
+    { type: "string", pattern: /'(?:''|[^'])*'/y }, // single-quoted, `''` = literal quote
     { type: "number", pattern: /\b\d+(?:\.\d+)?\b/y },
-    { type: "keyword", pattern: /\b[a-zA-Z_][\w]*\b/y },
-    { type: "operator", pattern: /<>|<=|>=|!=|[=<>+\-*/]/y },
+    { type: "keyword", pattern: /\b[a-zA-Z_][\w]*\b/y }, // every bareword (refined below)
+    { type: "operator", pattern: /<>|<=|>=|!=|[=<>+\-*/]/y }, // `<>` (not-equal) longest-first
     { type: "punctuation", pattern: /[(),;.]/y },
   ];
   const tokens = tokenizeWith(source, rules);
   for (const t of tokens) {
     if (t.type === "keyword") {
+      // Case-insensitive check: anything not a reserved word is an identifier.
       if (!KW.has(t.text.toLowerCase())) t.type = "plain";
     }
   }
   return tokens;
 }
 
-/** Tokenizer for YAML ("yaml" canonical language). Line-based rather than
- *  regex-rule-based: each line is matched once against a `key: value` pattern
- *  and the value is sniffed for string/number/boolean shape. */
+/**
+ * Tokenizer for YAML ("yaml" canonical language). Line-based rather than
+ * regex-rule-based: each line is matched once against a `key: value` pattern
+ * and the value is sniffed for string/number/boolean shape.
+ * @param source YAML source text.
+ * @returns Tokens with newlines re-inserted between lines as "plain" separators.
+ * @remarks
+ * - Newlines are stripped by `split("\n")` and re-emitted as an explicit "\n" plain
+ *   token before every line except the first, so concatenating the output still
+ *   reproduces `source` exactly (including a trailing newline as a final empty line).
+ * - A whole-line comment (first non-space char is `#`) is emitted verbatim. Inline
+ *   `# …` trailing comments are not split out - they land in the value's "plain".
+ * - The key regex allows an optional leading list dash (`- key: value`). The value
+ *   `rest` is then shape-sniffed in priority order: quoted -> "string", numeric ->
+ *   "number", `true/false/null/~` -> "boolean", otherwise "plain" (bare scalar, flow
+ *   collection, anchor, etc.). Only fully-matching values are recolored; a value with
+ *   trailing content stays "plain".
+ * - Lines that don't look like `key:` (list items, block scalars, blank lines) are
+ *   emitted as a single "plain" token.
+ */
 function tokenizeYAML(source: string): Token[] {
   const tokens: Token[] = [];
   const lines = source.split("\n");
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]!;
-    if (i > 0) tokens.push({ type: "plain", text: "\n" });
+    if (i > 0) tokens.push({ type: "plain", text: "\n" }); // re-insert the split newline
     if (line.trim().startsWith("#")) {
-      tokens.push({ type: "comment", text: line });
+      tokens.push({ type: "comment", text: line }); // whole-line comment
       continue;
     }
+    // Capture: [1] indent (+ optional list dash), [2] key, [3] `:`, [4] the value tail.
     const m = line.match(/^(\s*-?\s*)([a-zA-Z_][\w-]*)(\s*:)(.*)$/);
     if (m) {
-      tokens.push({ type: "plain", text: m[1]! });
-      tokens.push({ type: "property", text: m[2]! });
-      tokens.push({ type: "punctuation", text: m[3]! });
+      tokens.push({ type: "plain", text: m[1]! }); // leading whitespace / `-`
+      tokens.push({ type: "property", text: m[2]! }); // the key
+      tokens.push({ type: "punctuation", text: m[3]! }); // the colon
       const rest = m[4]!;
+      // Sniff the value's scalar type (each test requires the value to fill `rest`).
       if (/^\s*("[^"]*"|'[^']*')\s*$/.test(rest)) {
         tokens.push({ type: "string", text: rest });
       } else if (/^\s*-?\d+(\.\d+)?\s*$/.test(rest)) {
         tokens.push({ type: "number", text: rest });
       } else if (/^\s*(true|false|null|~)\s*$/.test(rest)) {
-        tokens.push({ type: "boolean", text: rest });
+        tokens.push({ type: "boolean", text: rest }); // `~` is YAML's null shorthand
       } else {
-        tokens.push({ type: "plain", text: rest });
+        tokens.push({ type: "plain", text: rest }); // bare scalar / mapping / list value
       }
     } else {
-      tokens.push({ type: "plain", text: line });
+      tokens.push({ type: "plain", text: line }); // not a `key:` line
     }
   }
   return tokens;
 }
 
-/** Tokenizer for unified diffs ("diff" canonical language, covers .patch
- *  too). Purely line-prefix-based: `+`/`-`/`@@`/`+++`/`---`/`diff `. */
+/**
+ * Tokenizer for unified diffs ("diff" canonical language, covers .patch
+ * too). Purely line-prefix-based: `+`/`-`/`@@`/`+++`/`---`/`diff `.
+ * @param source Unified-diff / patch text.
+ * @returns One token per line (plus re-inserted "\n" separators), each coloured by prefix.
+ * @remarks Classification is by first characters, checked in this order so the
+ *   3-char file headers `+++`/`---` are recognized as "diff-meta" *before* the
+ *   single-char `+`/`-` add/remove tests could mislabel them:
+ *   - `+++` / `---` / `@@` / `diff ` -> "diff-meta" (hunk & file headers)
+ *   - `+` -> "diff-add" (added line, green background via {@link tokenClass})
+ *   - `-` -> "diff-del" (removed line, red background)
+ *   - anything else -> "plain" (unchanged context line)
+ *   Newlines are re-emitted between lines exactly as in {@link tokenizeYAML}.
+ */
 function tokenizeDiff(source: string): Token[] {
   const tokens: Token[] = [];
   const lines = source.split("\n");
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]!;
-    if (i > 0) tokens.push({ type: "plain", text: "\n" });
+    if (i > 0) tokens.push({ type: "plain", text: "\n" }); // re-insert the split newline
     if (
+      // File/hunk headers first so `+++`/`---` don't fall into the +/- cases below.
       line.startsWith("+++") ||
       line.startsWith("---") ||
       line.startsWith("@@") ||
@@ -559,20 +858,35 @@ function tokenizeDiff(source: string): Token[] {
     ) {
       tokens.push({ type: "diff-meta", text: line });
     } else if (line.startsWith("+")) {
-      tokens.push({ type: "diff-add", text: line });
+      tokens.push({ type: "diff-add", text: line }); // added line
     } else if (line.startsWith("-")) {
-      tokens.push({ type: "diff-del", text: line });
+      tokens.push({ type: "diff-del", text: line }); // removed line
     } else {
-      tokens.push({ type: "plain", text: line });
+      tokens.push({ type: "plain", text: line }); // unchanged context line
     }
   }
   return tokens;
 }
 
-/** Post-processes a token stream's generic "keyword" tokens (emitted by the
- *  identifier-matching rule shared across JS/Python) into their final type:
- *  "keyword" if actually reserved, "builtin" for known globals, "boolean" for
- *  literal constants (true/false/null/…), or "plain" for ordinary identifiers. */
+// ===========================================================================
+// Identifier refinement + public API
+// ===========================================================================
+
+/**
+ * Post-processes a token stream's generic "keyword" tokens (emitted by the
+ * identifier-matching rule shared across JS/Python) into their final type:
+ * "keyword" if actually reserved, "builtin" for known globals, "boolean" for
+ * literal constants (true/false/null/…), or "plain" for ordinary identifiers.
+ * @param tokens Token stream from {@link tokenizeWith} (mutated in place).
+ * @param keywords Reserved-word set for the language (e.g. {@link JS_KEYWORDS}).
+ * @param builtins Known-global set (e.g. {@link JS_BUILTINS}).
+ * @param literals Literal-constant set (e.g. {@link JS_LITERALS}).
+ * @returns The same `tokens` array (returned for chaining convenience).
+ * @remarks Case-sensitive membership tests, checked keyword -> builtin -> literal
+ *   -> plain. Only tokens currently typed "keyword" are considered, so tokens the
+ *   scanner already classified (strings, numbers, "function" call sites, …) are
+ *   untouched - e.g. `Math` in `Math(x)` stays "function", not "builtin".
+ */
 function refineIdentifiers(
   tokens: Token[],
   keywords: Set<string>,
@@ -581,6 +895,8 @@ function refineIdentifiers(
 ): Token[] {
   for (const t of tokens) {
     if (t.type === "keyword") {
+      // Priority chain: genuine reserved word -> known global/type -> literal
+      // constant (true/false/null/…) -> otherwise a user-defined identifier.
       if (keywords.has(t.text)) t.type = "keyword";
       else if (builtins.has(t.text)) t.type = "builtin";
       else if (literals.has(t.text)) t.type = "boolean";
@@ -599,7 +915,7 @@ function refineIdentifiers(
  *   if empty) when it doesn't match any known alias.
  */
 export function canonicalLang(lang: string): string {
-  const l = lang.toLowerCase().trim();
+  const l = lang.toLowerCase().trim(); // normalize case/whitespace before matching
   if (l === "js" || l === "jsx" || l === "javascript" || l === "mjs" || l === "cjs") return "js";
   if (l === "ts" || l === "tsx" || l === "typescript") return "ts";
   if (l === "py" || l === "python") return "python";
@@ -610,6 +926,8 @@ export function canonicalLang(lang: string): string {
   if (l === "sql") return "sql";
   if (l === "yaml" || l === "yml") return "yaml";
   if (l === "diff" || l === "patch") return "diff";
+  // Unknown tag: return it lowercased (so `highlight`'s switch falls through to a
+  // single "plain" token), or "plain" when the tag was empty/whitespace-only.
   return l || "plain";
 }
 
@@ -623,10 +941,10 @@ export function canonicalLang(lang: string): string {
  *   token wrapping the entire source for languages with no dedicated tokenizer.
  */
 export function highlight(source: string, lang: string): Token[] {
-  const canon = canonicalLang(lang);
+  const canon = canonicalLang(lang); // collapse aliases to a canonical key
   switch (canon) {
     case "js":
-    case "ts":
+    case "ts": // JS and TS share one tokenizer (JS_KEYWORDS already covers TS words)
       return tokenizeJS(source);
     case "python":
       return tokenizePython(source);
@@ -645,6 +963,7 @@ export function highlight(source: string, lang: string): Token[] {
     case "diff":
       return tokenizeDiff(source);
     default:
+      // Unknown/unsupported language: emit the source unhighlighted as one token.
       return [{ type: "plain", text: source }];
   }
 }
@@ -658,42 +977,43 @@ export function highlight(source: string, lang: string): Token[] {
 export function tokenClass(type: TokenType): string {
   switch (type) {
     case "comment":
-      return "text-gray-500 italic";
+      return "text-gray-500 italic"; // muted + italic to recede visually
     case "string":
-      return "text-emerald-300";
+      return "text-emerald-300"; // green, shared with diff-add text
     case "number":
-      return "text-orange-300";
+      return "text-orange-300"; // orange, shared with boolean literals
     case "keyword":
-      return "text-violet-300";
+      return "text-violet-300"; // violet, shared with diff-meta headers
     case "builtin":
       return "text-sky-300";
     case "function":
-      return "text-yellow-200";
+      return "text-yellow-200"; // yellow, shared with HTML attr names
     case "operator":
       return "text-pink-300";
     case "punctuation":
-      return "text-gray-400";
+      return "text-gray-400"; // slightly brighter than comments, dimmer than plain
     case "property":
       return "text-cyan-300";
     case "tag":
       return "text-rose-300";
     case "attr":
-      return "text-yellow-200";
+      return "text-yellow-200"; // matches "function" colour by design
     case "variable":
       return "text-amber-300";
     case "boolean":
-      return "text-orange-300";
+      return "text-orange-300"; // literals grouped with numbers by colour
     case "diff-add":
-      return "text-emerald-300 bg-emerald-500/10";
+      return "text-emerald-300 bg-emerald-500/10"; // green text + faint green row tint
     case "diff-del":
-      return "text-red-300 bg-red-500/10";
+      return "text-red-300 bg-red-500/10"; // red text + faint red row tint
     case "diff-meta":
       return "text-violet-300";
     case "plain":
     default:
-      return "text-gray-200";
+      return "text-gray-200"; // default body text colour
   }
 }
 
-// Re-export for convenience
+// Re-export for convenience (e.g. so tests/consumers can build patterns from
+// user input); the built-in tokenizers themselves never call escapeRegex.
 export { escapeRegex as _escapeRegex };

--- a/client/src/lib/push.ts
+++ b/client/src/lib/push.ts
@@ -1,8 +1,32 @@
 /**
  * @file push.ts
  * @description Provides functions for managing push notifications in the agent dashboard application. It includes utilities for subscribing and unsubscribing to push notifications using the Push API and Service Workers. The module handles the conversion of VAPID public keys, manages push subscriptions, and communicates with the backend API to register or unregister push endpoints. This allows the application to send real-time notifications to users about important events or updates.
+ *
+ * ## Web Push in one paragraph
+ * Web Push lets the server deliver a notification to this browser even when the dashboard
+ * tab is closed, by going through the browser vendor's push service. Authentication uses
+ * VAPID (Voluntary Application Server Identification): the server holds a key pair and
+ * exposes its public key; the browser bakes that public key into the subscription so the
+ * push service will only accept notifications signed by the matching private key.
+ *
+ * ## Subscription lifecycle handled here
+ * 1. {@link subscribeToPush} - feature-detect Service Worker + Push support, wait for the
+ *    active service worker, fetch the server's VAPID public key, ask the browser's
+ *    `PushManager` to create a subscription bound to that key, then POST the resulting
+ *    endpoint/keys to the backend so it can target this browser later.
+ * 2. {@link unsubscribeFromPush} - tear the subscription down in the browser and DELETE it
+ *    on the backend so no further deliveries are attempted to a dead endpoint.
+ *
+ * Both entry points are idempotent and fail-soft: they no-op on unsupported browsers and on
+ * the "already in the desired state" case, so callers can invoke them freely (e.g. on every
+ * app load, or on a settings toggle) without tracking prior state themselves.
+ *
  * @author Son Nguyen <hoangson091104@gmail.com>
  */
+
+// ===========================================================================
+// VAPID key decoding
+// ===========================================================================
 
 /**
  * Decodes a URL-safe base64 VAPID public key (as served by
@@ -11,17 +35,32 @@
  * @param base64String URL-safe base64 string (`-`/`_` instead of `+`/`/`,
  *   `=` padding optional - this re-pads before decoding).
  * @returns The decoded bytes as an `ArrayBuffer`.
+ * @remarks Why this dance is necessary: VAPID keys are transmitted in *URL-safe* base64
+ *   (base64url) and usually unpadded, but the browser's `atob` only understands *standard*
+ *   base64 with proper `=` padding. So we:
+ *   1. Re-pad to a multiple of 4 chars - `(4 - len % 4) % 4` yields 0..3 `=` (the outer
+ *      `% 4` collapses the "already aligned" case from 4 back to 0).
+ *   2. Translate the URL-safe alphabet back to standard (`-`->`+`, `_`->`/`).
+ *   3. `atob` to a binary string, then copy char codes into a `Uint8Array`.
+ *   `.buffer` is returned because `applicationServerKey` accepts an `ArrayBuffer`/typed view.
  */
 function urlBase64ToUint8Array(base64String: string): ArrayBuffer {
+  // 1. Compute the missing `=` padding so the length is a multiple of 4.
   const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
+  // 2. Re-pad and map the base64url alphabet (`-`/`_`) to standard base64 (`+`/`/`).
   const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
+  // 3. Decode to a binary string and copy each byte into the output buffer.
   const rawData = atob(base64);
   const outputArray = new Uint8Array(rawData.length);
   for (let index = 0; index < rawData.length; index++) {
-    outputArray[index] = rawData.charCodeAt(index);
+    outputArray[index] = rawData.charCodeAt(index); // each char code is one byte (0..255)
   }
   return outputArray.buffer;
 }
+
+// ===========================================================================
+// Subscribe / unsubscribe
+// ===========================================================================
 
 /**
  * Subscribes the browser to Web Push notifications, if not already
@@ -31,26 +70,43 @@ function urlBase64ToUint8Array(base64String: string): ArrayBuffer {
  * Fetches the server's VAPID public key, creates the push subscription via
  * the active service worker, then registers it with the backend so
  * `/api/push/send` can target this browser.
+ * @returns A promise that resolves once the (possibly new) subscription is registered,
+ *   or immediately when the environment/state makes subscribing unnecessary.
+ * @remarks
+ * - Feature-detects both `navigator.serviceWorker` and `window.PushManager`; on older or
+ *   non-secure contexts (Push requires HTTPS/localhost) it simply returns.
+ * - `serviceWorker.ready` resolves only once a service worker is active, so this must run
+ *   after the SW registration has taken control.
+ * - `userVisibleOnly: true` is mandatory in Chromium-based browsers: it promises every
+ *   push will surface a user-visible notification (no silent pushes).
+ * - The permission prompt is triggered implicitly by `pushManager.subscribe`; if the user
+ *   denies it, the returned promise rejects and this function throws (callers decide how to
+ *   surface that).
+ * - `subscription.toJSON()` serializes the endpoint URL plus the `p256dh`/`auth` keys the
+ *   backend needs to encrypt payloads for this browser.
  */
 export async function subscribeToPush(): Promise<void> {
+  // Bail on browsers without Service Worker or Push API (or insecure contexts).
   if (!("serviceWorker" in navigator) || !("PushManager" in window)) return;
 
-  const registration = await navigator.serviceWorker.ready;
+  const registration = await navigator.serviceWorker.ready; // wait for an active SW
   const existing = await registration.pushManager.getSubscription();
-  if (existing) return;
+  if (existing) return; // already subscribed -> idempotent no-op
 
+  // Fetch the server's VAPID public key and decode it for `applicationServerKey`.
   const res = await fetch("/api/push/vapid-public-key");
   const { publicKey } = await res.json();
 
   const subscription = await registration.pushManager.subscribe({
-    userVisibleOnly: true,
+    userVisibleOnly: true, // required by Chromium: every push must be user-visible
     applicationServerKey: urlBase64ToUint8Array(publicKey),
   });
 
+  // Register the endpoint + keys with the backend so it can push to this browser.
   await fetch("/api/push/subscribe", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(subscription.toJSON()),
+    body: JSON.stringify(subscription.toJSON()), // { endpoint, keys: { p256dh, auth } }
   });
 }
 
@@ -59,17 +115,24 @@ export async function subscribeToPush(): Promise<void> {
  * subscribed, and tells the backend to forget the endpoint (so it stops
  * attempting deliveries to it). No-ops silently when there's no active
  * subscription or the browser lacks Service Worker support.
+ * @returns A promise that resolves once both the browser-side unsubscribe and the
+ *   backend DELETE have completed (or immediately when there's nothing to remove).
+ * @remarks Mirrors {@link subscribeToPush}. The endpoint is captured *before* calling
+ *   `subscription.unsubscribe()` because the subscription object's `endpoint` is what the
+ *   backend keys deliveries on - it's read first so the DELETE can identify the right row
+ *   even though the subscription is torn down locally beforehand.
  */
 export async function unsubscribeFromPush(): Promise<void> {
-  if (!("serviceWorker" in navigator)) return;
+  if (!("serviceWorker" in navigator)) return; // no SW support -> nothing to do
 
   const registration = await navigator.serviceWorker.ready;
   const subscription = await registration.pushManager.getSubscription();
-  if (!subscription) return;
+  if (!subscription) return; // not subscribed -> idempotent no-op
 
-  const endpoint = subscription.endpoint;
-  await subscription.unsubscribe();
+  const endpoint = subscription.endpoint; // capture before tearing down the subscription
+  await subscription.unsubscribe(); // remove the browser-side subscription
 
+  // Tell the backend to forget this endpoint so it stops attempting deliveries.
   await fetch("/api/push/subscribe", {
     method: "DELETE",
     headers: { "Content-Type": "application/json" },

--- a/client/src/lib/types.ts
+++ b/client/src/lib/types.ts
@@ -4,6 +4,118 @@
  * @author Son Nguyen <hoangson091104@gmail.com>
  */
 
+/**
+ * ## Module overview
+ *
+ * This module is the single source of truth for the shapes exchanged between the
+ * dashboard's Express/SQLite backend (`server/`) and its React + Vite frontend
+ * (`client/`). Every interface here mirrors either:
+ *
+ *  - a **SQLite row** (e.g. {@link Session}, {@link Agent}, {@link DashboardEvent},
+ *    {@link AlertRule}, {@link WorkflowRun}), possibly with a few extra computed
+ *    columns that only appear on certain queries; or
+ *  - a **REST response body** (e.g. {@link Stats}, {@link Analytics},
+ *    {@link CostResult}, {@link WorkflowData}, {@link TranscriptResult}); or
+ *  - a **WebSocket push payload** (e.g. {@link WSMessage} and its `data` union
+ *    members such as {@link ImportProgressMessage}, {@link RunStreamPayload},
+ *    {@link CcConfigChangedPayload}).
+ *
+ * ### Data-flow context
+ *
+ * The dashboard is local-first and event-driven. Claude Code emits lifecycle
+ * hooks → the Express server ingests them → rows are written to SQLite → the
+ * server broadcasts a {@link WSMessage} over the dashboard WebSocket → the React
+ * UI updates in real time. The same rows are also queryable over REST for the
+ * initial page load and for pagination. The types below therefore appear on both
+ * the "fetch on mount" path and the "live update" path, and must stay backward
+ * compatible so older UI tabs keep working while a session streams.
+ *
+ * ### Conventions used throughout
+ *
+ *  - **Timestamps** are ISO-8601 strings (e.g. `"2026-03-19T14:03:22.114Z"`)
+ *    unless a field name or its doc comment says otherwise. A handful of
+ *    lifecycle payloads (`Run*Payload.at`, `WorkflowProgressEntry.startedAt`)
+ *    use epoch milliseconds instead — those are called out explicitly.
+ *  - **`null` vs `undefined`.** A `T | null` field is a real column that is
+ *    currently empty (the row exists but the value is unknown/not-yet-set). An
+ *    optional `field?: T` is a value that is only present on some responses
+ *    (e.g. a joined/computed column, or a field a newer server version added).
+ *    Both meanings can coexist as `field?: T | null`.
+ *  - **Costs** are always USD. Pricing rate fields are USD per million tokens
+ *    ("MTok"); computed `cost`/`*_cost` fields are absolute USD amounts.
+ *  - **Token counts** are raw integer token totals, bucketed into
+ *    input / output / cache-read / cache-write categories. Cache reads are
+ *    billed cheaper than fresh input; cache writes are billed as a premium.
+ *  - **`metadata` / `data` / `details` string fields** hold opaque JSON that has
+ *    NOT been parsed — call `JSON.parse` before reading them. They may be `null`.
+ *  - **Status enums** are persisted lifecycle values (see {@link SessionStatus},
+ *    {@link AgentStatus}); the `Effective*` variants overlay a transient
+ *    "waiting on human input" state used only for rendering, never persisted.
+ *
+ * ### REST endpoint → type index
+ *
+ * A quick map from the backend routes to the response type they return, so a
+ * reader can jump from an API call to the shape they'll get back:
+ *
+ *  - `GET  /api/sessions`, `/api/sessions/:id` .......... {@link Session}(`[]`)
+ *  - `GET  /api/agents` ................................. {@link Agent}`[]`
+ *  - `GET  /api/events`, `/api/sessions/:id` (events) ... {@link DashboardEvent}`[]`
+ *  - `GET  /api/stats` .................................. {@link Stats}
+ *  - `GET  /api/analytics` ............................. {@link Analytics}
+ *  - `GET/PUT /api/pricing` ............................ {@link ModelPricing}`[]`
+ *  - `GET  /api/pricing/cost[/:sessionId]` ............. {@link CostResult}
+ *  - `GET  /api/updates/status` ........................ {@link UpdateStatusPayload}
+ *  - `GET/POST/PATCH /api/alerts/rules` ................ {@link AlertRule}(`[]`)
+ *  - `GET  /api/alerts` ................................ {@link AlertEvent}`[]`
+ *  - `GET  /api/webhooks/providers` .................... {@link WebhookProvider}`[]`
+ *  - `GET/POST/PATCH /api/webhooks` ................... {@link WebhookTarget}(`[]`)
+ *  - `GET  /api/webhooks/:id/deliveries` .............. {@link WebhookDelivery}`[]`
+ *  - `POST /api/webhooks/:id/test` .................... {@link WebhookTestResult}
+ *  - `GET  /api/sessions/:id/stats` ................... {@link SessionStats}
+ *  - `GET  /api/sessions/:id/transcript` ............. {@link TranscriptResult}
+ *  - `GET  /api/sessions/:id/transcripts` ............ {@link TranscriptListResult}
+ *  - `GET  /api/workflows` ........................... {@link WorkflowData}
+ *  - `GET  /api/workflows/session/:id` ............... {@link SessionDrillIn}
+ *  - `GET  /api/workflows/runs[/:runId]` ............. {@link WorkflowRunsResponse} /
+ *    {@link WorkflowRunDetail}
+ *
+ * ### WebSocket `type` → payload index
+ *
+ * Every {@link WSMessage} carries a `type` discriminant and a matching `data`
+ * payload (see {@link WSMessage} for the enumerated union):
+ *
+ *  - `session_created` / `session_updated` ............ {@link Session}
+ *  - `agent_created` / `agent_updated` ................ {@link Agent}
+ *  - `new_event` ..................................... {@link DashboardEvent}
+ *  - `import.progress` ............................... {@link ImportProgressMessage}
+ *  - `update_status` ................................ {@link UpdateStatusPayload}
+ *  - `run_stream` / `run_status` / `run_input_ack` ... {@link RunStreamPayload} /
+ *    {@link RunStatusPayload} / {@link RunInputAckPayload}
+ *  - `cc_config_changed` ............................ {@link CcConfigChangedPayload}
+ *  - `alert_triggered` / `alert_updated` ............ {@link AlertEvent}
+ *  - `workflow_upserted` ............................ {@link WorkflowRun}
+ *
+ * ### Where these types are consumed
+ *
+ * The API-layer helpers in `client/src/lib/` (the fetch wrappers and the
+ * `useWebSocket`/`eventBus` plumbing) return and dispatch these shapes; the
+ * page components under `client/src/pages/` (Dashboard, SessionDetail,
+ * Analytics, Workflows, Settings) then bind them straight to cards, tables, and
+ * charts. Because a live tab can receive a `*_updated` push at any moment, the
+ * UI is written to merge partial row updates over whatever it already has, which
+ * is why so many computed/joined fields below are optional rather than required.
+ *
+ * Keeping these types accurate is a non-negotiable contract: the server response
+ * shapes and WebSocket message types are expected to stay stable and backward
+ * compatible (see the project's change guidelines for API/DB/WebSocket areas).
+ */
+
+// ───── Core lifecycle enums ─────
+// Small string-literal unions that model the persisted state machines for
+// sessions and agents. They are stored verbatim in SQLite `status`/`type`
+// columns and echoed back on every API/WebSocket payload, so the exact string
+// values here must match what the server writes.
+
 /** Persisted lifecycle state of a `Session` row. "abandoned" is assigned by the
  *  server-side cleanup sweep for sessions that went stale without a clean end. */
 export type SessionStatus = "active" | "completed" | "error" | "abandoned";
@@ -19,46 +131,81 @@ export type AgentType = "main" | "subagent";
  * `awaiting_input_since` is set on a session or agent. Renders as a yellow
  * "Waiting" badge so the dashboard can flag sessions blocked on a Claude Code
  * permission prompt without changing the underlying lifecycle enum.
+ *
+ * The literal value is intentionally `"waiting"` (the same string as
+ * {@link AgentStatus}'s idle-but-alive state) so the presentation lookups in
+ * {@link STATUS_CONFIG}/{@link SESSION_STATUS_CONFIG} need only one "waiting"
+ * entry to cover both the persisted-idle and the overlaid-blocked cases.
  */
 export const AWAITING_STATUS = "waiting" as const;
+/** {@link AgentStatus} widened with the transient {@link AWAITING_STATUS} overlay;
+ *  the type the UI actually renders a badge for (see {@link effectiveAgentStatus}). */
 export type EffectiveAgentStatus = AgentStatus | typeof AWAITING_STATUS;
+/** {@link SessionStatus} widened with the transient {@link AWAITING_STATUS} overlay;
+ *  the type the UI actually renders a badge for (see {@link effectiveSessionStatus}). */
 export type EffectiveSessionStatus = SessionStatus | typeof AWAITING_STATUS;
+
+// ───── Session & Agent rows ─────
+// The two primary entities. A `Session` is one `claude` CLI invocation; an
+// `Agent` is one process within it (the main loop or a spawned subagent). Both
+// are created lazily on their first hook event and mutated as hooks stream in.
 
 /**
  * A Claude Code CLI invocation tracked by the dashboard - one row per top-level
  * `claude` process, created on its first hook event (or on import) and updated
  * as hooks stream in. Returned by GET /api/sessions, /api/sessions/:id, and
  * pushed live via the `session_created`/`session_updated` WebSocket messages.
+ *
+ * Fields split into three groups: always-present columns (`id`..`metadata`),
+ * join-only computed columns (`agent_count`, `last_activity`, `cost`) that only
+ * appear on responses whose query attaches them, and the transient
+ * `awaiting_input_since` overlay used to render the "Waiting" badge.
  */
 export interface Session {
-  /** Session UUID, taken from the Claude Code hook payload's `session_id`. */
+  /** Session UUID, taken from the Claude Code hook payload's `session_id`.
+   *  Primary key (`sessions.id`); also the foreign key that `Agent`/
+   *  `DashboardEvent` rows join on. Example: `"9f2c1e7a-...-b3"`. */
   id: string;
   /** User-assigned or auto-derived display title; null until named (e.g. via
-   *  `/rename`, `claude -n`, or the picker) - the UI falls back to the id. */
+   *  `/rename`, `claude -n`, or the picker) - the UI falls back to the id.
+   *  Maps to `sessions.name`. Example: `"Fix desktop freeze on large history"`. */
   name: string | null;
+  /** Persisted lifecycle state; see {@link SessionStatus}. Drives filtering and,
+   *  via {@link SESSION_STATUS_CONFIG}, the colored status badge. Maps to
+   *  `sessions.status`. One of "active" | "completed" | "error" | "abandoned". */
   status: SessionStatus;
-  /** Working directory the CLI was launched from, or null if never reported. */
+  /** Working directory the CLI was launched from, or null if never reported.
+   *  Maps to `sessions.cwd`. Example: `"/Users/dev/project"`. */
   cwd: string | null;
-  /** Model id reported by the session's SessionStart hook; null if unknown. */
+  /** Model id reported by the session's SessionStart hook; null if unknown.
+   *  Maps to `sessions.model`. Example: `"claude-opus-4-8"`. */
   model: string | null;
-  /** ISO timestamp of the session's first hook event. */
+  /** ISO timestamp of the session's first hook event. Serves as the session's
+   *  creation/start time and the left edge of its timeline. Maps to
+   *  `sessions.started_at`. Example: `"2026-03-19T14:03:22.114Z"`. */
   started_at: string;
-  /** ISO timestamp of SessionEnd, or null while the session is still active. */
+  /** ISO timestamp of SessionEnd, or null while the session is still active.
+   *  Maps to `sessions.ended_at`. Duration = `ended_at - started_at`. */
   ended_at: string | null;
-  /** Opaque JSON string of extra session metadata; parse before use. May be null. */
+  /** Opaque JSON string of extra session metadata; parse before use. May be
+   *  null. Maps to `sessions.metadata`. `JSON.parse` before reading any keys. */
   metadata: string | null;
   /** Count of `Agent` rows (main + subagents) belonging to this session.
-   *  Only present on list/detail responses that join agent counts. */
+   *  Only present on list/detail responses that join agent counts (a computed
+   *  column, not a stored one). Undefined ≠ zero: it means "not joined here". */
   agent_count?: number;
   /** ISO timestamp of the most recent event in this session, for "last active"
-   *  sorting; only present where the query computes it. */
+   *  sorting; only present where the query computes it. Distinct from
+   *  `started_at` (creation) and `ended_at` (clean finish). */
   last_activity?: string;
   /** Total USD cost for the session, computed from its token usage against the
-   *  active pricing rules. Only present on responses that attach pricing. */
+   *  active pricing rules. Only present on responses that attach pricing.
+   *  Absolute dollars (e.g. `0.42`), already summed across all buckets. */
   cost?: number;
   /** ISO timestamp set when Claude Code is blocked waiting for the user
    * (permission prompt or "waiting for your input" notice). Cleared on the
-   * next non-Notification hook event. Null when the session is not waiting. */
+   * next non-Notification hook event. Null when the session is not waiting.
+   * Feeds {@link isSessionAwaitingInput} and the yellow "Waiting" overlay. */
   awaiting_input_since?: string | null;
 }
 
@@ -66,39 +213,64 @@ export interface Session {
  * A single agent process within a session: either the main Claude Code CLI or
  * a subagent spawned via the Task/Agent tool. Returned nested under `Session`
  * responses and by GET /api/agents; pushed live via `agent_created`/`agent_updated`.
+ *
+ * Main agents typically carry the session's overall cost; subagents may carry
+ * their own per-agent token buckets in `metadata` and expose an individual
+ * `cost`. The `parent_agent_id` self-reference lets the Workflows views rebuild
+ * the parent→child delegation tree.
  */
 export interface Agent {
-  /** Agent UUID. For main agents this is typically `${session_id}-main`. */
+  /** Agent UUID. For main agents this is typically `${session_id}-main`; for
+   *  Workflow-tool inner agents it follows `${sessionId}-jsonl-<agentId>`. Maps
+   *  to `agents.id` (primary key). */
   id: string;
-  /** Owning session's id (foreign key into `Session.id`). */
+  /** Owning session's id (foreign key into `Session.id`). Maps to
+   *  `agents.session_id`. */
   session_id: string;
   /** Display name - the subagent_type for subagents, or a generic main-agent
-   *  label; used for the swim-lane / pill labels when subagent_type is unset. */
+   *  label; used for the swim-lane / pill labels when subagent_type is unset.
+   *  Maps to `agents.name`. */
   name: string;
+  /** Whether this is the top-level agent or a delegated one; see {@link AgentType}.
+   *  Maps to `agents.type`. "main" | "subagent". */
   type: AgentType;
   /** Task/Agent tool `subagent_type` (e.g. "frontend-reviewer"); null for main
-   *  agents and for subagents that predate this field. */
+   *  agents and for subagents that predate this field. Maps to
+   *  `agents.subagent_type`. The pseudo-value "compaction" marks a
+   *  context-compression pseudo-agent rather than a real delegation. */
   subagent_type: string | null;
+  /** Persisted lifecycle state; see {@link AgentStatus}. Rendered via
+   *  {@link STATUS_CONFIG} (with the {@link AWAITING_STATUS} overlay applied).
+   *  Maps to `agents.status`. "working" | "waiting" | "completed" | "error". */
   status: AgentStatus;
   /** Free-text description of what the agent was asked to do (from the Task
-   *  tool's `description`/`prompt` input); null when not captured. */
+   *  tool's `description`/`prompt` input); null when not captured. Maps to
+   *  `agents.task`. Example: `"Review the diff for regressions"`. */
   task: string | null;
   /** Name of the tool currently mid-execution (set on PreToolUse, cleared on
-   *  PostToolUse); null when the agent isn't inside a tool call. */
+   *  PostToolUse); null when the agent isn't inside a tool call. Maps to
+   *  `agents.current_tool`. Powers the "currently running X" live hint. */
   current_tool: string | null;
-  /** ISO timestamp the agent was created (its first hook event). */
+  /** ISO timestamp the agent was created (its first hook event). Maps to
+   *  `agents.started_at`; the left edge of the agent's swim lane. */
   started_at: string;
-  /** ISO timestamp the agent finished (Stop/SubagentStop), or null if running. */
+  /** ISO timestamp the agent finished (Stop/SubagentStop), or null if running.
+   *  Maps to `agents.ended_at`. */
   ended_at: string | null;
-  /** ISO timestamp of the most recent event attributed to this agent. */
+  /** ISO timestamp of the most recent event attributed to this agent. Maps to
+   *  `agents.updated_at`; bumped on every ingested event for this agent. */
   updated_at: string;
   /** Id of the agent that spawned this one via Task/Agent; null for main agents
-   *  and for subagents whose parent wasn't recorded (e.g. legacy imports). */
+   *  and for subagents whose parent wasn't recorded (e.g. legacy imports). Maps
+   *  to `agents.parent_agent_id`; the self-reference that builds the agent tree. */
   parent_agent_id: string | null;
   /** Opaque JSON string (e.g. per-agent token buckets under `.tokens`, used by
-   *  `cost` below); parse before use. May be null. */
+   *  `cost` below); parse before use. May be null. Maps to `agents.metadata`.
+   *  This is where a subagent's own input/output/cache token counts live. */
   metadata: string | null;
-  /** Mirrors the parent session: ISO timestamp when set, null otherwise. */
+  /** Mirrors the parent session: ISO timestamp when set, null otherwise. Feeds
+   *  {@link isAgentAwaitingInput} / {@link effectiveAgentStatus}; ignored once
+   *  the agent has reached a terminal status. */
   awaiting_input_since?: string | null;
   /**
    * The agent's OWN cost (USD), computed server-side from its per-agent token
@@ -107,6 +279,12 @@ export interface Agent {
    */
   cost?: number;
 }
+
+// ───── "Awaiting input" overlay helpers ─────
+// Pure predicates and mappers that derive the transient {@link AWAITING_STATUS}
+// overlay from a row's `awaiting_input_since` flag. Kept here (next to the
+// types) so both the server-shaped rows and the UI agree on when a session or
+// agent counts as "blocked on the human" versus merely idle.
 
 /**
  * True when a session is paused on a permission prompt or input request.
@@ -142,55 +320,81 @@ export function effectiveSessionStatus(session: Session): EffectiveSessionStatus
   return isSessionAwaitingInput(session) ? AWAITING_STATUS : session.status;
 }
 
+// ───── Events ─────
+// The raw hook/lifecycle events that everything else is aggregated from. One
+// `DashboardEvent` row per ingested Claude Code hook.
+
 /**
  * A single raw hook/lifecycle event ingested from a Claude Code session -
  * the atomic unit rendered in the ActivityFeed / SessionDetail timelines.
  * Returned by GET /api/events and /api/sessions/:id; streamed live as the
  * `new_event` WebSocket message.
+ *
+ * All the analytics/workflow rollups elsewhere in this file are derived by the
+ * server from these rows, so an event's `event_type`/`tool_name`/`created_at`
+ * are the fundamental facts everything downstream counts and groups by.
  */
 export interface DashboardEvent {
-  /** Autoincrement primary key (also the WS/pagination cursor). */
+  /** Autoincrement primary key (also the WS/pagination cursor). Maps to
+   *  `events.id`. Monotonic, so `id > cursor` pages forward reliably. */
   id: number;
-  /** Owning session's id. */
+  /** Owning session's id. Maps to `events.session_id` (FK into `Session.id`). */
   session_id: string;
   /** Id of the agent that produced the event; null for session-level events
-   *  emitted before any agent row exists. */
+   *  emitted before any agent row exists. Maps to `events.agent_id`. */
   agent_id: string | null;
   /** Hook name, e.g. "PreToolUse", "Stop", "SessionStart", "Compaction",
    *  "TurnDuration", "APIError" - see {@link statusFromEventType} for the
-   *  mapping to a UI status badge. */
+   *  mapping to a UI status badge. Maps to `events.event_type`. This is the
+   *  single most-grouped-by column across the analytics/workflow rollups. */
   event_type: string;
   /** Tool invoked for PreToolUse/PostToolUse events (e.g. "Bash", "Edit",
-   *  or an `mcp__server__tool` name); null for non-tool events. */
+   *  or an `mcp__server__tool` name); null for non-tool events. Maps to
+   *  `events.tool_name`. Example: `"mcp__github__list_issues"`. */
   tool_name: string | null;
   /** Short server-generated description shown in list rows; null when the
-   *  importer had nothing more useful than the raw payload. */
+   *  importer had nothing more useful than the raw payload. Maps to
+   *  `events.summary`. Example: `"Edited src/lib/types.ts"`. */
   summary: string | null;
   /** Opaque JSON string of the full hook payload (tool_input/tool_response,
-   *  cwd, etc.) - `JSON.parse` before reading; null if the payload was empty. */
+   *  cwd, etc.) - `JSON.parse` before reading; null if the payload was empty.
+   *  Maps to `events.data`. Can be large; only parsed on demand in detail views. */
   data: string | null;
-  /** ISO timestamp the event was recorded (ingest time, not hook-reported time). */
+  /** ISO timestamp the event was recorded (ingest time, not hook-reported time).
+   *  Maps to `events.created_at`. Drives all time-bucketed charts. */
   created_at: string;
 }
+
+// ───── Overview & analytics ─────
+// Aggregated read models for the dashboard header cards and the Analytics page.
+// {@link Stats} is the cheap, frequently-polled counter set; {@link Analytics}
+// is the richer chart-backing superset served from a separate endpoint.
 
 /** Response shape of GET /api/stats - the lightweight counters polled for the
  *  dashboard header/overview cards. See {@link Analytics} for the richer,
  *  chart-oriented superset served from /api/analytics. */
 export interface Stats {
+  /** Total number of `Session` rows, all statuses. The "Sessions" header card. */
   total_sessions: number;
-  /** Sessions whose `status` is "active" (not yet ended or errored). */
+  /** Sessions whose `status` is "active" (not yet ended or errored). Drives the
+   *  green "live sessions" indicator. */
   active_sessions: number;
-  /** Agents whose `status` is "working" or "waiting". */
+  /** Agents whose `status` is "working" or "waiting". The count of agents that
+   *  are still alive (not completed/errored) right now. */
   active_agents: number;
+  /** Total number of `Agent` rows across all sessions (main + subagents). */
   total_agents: number;
+  /** Total number of ingested `DashboardEvent` rows, all time. */
   total_events: number;
-  /** Events recorded since local midnight, per the client's `tz_offset` query param. */
+  /** Events recorded since local midnight, per the client's `tz_offset` query
+   *  param (minutes offset from UTC) so "today" matches the viewer's clock. */
   events_today: number;
-  /** Number of currently-open dashboard WebSocket connections on this server. */
+  /** Number of currently-open dashboard WebSocket connections on this server.
+   *  A rough "how many dashboard tabs are watching" gauge. */
   ws_connections: number;
-  /** Agent count keyed by `AgentStatus` value. */
+  /** Agent count keyed by `AgentStatus` value (e.g. `{ working: 3, completed: 12 }`). */
   agents_by_status: Record<string, number>;
-  /** Session count keyed by `SessionStatus` value. */
+  /** Session count keyed by `SessionStatus` value (e.g. `{ active: 2, completed: 40 }`). */
   sessions_by_status: Record<string, number>;
 }
 
@@ -199,73 +403,116 @@ export interface Stats {
  * that back the Analytics page's charts. A superset of {@link Stats}: `overview`
  * mirrors the same overview counters so both endpoints share the same shape
  * for the common fields.
+ *
+ * The `daily_*` and `*_usage`/`*_types` arrays are already sorted and bucketed
+ * by the server for direct binding to charts (most-used-first, or oldest-day
+ * first for the time series).
  */
 export interface Analytics {
   /** Lifetime token totals across every session, by bucket. */
   tokens: {
+    /** Sum of fresh (non-cached) input tokens billed as standard input. */
     total_input: number;
+    /** Sum of generated output/completion tokens. */
     total_output: number;
     /** Tokens served from prompt cache reads (billed at the cheaper cache rate). */
     total_cache_read: number;
     /** Tokens written to create/extend a prompt cache entry. */
     total_cache_write: number;
   };
-  /** Tool invocation counts across all events, most-used first. */
+  /** Tool invocation counts across all events, most-used first. Backs the
+   *  "top tools" bar chart. Example item: `{ tool_name: "Bash", count: 312 }`. */
   tool_usage: Array<{ tool_name: string; count: number }>;
-  /** Event counts bucketed by local calendar day, for the activity chart. */
+  /** Event counts bucketed by local calendar day, for the activity chart. Each
+   *  `date` is a `YYYY-MM-DD` day in the viewer's timezone; oldest first. */
   daily_events: Array<{ date: string; count: number }>;
-  /** New-session counts bucketed by local calendar day. */
+  /** New-session counts bucketed by local calendar day (same `YYYY-MM-DD`
+   *  bucketing as `daily_events`). */
   daily_sessions: Array<{ date: string; count: number }>;
-  /** Subagent counts grouped by `subagent_type`. */
+  /** Subagent counts grouped by `subagent_type`. Backs the "subagent mix" chart. */
   agent_types: Array<{ subagent_type: string; count: number }>;
-  /** Event counts grouped by `event_type`. */
+  /** Event counts grouped by `event_type` (e.g. PreToolUse, Stop, APIError). */
   event_types: Array<{ event_type: string; count: number }>;
-  /** Mean number of events per session, across all sessions. */
+  /** Mean number of events per session, across all sessions. A rough
+   *  "how busy is a typical session" gauge. */
   avg_events_per_session: number;
   /** Total count of agents with `type === "subagent"` across all sessions. */
   total_subagents: number;
   /** Same overview counters as {@link Stats}, minus `events_today`/`ws_connections`. */
   overview: {
+    /** Total number of `Session` rows, all statuses. */
     total_sessions: number;
+    /** Sessions whose `status` is "active". */
     active_sessions: number;
+    /** Agents whose `status` is "working" or "waiting". */
     active_agents: number;
+    /** Total number of `Agent` rows across all sessions. */
     total_agents: number;
+    /** Total number of ingested `DashboardEvent` rows. */
     total_events: number;
   };
+  /** Agent count keyed by `AgentStatus` value. */
   agents_by_status: Record<string, number>;
+  /** Session count keyed by `SessionStatus` value. */
   sessions_by_status: Record<string, number>;
 }
+
+// ───── Pricing & cost model ─────
+// The user-editable pricing rules and the server-computed cost breakdowns they
+// produce. Rates are USD per million tokens ("MTok"); computed costs are
+// absolute USD. Matching is longest-`model_pattern`-wins over a bucket's model.
 
 /**
  * A user-defined cost rule row from GET/PUT /api/pricing. Token usage is
  * matched against the longest `model_pattern` whose `%`-wildcard regex matches
  * the bucket's model id (see server/routes/pricing.js `calculateCost`); all
  * rate fields are USD per million tokens ("MTok").
+ *
+ * The `intro_*` fields model a time-limited promotional rate: while today is on
+ * or before `intro_until`, usage prices at the intro rates; afterwards it falls
+ * back to the standard rates above. The `fast_*` fields are the premium rates
+ * applied when a token bucket's `speed` is "fast".
  */
 export interface ModelPricing {
   /** SQL LIKE-style pattern (`%` wildcard) matched against a token bucket's
-   *  model id; longer/more-specific patterns win ties. Primary key. */
+   *  model id; longer/more-specific patterns win ties. Primary key. Examples:
+   *  `"claude-opus-4%"` (specific) beats `"claude-%"` (catch-all). */
   model_pattern: string;
-  /** Human-readable name shown in the Settings pricing table. */
+  /** Human-readable name shown in the Settings pricing table. Example:
+   *  `"Claude Opus 4"`. Purely presentational; not used for matching. */
   display_name: string;
+  /** Standard rate (USD/MTok) for fresh input tokens. Example: `15` means
+   *  $15 per 1,000,000 input tokens. */
   input_per_mtok: number;
+  /** Standard rate (USD/MTok) for output/completion tokens. Typically several
+   *  times the input rate (e.g. `75`). */
   output_per_mtok: number;
-  /** Rate for tokens served from prompt-cache reads (cheaper than input). */
+  /** Rate for tokens served from prompt-cache reads (cheaper than input, often
+   *  ~10% of the input rate). Applied to a bucket's `cache_read_tokens`. */
   cache_read_per_mtok: number;
-  /** Rate for tokens written to a 5-minute prompt-cache entry. */
+  /** Rate for tokens written to a 5-minute prompt-cache entry (a premium over
+   *  fresh input). Applied to the 5-minute portion of a bucket's cache writes. */
   cache_write_per_mtok: number;
-  /** Rate for tokens written to a 1-hour (extended) prompt-cache entry. */
+  /** Rate for tokens written to a 1-hour (extended) prompt-cache entry - a
+   *  higher premium than the 5-minute rate. Applied to
+   *  `CostBreakdown.cache_write_1h_tokens`. */
   cache_write_1h_per_mtok: number;
-  /** Premium input rate applied when a token bucket's `speed` is "fast". */
+  /** Premium input rate applied when a token bucket's `speed` is "fast"; see
+   *  {@link CostBreakdown.speed}. */
   fast_input_per_mtok: number;
   /** Premium output rate applied when a token bucket's `speed` is "fast". */
   fast_output_per_mtok: number;
   // Time-limited introductory rates: usage on/before intro_until (YYYY-MM-DD)
   // prices at these rates, after it at the standard rates. null/0 = no intro.
+  /** Intro input rate (USD/MTok) while the promo is active; null/0 = no promo. */
   intro_input_per_mtok?: number;
+  /** Intro output rate (USD/MTok) while the promo is active; null/0 = no promo. */
   intro_output_per_mtok?: number;
+  /** Intro cache-read rate (USD/MTok) while the promo is active. */
   intro_cache_read_per_mtok?: number;
+  /** Intro 5-minute cache-write rate (USD/MTok) while the promo is active. */
   intro_cache_write_per_mtok?: number;
+  /** Intro 1-hour cache-write rate (USD/MTok) while the promo is active. */
   intro_cache_write_1h_per_mtok?: number;
   /** Last day (YYYY-MM-DD, inclusive) the intro rates apply; null/absent = no
    *  active promo, so usage always prices at the standard rates above. */
@@ -278,30 +525,48 @@ export interface ModelPricing {
  * One row of a {@link CostResult.breakdown} - token usage and cost aggregated
  * per (model, speed, inference_geo, service_tier) tuple. Emitted by
  * `calculateCost` in server/routes/pricing.js.
+ *
+ * The four grouping keys (`model`, `speed`, `inference_geo`, `service_tier`)
+ * together identify the pricing dimension a chunk of usage was billed under;
+ * the `*_tokens`/`*_requests` counters are the usage, and `cost` is the USD
+ * result of pricing that usage against `matched_rule`.
  */
 export interface CostBreakdown {
+  /** Model id this usage bucket was recorded under. Example: `"claude-opus-4-8"`. */
   model: string;
-  /** "standard" or "fast" (premium, lower-latency) inference tier. */
+  /** "standard" or "fast" (premium, lower-latency) inference tier. Selects
+   *  between the standard rates and {@link ModelPricing}'s `fast_*` rates. */
   speed?: string;
   /** Data-residency region the request was billed under (e.g. "us"), which
    *  applies a pricing multiplier; absent/"global" for the default region. */
   inference_geo?: string;
-  /** "standard" or "batch" (discounted, async) API tier. */
+  /** "standard" or "batch" (discounted, async) API tier. Batch usage prices at
+   *  a reduced rate. */
   service_tier?: string;
+  /** Fresh (non-cached) input tokens in this bucket. Priced at the input rate. */
   input_tokens: number;
+  /** Output/completion tokens in this bucket. Priced at the output rate. */
   output_tokens: number;
+  /** Tokens served from prompt-cache reads in this bucket. Priced at the cheaper
+   *  cache-read rate. */
   cache_read_tokens: number;
-  /** Total cache-write tokens (5-minute + 1-hour splits combined). */
+  /** Total cache-write tokens (5-minute + 1-hour splits combined). The 5-minute
+   *  portion is `cache_write_tokens - (cache_write_1h_tokens ?? 0)`. */
   cache_write_tokens: number;
-  /** Portion of `cache_write_tokens` written to a 1-hour cache entry. */
+  /** Portion of `cache_write_tokens` written to a 1-hour cache entry, priced at
+   *  the higher `ModelPricing.cache_write_1h_per_mtok` rate. */
   cache_write_1h_tokens?: number;
-  /** Count of server-side web_search tool invocations in this bucket. */
+  /** Count of server-side web_search tool invocations in this bucket. Feeds the
+   *  per-1,000-searches surcharge in {@link CostFeatureCosts.web_search_cost}. */
   web_search_requests?: number;
-  /** Count of server-side web_fetch tool invocations in this bucket. */
+  /** Count of server-side web_fetch tool invocations in this bucket (currently
+   *  not surcharged). */
   web_fetch_requests?: number;
-  /** Count of server-side code_execution tool invocations in this bucket. */
+  /** Count of server-side code_execution tool invocations in this bucket; feeds
+   *  the container-time estimate in {@link CostFeatureCosts}. */
   code_execution_requests?: number;
-  /** USD cost for this bucket (token cost + web-search surcharge). */
+  /** USD cost for this bucket (token cost + web-search surcharge). Sum of all
+   *  buckets' `cost` (plus feature costs) equals {@link CostResult.total_cost}. */
   cost: number;
   /** The `ModelPricing.model_pattern` that matched, or null if no rule matched
    *  (in which case `cost` is 0 and the usage also appears in `unpriced_models`). */
@@ -309,7 +574,8 @@ export interface CostBreakdown {
 }
 
 /** Non-token surcharges layered on top of the per-bucket token cost in a
- *  {@link CostResult}: web search, web fetch, and code-execution container time. */
+ *  {@link CostResult}: web search, web fetch, and code-execution container time.
+ *  All amounts are USD; these are summed into {@link CostResult.total_cost}. */
 export interface CostFeatureCosts {
   /** USD surcharge for web_search tool calls, billed per 1,000 searches. */
   web_search_cost: number;
@@ -327,58 +593,93 @@ export interface CostFeatureCosts {
  *  its cost is $0 in the totals, surfaced here so the Settings UI can prompt
  *  the user to add a pricing rule instead of silently under-reporting cost. */
 export interface UnpricedModel {
+  /** The model id that had usage but matched no pricing rule. The value the
+   *  Settings UI suggests creating a {@link ModelPricing} rule for. */
   model: string;
+  /** Fresh input tokens recorded for this unpriced model (would-be-billed). */
   input_tokens: number;
+  /** Output tokens recorded for this unpriced model (would-be-billed). */
   output_tokens: number;
+  /** Cache-read tokens recorded for this unpriced model. */
   cache_read_tokens: number;
+  /** Cache-write tokens recorded for this unpriced model. */
   cache_write_tokens: number;
 }
 
-/** Response shape of GET /api/pricing/cost and /api/pricing/cost/:sessionId. */
+/** Response shape of GET /api/pricing/cost and /api/pricing/cost/:sessionId.
+ *  Bundles the grand total, the per-bucket breakdown, a daily time series, and
+ *  (optionally) the feature surcharges and any usage that priced at $0. */
 export interface CostResult {
-  /** Grand total USD cost (token cost + all feature surcharges). */
+  /** Grand total USD cost (token cost + all feature surcharges). The headline
+   *  dollar figure shown on the cost card. */
   total_cost: number;
+  /** Per (model, speed, geo, tier) token/cost rows; see {@link CostBreakdown}.
+   *  The detailed table that sums to `total_cost`. */
   breakdown: CostBreakdown[];
-  /** Total cost per local calendar day, oldest first. */
+  /** Total cost per local calendar day, oldest first. Each `date` is a
+   *  `YYYY-MM-DD` bucket; backs the spend-over-time line chart. */
   daily_costs: Array<{ date: string; cost: number }>;
+  /** Web-search/web-fetch/code-execution surcharges; absent when none applied. */
   feature_costs?: CostFeatureCosts;
   /** Present only when at least one model had usage but no pricing rule. */
   unpriced_models?: UnpricedModel[];
 }
 
+// ───── Import progress ─────
+
 /** Payload of the `import.progress` WebSocket message, streamed while a
- *  transcript import (default scan, path scan, or file upload) is running. */
+ *  transcript import (default scan, path scan, or file upload) is running.
+ *  A determinate progress bar can be drawn from `processed`/`total`; terminal
+ *  states are `phase: "complete" | "error"`. */
 export interface ImportProgressMessage {
   /** Correlates progress events to one import run; absent on terminal states
-   *  emitted without a tracked run. */
+   *  emitted without a tracked run. Lets the UI ignore stray messages from a
+   *  different, concurrent import. */
   importId?: string;
   /** Import lifecycle stage; "extract_error" is a non-fatal per-file failure
-   *  during "extract" that doesn't abort the overall run. */
+   *  during "extract" that doesn't abort the overall run. Normal happy path is
+   *  start → scan → extract → parse → complete. */
   phase: "start" | "scan" | "extract" | "parse" | "complete" | "error" | "extract_error";
-  /** Which import flow triggered this run. */
+  /** Which import flow triggered this run. "default" scans the standard Claude
+   *  Code projects dir; "path" scans a user-supplied path; "upload" ingests an
+   *  uploaded file. */
   source?: "default" | "path" | "upload";
-  /** Items processed so far, for a determinate progress bar. */
+  /** Items processed so far, for a determinate progress bar. Numerator of
+   *  `processed / total`. */
   processed?: number;
-  /** Total items expected, once known (may be absent during "scan"). */
+  /** Total items expected, once known (may be absent during "scan"). Denominator
+   *  of the progress bar. */
   total?: number;
-  /** Short label for what's currently being processed (e.g. a file name). */
+  /** Short label for what's currently being processed (e.g. a file name). Shown
+   *  as the progress bar's caption. */
   current?: string;
-  /** Filesystem path being scanned/imported, when applicable. */
+  /** Filesystem path being scanned/imported, when applicable (mainly the
+   *  "path"/"upload" flows). */
   path?: string;
-  /** Human-readable failure message; present on "error"/"extract_error". */
+  /** Human-readable failure message; present on "error"/"extract_error". For
+   *  "extract_error" it describes a single skipped file, not a fatal abort. */
   error?: string;
-  /** Running tallies (e.g. imported/skipped/errors) keyed by counter name. */
+  /** Running tallies (e.g. imported/skipped/errors) keyed by counter name.
+   *  Example: `{ imported: 12, skipped: 3, errors: 1 }`. */
   counters?: Record<string, number>;
 }
 
-/** Payload for `update_status` WebSocket messages and GET /api/updates/status */
+// ───── Self-update status ─────
+
+/** Payload for `update_status` WebSocket messages and GET /api/updates/status.
+ *  Describes whether the install directory is a git clone that is behind its
+ *  canonical remote, and (when it is) exactly how to bring it up to date. Many
+ *  fields are optional because a non-git install reports only the bare minimum. */
 export interface UpdateStatusPayload {
   /** False when the install directory isn't a git clone at all - in that case
-   *  every other field except `repo_root`/`manual_command`/`message` is absent. */
+   *  every other field except `repo_root`/`manual_command`/`message` is absent,
+   *  and the UI shows a "not a git checkout" note instead of an update button. */
   git_repo: boolean;
-  /** True when `local_sha` is behind `remote_sha` on the canonical remote. */
+  /** True when `local_sha` is behind `remote_sha` on the canonical remote.
+   *  Drives whether the "Update available" call-to-action is shown. */
   update_available: boolean;
-  /** Absolute path to the detected git repository root. */
+  /** Absolute path to the detected git repository root. Example:
+   *  `"/Users/dev/Claude-Code-Agent-Monitor"`. */
   repo_root?: string;
   /** Resolved ref compared against, e.g. "upstream/master" or "origin/main";
    *  null when no remote could be resolved (e.g. no remotes configured). */
@@ -405,11 +706,15 @@ export interface UpdateStatusPayload {
   /** Plain-language explanation when the user is *not* on the canonical
    * default branch, so the manual command makes sense in context. */
   situation_note?: string | null;
-  /** Local HEAD commit SHA; null when it couldn't be resolved. */
+  /** Local HEAD commit SHA; null when it couldn't be resolved. Compared against
+   *  `remote_sha` to decide `update_available`. Example: `"6f96383"` (short) or
+   *  the full 40-char hash. */
   local_sha?: string | null;
-  /** Remote-ref commit SHA; null when it couldn't be resolved. */
+  /** Remote-ref commit SHA; null when it couldn't be resolved. The tip of
+   *  `remote_ref` we'd fast-forward to. */
   remote_sha?: string | null;
-  /** Number of commits the local branch trails behind `remote_sha`. */
+  /** Number of commits the local branch trails behind `remote_sha`. 0 means
+   *  up to date; > 0 drives the "N commits behind" badge. */
   commits_behind?: number;
   /** Shell command the user can copy/run to update manually (`git pull`,
    *  `git fetch && git merge`, etc., chosen based on `situation`). */
@@ -421,38 +726,56 @@ export interface UpdateStatusPayload {
   fetch_error?: string;
 }
 
+// ───── Interactive run streaming ─────
+// Payloads for the "run a `claude` process from the dashboard" feature. A run is
+// started via POST /api/run and identified by a `RunHandle` id; the server then
+// streams stdout envelopes, status transitions, and stdin acks back over the WS.
+
 /** Payload for the `run_stream` WebSocket message: one streamed JSON envelope
  *  from a headless/conversation `claude` process started via POST /api/run. */
 export interface RunStreamPayload {
-  /** Id of the `RunHandle` this envelope belongs to. */
+  /** Id of the `RunHandle` this envelope belongs to. Lets the UI route the chunk
+   *  to the right run panel when several runs stream at once. */
   id: string;
   /** Raw stream-json envelope emitted by the Claude Code CLI (assistant text
-   *  deltas, tool_use/tool_result blocks, etc.) - shape varies by event type. */
+   *  deltas, tool_use/tool_result blocks, etc.) - shape varies by event type.
+   *  Typed as `unknown` because it's forwarded verbatim and narrowed at render. */
   envelope: unknown;
 }
 /** Payload for the `run_status` WebSocket message: a lifecycle transition for
  *  a run started via POST /api/run (mirrors `RunHandle.status`). */
 export interface RunStatusPayload {
+  /** Id of the `RunHandle` whose status changed. */
   id: string;
+  /** New run lifecycle state; terminal states are "completed"/"error"/"killed".
+   *  "spawning" → the child is being started; "running" → streaming output;
+   *  "killed" → the run was cancelled by the user. */
   status: "spawning" | "running" | "completed" | "error" | "killed";
-  /** Epoch-ms timestamp of this status transition. */
+  /** Epoch-ms timestamp of this status transition (NOT an ISO string, unlike
+   *  most timestamps in this file). */
   at: number;
-  /** Process exit code; present once status reaches "completed"/"error". */
+  /** Process exit code; present once status reaches "completed"/"error". 0 means
+   *  a clean exit. */
   exitCode?: number;
-  /** Claude Code session id resumed/created by this run, once known. */
+  /** Claude Code session id resumed/created by this run, once known. Lets the UI
+   *  link a run to the {@link Session} it produced. */
   sessionId?: string | null;
-  /** Failure message; present when status is "error". */
+  /** Failure message; present when status is "error". Surfaced in the run panel. */
   error?: string;
 }
 /** Payload for the `run_input_ack` WebSocket message: confirms a message sent
  *  via POST /api/run/:id/message was written to the child process's stdin. */
 export interface RunInputAckPayload {
+  /** Id of the `RunHandle` the input was delivered to. */
   id: string;
-  /** Echoes the id returned by the `send` call this acks. */
+  /** Echoes the id returned by the `send` call this acks, so the UI can clear
+   *  the matching "sending…" pending state. */
   messageId: string;
-  /** Epoch-ms timestamp the input was delivered. */
+  /** Epoch-ms timestamp the input was delivered (not an ISO string). */
   at: number;
 }
+
+// ───── Claude Code config change notifications ─────
 
 /** Payload for the `cc_config_changed` WebSocket message: broadcast whenever a
  *  Claude Code config artifact (skill, agent, command, settings, memory, …) is
@@ -464,17 +787,24 @@ export interface CcConfigChangedPayload {
   source: "dashboard" | "fs";
   /** Mutation kind; absent for some fs-watcher events that only report scope. */
   action?: "write" | "delete";
-  /** "user" (~/.claude) or "project" (repo's .claude) config root affected. */
+  /** "user" (~/.claude) or "project" (repo's .claude) config root affected.
+   *  Lets a listening tab decide whether the change is relevant to its view. */
   scope?: "user" | "project";
-  /** Artifact kind, e.g. "skills", "agents", "commands", "settings", "memory". */
+  /** Artifact kind, e.g. "skills", "agents", "commands", "settings", "memory".
+   *  Selects which cc-config panel should refresh. */
   type?: string;
-  /** Artifact name (e.g. skill/agent name); null/absent for whole-file events. */
+  /** Artifact name (e.g. skill/agent name); null/absent for whole-file events
+   *  (like a settings.json save that isn't scoped to one named artifact). */
   name?: string | null;
-  /** Absolute file paths touched by this change, when known. */
+  /** Absolute file paths touched by this change, when known. Example:
+   *  `["/Users/dev/.claude/skills/foo/SKILL.md"]`. */
   paths?: string[];
 }
 
-// ── Alerting ──
+// ───── Alerting ─────
+// User-defined rules that watch the ingest stream (or a periodic sweep) and fire
+// {@link AlertEvent}s. {@link AlertRuleConfig} is a tagged bag of settings whose
+// applicable fields depend on the parent rule's {@link AlertRuleType}.
 
 /** Kind of condition an {@link AlertRule} evaluates. "event_pattern" and
  *  "token_threshold" are checked on every hook ingest; "inactivity" and
@@ -513,47 +843,72 @@ export interface AlertRuleConfig {
   total_tokens?: number;
 }
 
-/** A user-defined alert rule from GET/POST/PATCH /api/alerts/rules. */
+/** A user-defined alert rule from GET/POST/PATCH /api/alerts/rules. Couples a
+ *  {@link AlertRuleType} with its {@link AlertRuleConfig}, an on/off switch, and
+ *  a per-scope cooldown to avoid re-firing on every matching event. */
 export interface AlertRule {
+  /** Rule id (primary key). Example: `"rule_inactivity_30m"`. */
   id: string;
+  /** User-assigned display name for the rule. Example: `"Idle > 30 min"`. */
   name: string;
+  /** Which condition family this rule evaluates; see {@link AlertRuleType}.
+   *  Determines which fields of `config` are meaningful. */
   rule_type: AlertRuleType;
+  /** The parsed, type-specific settings for the rule; see {@link AlertRuleConfig}.
+   *  Already deserialized (unlike the opaque JSON string columns elsewhere). */
   config: AlertRuleConfig;
-  /** Whether the rule is evaluated at all; disabled rules never fire. */
+  /** Whether the rule is evaluated at all; disabled rules never fire but are
+   *  kept for later re-enabling. */
   enabled: boolean;
   /** Minimum seconds between two firings of this rule for the same
-   *  session/agent scope, to avoid spamming on repeated matches. */
+   *  session/agent scope, to avoid spamming on repeated matches. Example:
+   *  `300` = at most one alert every 5 minutes per session. */
   cooldown_seconds: number;
+  /** ISO timestamp the rule was created. */
   created_at: string;
+  /** ISO timestamp the rule was last updated. */
   updated_at: string;
 }
 
 /** One firing of an {@link AlertRule}, from GET /api/alerts; pushed live via
- *  the `alert_triggered` (new) / `alert_updated` (acknowledged) WS messages. */
+ *  the `alert_triggered` (new) / `alert_updated` (acknowledged) WS messages.
+ *  Denormalizes the rule's name/type at fire time so the row still renders even
+ *  after the originating rule is renamed or deleted. */
 export interface AlertEvent {
+  /** Alert-event id (autoincrement primary key). */
   id: number;
   /** Rule that fired (foreign key into `AlertRule.id`). */
   rule_id: string;
   /** Denormalized copy of the rule's name at fire time, for display even if
    *  the rule is later renamed or deleted. */
   rule_name: string;
+  /** Denormalized copy of the rule's type at fire time; see {@link AlertRuleType}. */
   rule_type: AlertRuleType;
-  /** Session the alert pertains to; null for rules with no session scope. */
+  /** Session the alert pertains to; null for rules with no session scope. FK
+   *  into `Session.id` when set. */
   session_id: string | null;
-  /** Agent the alert pertains to; null when not agent-specific. */
+  /** Agent the alert pertains to; null when not agent-specific. FK into
+   *  `Agent.id` when set. */
   agent_id: string | null;
-  /** Human-readable description of what triggered the alert. */
+  /** Human-readable description of what triggered the alert. Example:
+   *  `"Session idle for 32 minutes"`. */
   message: string;
   /** Opaque JSON string with extra context (matched event, thresholds); may
-   *  be null. Parse before use. */
+   *  be null. Parse before use (`JSON.parse`). */
   details: string | null;
-  /** ISO timestamp the alert fired. */
+  /** ISO timestamp the alert fired. Sort key for the alerts list (newest first). */
   triggered_at: string;
-  /** ISO timestamp the user acknowledged it; null while unacknowledged. */
+  /** ISO timestamp the user acknowledged it; null while unacknowledged. The
+   *  `alert_updated` WS message flips this from null to a timestamp. */
   acknowledged_at: string | null;
 }
 
-// ── Webhooks ──
+// ───── Webhooks ─────
+// Outbound delivery of alerts to chat/incident/automation providers. The
+// provider catalog ({@link WebhookProvider}/{@link WebhookProviderField}) drives
+// the "Add webhook" form; {@link WebhookTarget} is a saved destination; the
+// {@link WebhookDelivery}* types record and summarize send attempts. Secrets are
+// always masked on the wire.
 
 /** Supported outbound webhook provider ids, from GET /api/webhooks/providers.
  *  "generic" is a bare HTTP POST for anything not natively supported. */
@@ -578,13 +933,15 @@ export type WebhookType =
  *  for a given {@link WebhookProvider} (e.g. Telegram's chat_id, PagerDuty's
  *  routing_key). Declared server-side in server/lib/webhook-providers.js. */
 export interface WebhookProviderField {
-  /** Key this value is stored/sent under in `WebhookTarget.config`. */
+  /** Key this value is stored/sent under in `WebhookTarget.config`. Example:
+   *  `"chat_id"` for Telegram, `"routing_key"` for PagerDuty. */
   key: string;
-  /** Form label. */
+  /** Form label shown next to the input. Example: `"Chat ID"`. */
   label: string;
-  /** Whether the value should be masked in the UI and redacted by the API. */
+  /** Whether the value should be masked in the UI and redacted by the API (used
+   *  for tokens/keys). */
   secret: boolean;
-  /** Whether the target can't be saved without this field. */
+  /** Whether the target can't be saved without this field (form validation). */
   required: boolean;
   /** Render as a free-text input or a fixed dropdown (`options`). */
   type: "string" | "enum";
@@ -598,7 +955,9 @@ export interface WebhookProviderField {
  *  /api/webhooks/providers - drives the "Add webhook" form without exposing
  *  server-internal formatter/auth logic. */
 export interface WebhookProvider {
+  /** Stable provider id; see {@link WebhookType}. The key the form submits back. */
   type: WebhookType;
+  /** Human-readable provider name shown in the picker. Example: `"Slack"`. */
   label: string;
   /** "chat" (Slack/Discord/Teams-style), "api" (PagerDuty/Opsgenie/Splunk),
    *  or "generic" (bare POST) - determines which extra options apply below. */
@@ -619,20 +978,26 @@ export interface WebhookProvider {
   supports_secret: boolean;
   /** Whether custom HTTP headers can be attached (generic family only). */
   supports_headers: boolean;
+  /** The provider-specific config fields to render on the form; see
+   *  {@link WebhookProviderField}. */
   fields: WebhookProviderField[];
 }
 
 /** Compact summary of a target's most recent delivery attempt, embedded in
  *  {@link WebhookTarget.last_delivery} for the targets list view. */
 export interface WebhookDeliverySummary {
+  /** Whether the most recent send succeeded (2xx) or failed. Drives the green/
+   *  red delivery indicator on the targets list. */
   status: "success" | "failed";
   /** HTTP status code returned by the endpoint; null on a transport-level
    *  failure (DNS, timeout, connection refused) before any response arrived. */
   status_code: number | null;
-  /** Number of send attempts made (including retries) for this delivery. */
+  /** Number of send attempts made (including retries) for this delivery. > 1
+   *  means the first attempt(s) failed and were retried. */
   attempts: number;
   /** Failure reason when `status` is "failed"; null on success. */
   error: string | null;
+  /** ISO timestamp of this delivery attempt (its "when"). */
   created_at: string;
 }
 
@@ -640,13 +1005,18 @@ export interface WebhookDeliverySummary {
  *  Secrets are never returned by the API - `url_preview` masks the URL and
  *  `headers`/`config` mask any field flagged `secret` in the provider schema. */
 export interface WebhookTarget {
+  /** Target id (primary key). */
   id: string;
-  /** User-assigned label for this target. */
+  /** User-assigned label for this target. Example: `"Team Slack #alerts"`. */
   name: string;
+  /** Provider this target delivers to; see {@link WebhookType}. Governs which
+   *  `config` fields are expected and how the payload is formatted. */
   type: WebhookType;
-  /** Whether alerts matching `rule_ids` are actually delivered here. */
+  /** Whether alerts matching `rule_ids` are actually delivered here. Disabled
+   *  targets are kept but skipped during fan-out. */
   enabled: boolean;
-  /** Masked: host + last 4 chars. The full URL is never returned by the API. */
+  /** Masked: host + last 4 chars. The full URL is never returned by the API.
+   *  Example: `"hooks.slack.com/…AbCd"`. */
   url_preview: string;
   /** Whether a signing secret is configured (its value is never returned). */
   has_secret: boolean;
@@ -656,44 +1026,67 @@ export interface WebhookTarget {
   config: Record<string, string> | null;
   /** Rule ids this target is scoped to; null = all rules. */
   rule_ids: string[] | null;
+  /** ISO timestamp the target was created. */
   created_at: string;
+  /** ISO timestamp the target was last updated. */
   updated_at: string;
   /** Outcome of the most recent delivery attempt; null if never delivered. */
   last_delivery: WebhookDeliverySummary | null;
 }
 
-/** One row of a target's delivery log, from GET /api/webhooks/:id/deliveries. */
+/** One row of a target's delivery log, from GET /api/webhooks/:id/deliveries.
+ *  A persisted, per-attempt record (unlike {@link WebhookTestResult}, which is
+ *  the ephemeral result of a manual test send). */
 export interface WebhookDelivery {
+  /** Delivery-log row id (autoincrement primary key). */
   id: number;
   /** Owning target's id (foreign key into `WebhookTarget.id`). */
   target_id: string;
   /** Denormalized target name at delivery time, for display after renames/deletes. */
   target_name: string;
+  /** Denormalized target provider at delivery time; see {@link WebhookType}. */
   target_type: WebhookType;
-  /** The `AlertEvent.id` that triggered this delivery; null for manual test sends. */
+  /** The `AlertEvent.id` that triggered this delivery; null for manual test
+   *  sends (which don't originate from a fired alert). */
   alert_id: number | null;
+  /** Whether this delivery succeeded or failed. */
   status: "success" | "failed";
+  /** HTTP status code returned; null on a transport-level failure. */
   status_code: number | null;
+  /** Number of send attempts made (including retries) for this delivery. */
   attempts: number;
+  /** Failure reason when `status` is "failed"; null on success. */
   error: string | null;
+  /** ISO timestamp of this delivery (sort key for the delivery log). */
   created_at: string;
 }
 
 /** Result of POST /api/webhooks/:id/test - a synchronous one-shot delivery
  *  probe used by the "Send test" button, not persisted to the delivery log. */
 export interface WebhookTestResult {
-  /** Whether the endpoint accepted the test payload (2xx response). */
+  /** Whether the endpoint accepted the test payload (2xx response). Renders the
+   *  green check / red x next to the "Send test" button. */
   ok: boolean;
-  /** HTTP status code returned; null on a transport-level failure. */
+  /** HTTP status code returned; null on a transport-level failure (DNS, timeout,
+   *  connection refused). */
   status: number | null;
+  /** Number of send attempts made during the probe (including any retries). */
   attempts: number;
+  /** Failure reason when `ok` is false; null on success. */
   error: string | null;
 }
+
+// ───── WebSocket envelope ─────
 
 /**
  * Envelope for every message the server pushes over the dashboard WebSocket
  * (see `server/websocket.js` `broadcast()`). Consumed by {@link eventBus} and
  * `useWebSocket`; `type` discriminates the shape of `data`.
+ *
+ * This is a hand-maintained discriminated union: each `type` string pairs with
+ * exactly one member of the `data` union (see the `type` field's doc comment
+ * for the full mapping). Because live UI tabs may outlive a server upgrade, the
+ * set of `type` values must only ever grow - never rename or repurpose one.
  */
 export interface WSMessage {
   /** Discriminant selecting which member of the `data` union applies:
@@ -717,6 +1110,7 @@ export interface WSMessage {
     | "alert_triggered"
     | "alert_updated"
     | "workflow_upserted";
+  /** The message body, whose concrete shape is selected by `type` above. */
   data:
     | Session
     | Agent
@@ -734,25 +1128,32 @@ export interface WSMessage {
   timestamp: string;
 }
 
-// ── Session stats ──
+// ───── Session stats ─────
 
 /** Response shape of GET /api/sessions/:id/stats - per-session rollups shown
- *  on the SessionDetail page's stats cards and charts. */
+ *  on the SessionDetail page's stats cards and charts. A single-session analog
+ *  of {@link Analytics}, scoped to one session's events/agents/tokens. */
 export interface SessionStats {
+  /** Id of the session these rollups describe (FK into `Session.id`). */
   session_id: string;
+  /** Total events recorded for this session (the sum of `events_by_type`). */
   total_events: number;
-  /** Event counts grouped by `event_type`. */
+  /** Event counts grouped by `event_type`, scoped to this session. */
   events_by_type: Array<{ event_type: string; count: number }>;
   /** Tool invocation counts within this session, most-used first. */
   tools_used: Array<{ tool_name: string; count: number }>;
-  /** Count of events representing an error (APIError, error-summary Stop). */
+  /** Count of events representing an error (APIError, error-summary Stop) in
+   *  this session. Drives the "N errors" badge on the detail page. */
   error_count: number;
-  /** ISO timestamp of the session's earliest event; null if it has none. */
+  /** ISO timestamp of the session's earliest event; null if it has none. The
+   *  left edge of the session's event timeline. */
   first_event_at: string | null;
-  /** ISO timestamp of the session's latest event; null if it has none. */
+  /** ISO timestamp of the session's latest event; null if it has none. The
+   *  right edge of the session's event timeline. */
   last_event_at: string | null;
   /** Agent counts for this session, broken out by role/status. */
   agents: {
+    /** Total agents in this session (main + subagents + compaction pseudo-agents). */
     total: number;
     /** Count with `type === "main"` (normally 1). */
     main: number;
@@ -763,70 +1164,104 @@ export interface SessionStats {
     /** Agent count keyed by `AgentStatus` value. */
     by_status: Record<string, number>;
   };
-  /** Subagent counts grouped by `subagent_type`, for this session only. */
+  /** Subagent counts grouped by `subagent_type`, for this session only (the
+   *  single-session analog of {@link Analytics.agent_types}). */
   subagent_types: Array<{ subagent_type: string; count: number }>;
-  /** Token totals across every agent in this session. */
+  /** Token totals across every agent in this session, summed by bucket. */
   tokens: {
+    /** Fresh (non-cached) input tokens summed over this session's agents. */
     input_tokens: number;
+    /** Output/completion tokens summed over this session's agents. */
     output_tokens: number;
+    /** Prompt-cache-read tokens summed over this session's agents. */
     cache_read_tokens: number;
+    /** Prompt-cache-write tokens summed over this session's agents. */
     cache_write_tokens: number;
   };
 }
 
-// ── Workflow types ──
+// ───── Workflow intelligence (events-derived) ─────
+// The analytics panels on the Workflows page. Every type below is COMPUTED by
+// the server from `DashboardEvent`/`Agent` rows (server/routes/workflows.js) -
+// none of them is a stored table. They all honor the same optional
+// session-status filter and are bundled together in {@link WorkflowData}.
+// NOTE: distinct from the "Workflow-tool runs" section further down, which is
+// ingested from on-disk journals, not derived from events.
 
 /** Headline metrics card data for the Workflows page - aggregated across
  *  sessions matching the optional status filter. From `getWorkflowStats` in
  *  server/routes/workflows.js. */
 export interface WorkflowStats {
+  /** Sessions considered (after the optional status filter). Denominator for the
+   *  per-session averages below. */
   totalSessions: number;
+  /** Total agents (main + subagents) across those sessions. */
   totalAgents: number;
+  /** Total agents with `type === "subagent"`. */
   totalSubagents: number;
-  /** Mean subagents spawned per session. */
+  /** Mean subagents spawned per session (`totalSubagents / totalSessions`). */
   avgSubagents: number;
-  /** Percent of finished (completed+error) agents that completed successfully. */
+  /** Percent of finished (completed+error) agents that completed successfully.
+   *  Range 0-100; excludes still-running agents from the denominator. */
   successRate: number;
-  /** Mean maximum parent→child agent nesting depth per session. */
+  /** Mean maximum parent→child agent nesting depth per session (1 = flat,
+   *  no delegation beyond the main agent). */
   avgDepth: number;
-  /** Mean session duration in seconds, across ended sessions. */
+  /** Mean session duration in seconds, across ended sessions (running sessions
+   *  are excluded so an open session doesn't skew the average). */
   avgDurationSec: number;
+  /** Total compaction pseudo-agents across all sessions considered. */
   totalCompactions: number;
   /** Mean compactions per session. */
   avgCompactions: number;
   /** The single most common two-tool sequence across all sessions, or null
-   *  if no session has at least two tool calls. */
+   *  if no session has at least two tool calls. Example:
+   *  `{ source: "Read", target: "Edit", count: 88 }` = "Read then Edit, 88x". */
   topFlow: { source: string; target: string; count: number } | null;
 }
 
 /** One directed delegation edge in the orchestration graph: `source` subagent
  *  type (or "main") spawned `target` subagent type `weight` times. */
 export interface OrchestrationEdge {
+  /** Delegating role: a `subagent_type`, or "main" for the top-level agent. */
   source: string;
+  /** Delegated-to `subagent_type`. */
   target: string;
+  /** How many times `source` spawned `target` across all sessions considered. */
   weight: number;
 }
 
 /** Data for the Workflows page's orchestration graph - who delegates to whom.
  *  From `getOrchestrationData` in server/routes/workflows.js. */
 export interface OrchestrationData {
+  /** Number of sessions the graph was computed over (after the status filter). */
   sessionCount: number;
-  /** Count of agents with `type === "main"`. */
+  /** Count of agents with `type === "main"` - the root nodes that delegate out. */
   mainCount: number;
-  /** Per-subagent-type totals with completion/error breakdown, most-used first. */
+  /** Per-subagent-type totals with completion/error breakdown, most-used first.
+   *  `completed + errors` may be less than `count` when some are still running. */
   subagentTypes: Array<{ subagent_type: string; count: number; completed: number; errors: number }>;
+  /** Directed delegation edges; see {@link OrchestrationEdge}. Rendered as the
+   *  arrows of the orchestration graph. */
   edges: OrchestrationEdge[];
-  /** Terminal-status counts across all agents ("completed"/"error" only). */
+  /** Terminal-status counts across all agents ("completed"/"error" only);
+   *  running/waiting agents are excluded. */
   outcomes: Array<{ status: string; count: number }>;
-  /** Total compaction pseudo-agents and how many distinct sessions had one. */
+  /** Total compaction pseudo-agents and how many distinct sessions had one.
+   *  `total` counts every compaction; `sessions` counts unique sessions with
+   *  at least one, so `total / sessions` is the average compactions per
+   *  compacting session. */
   compactions: { total: number; sessions: number };
 }
 
 /** One tool→tool adjacency edge: `target` ran immediately after `source`
  *  within the same session, `value` times. */
 export interface ToolFlowTransition {
+  /** The tool that ran first. */
   source: string;
+  /** The tool that ran immediately after `source` in the same session. */
   target: string;
+  /** How many times this exact adjacency occurred across sessions. */
   value: number;
 }
 
@@ -834,63 +1269,84 @@ export interface ToolFlowTransition {
  *  `getToolFlowData` in server/routes/workflows.js (top 50 transitions,
  *  top 15 tools by count). */
 export interface ToolFlowData {
+  /** The adjacency edges (top 50); see {@link ToolFlowTransition}. The links of
+   *  the tool-flow graph. */
   transitions: ToolFlowTransition[];
-  /** Per-tool total invocation counts, used to size graph nodes. */
+  /** Per-tool total invocation counts, used to size graph nodes (top 15 tools).
+   *  Larger `count` → larger node in the Sankey/graph. */
   toolCounts: Array<{ tool_name: string; count: number }>;
 }
 
 /** Per-subagent-type effectiveness row for the Workflows page (top 12 by
  *  volume). From `getSubagentEffectiveness` in server/routes/workflows.js. */
 export interface SubagentEffectivenessItem {
+  /** The subagent type this row summarizes. */
   subagent_type: string;
+  /** Total invocations of this subagent type (all statuses, denominator). */
   total: number;
+  /** How many of those invocations reached "completed" (numerator of successRate). */
   completed: number;
+  /** How many of those invocations reached "error". */
   errors: number;
-  /** Distinct sessions this subagent type appeared in. */
+  /** Distinct sessions this subagent type appeared in (breadth of use). */
   sessions: number;
-  /** Percent of finished (completed+error) runs that completed successfully. */
+  /** Percent of finished (completed+error) runs that completed successfully
+   *  (0-100); still-running runs are excluded from the denominator. */
   successRate: number;
   /** Mean duration in seconds for finished runs; null if none have ended. */
   avgDuration: number | null;
   /** 7-slot invocation-count histogram over the last 8 weeks, Monday-first
-   *  ([Mon, Tue, Wed, Thu, Fri, Sat, Sun]). */
+   *  ([Mon, Tue, Wed, Thu, Fri, Sat, Sun]). Rendered as a small day-of-week
+   *  sparkline; index 0 is Monday. */
   trend: number[];
 }
 
 /** One recurring subagent-type sequence detected across sessions (2-3 step
  *  windows and full sequences all included), sorted by frequency. */
 export interface WorkflowPattern {
-  /** Ordered `subagent_type` sequence, e.g. ["planner", "coder", "reviewer"]. */
+  /** Ordered `subagent_type` sequence, e.g. ["planner", "coder", "reviewer"].
+   *  The recurring delegation "recipe" this row represents. */
   steps: string[];
-  /** Number of sessions exhibiting this exact sequence/sub-sequence. */
+  /** Number of sessions exhibiting this exact sequence/sub-sequence. Higher =
+   *  a more established habit. */
   count: number;
-  /** `count` as a percentage of all sessions considered. */
+  /** `count` as a percentage of all sessions considered (0-100). */
   percentage: number;
 }
 
 /** Data for the Workflows page's pattern-mining panel (top 10 patterns).
  *  From `getWorkflowPatterns` in server/routes/workflows.js. */
 export interface WorkflowPatternsData {
+  /** The mined recurring subagent-type sequences; see {@link WorkflowPattern}. */
   patterns: WorkflowPattern[];
-  /** Sessions that spawned zero subagents (main agent worked solo). */
+  /** Sessions that spawned zero subagents (main agent worked solo). The
+   *  complement of the sessions that show up in `patterns`. */
   soloSessionCount: number;
-  /** `soloSessionCount` as a percentage of all sessions considered. */
+  /** `soloSessionCount` as a percentage of all sessions considered (0-100). */
   soloPercentage: number;
 }
 
 /** Model choice and token usage broken down by delegation role, for the
  *  Workflows page's model-delegation panel. From `getModelDelegation`. */
 export interface ModelDelegationData {
-  /** Models used by main agents, with agent/session counts, most-used first. */
+  /** Models used by main agents, with agent/session counts, most-used first.
+   *  `session_count` disambiguates "one busy session" from "many sessions". */
   mainModels: Array<{ model: string; agent_count: number; session_count: number }>;
-  /** Models used by subagents (approximated via the owning session's model). */
+  /** Models used by subagents (approximated via the owning session's model,
+   *  since subagents don't always report their own model). */
   subagentModels: Array<{ model: string; agent_count: number }>;
-  /** Token totals grouped by model, most total tokens first. */
+  /** Token totals grouped by model, most total tokens first. Lets the panel show
+   *  which model soaks up the most tokens, split by bucket. */
   tokensByModel: Array<{
+    /** Model id these token totals are for. */
     model: string;
+    /** Fresh (non-cached) input tokens for this model. */
     input_tokens: number;
+    /** Output/completion tokens for this model. */
     output_tokens: number;
+    /** Prompt-cache-read tokens for this model. */
     cache_read_tokens: number;
+    /** Prompt-cache-write tokens for this model. */
     cache_write_tokens: number;
   }>;
 }
@@ -898,14 +1354,18 @@ export interface ModelDelegationData {
 /** Data for the Workflows page's error-propagation panel - where in the agent
  *  hierarchy errors occur. From `getErrorPropagation` in workflows.js. */
 export interface ErrorPropagationData {
-  /** Error counts by parent→child nesting depth (0 = main agent / session-level). */
+  /** Error counts by parent→child nesting depth (0 = main agent / session-level).
+   *  Higher depth = errors happening deeper in the delegation tree. */
   byDepth: Array<{ depth: number; count: number }>;
-  /** Top 5 error-prone subagent types by error count. */
+  /** Top 5 error-prone subagent types by error count. Highlights which roles
+   *  fail most often. */
   byType: Array<{ subagent_type: string; count: number }>;
-  /** Top 10 recurring error-event summaries (Stop-with-error, APIError) by count. */
+  /** Top 10 recurring error-event summaries (Stop-with-error, APIError) by count.
+   *  Surfaces the most common concrete failure messages. */
   eventErrors: Array<{ summary: string; count: number }>;
   /** Sessions with at least one error (agent error, session error, or error event). */
   sessionsWithErrors: number;
+  /** Total sessions considered (denominator for `errorRate`). */
   totalSessions: number;
   /** `sessionsWithErrors` as a percentage of `totalSessions`. */
   errorRate: number;
@@ -914,49 +1374,68 @@ export interface ErrorPropagationData {
 /** One row of the Workflows page's concurrency chart: a role/subagent-type's
  *  average position within the session timeline. */
 export interface ConcurrencyLane {
-  /** "Main Agent" or a `subagent_type` string. */
+  /** "Main Agent" or a `subagent_type` string. The lane label. */
   name: string;
-  /** Mean start position as a 0-1 fraction of total session duration. */
+  /** Mean start position as a 0-1 fraction of total session duration (0 = at the
+   *  very start, 1 = at the very end). */
   avgStart: number;
-  /** Mean end position as a 0-1 fraction of total session duration. */
+  /** Mean end position as a 0-1 fraction of total session duration; always
+   *  `>= avgStart`. Together they define where the lane sits on the timeline. */
   avgEnd: number;
-  /** Number of agent instances averaged into this lane. */
+  /** Number of agent instances averaged into this lane (the sample size). */
   count: number;
 }
 
 /** Data for the Workflows page's concurrency chart. From `getConcurrencyData`
  *  in server/routes/workflows.js (computed only from sessions that have ended). */
 export interface ConcurrencyData {
+  /** One averaged lane per role/subagent-type; see {@link ConcurrencyLane}.
+   *  Overlapping `avgStart`/`avgEnd` ranges reveal which roles tend to run
+   *  concurrently versus sequentially. */
   aggregateLanes: ConcurrencyLane[];
 }
 
 /** One row of the Workflows page's session-complexity scatter/table (most
  *  recent 200 sessions). From `getSessionComplexity` in workflows.js. */
 export interface SessionComplexityItem {
+  /** Session id. */
   id: string;
+  /** Session display name; null when unnamed. */
   name: string | null;
+  /** Session status string (see {@link SessionStatus}; typed loosely as string
+   *  here since it arrives from a computed query rather than the typed column). */
   status: string;
-  /** Session duration in seconds (0 if still running, per `durationSec`). */
+  /** Session duration in seconds (0 if still running, per `durationSec`). One of
+   *  the scatter-plot axes on the complexity view. */
   duration: number;
-  /** Total agents (main + subagents) belonging to this session. */
+  /** Total agents (main + subagents) belonging to this session. A complexity
+   *  axis (more agents = more delegation). */
   agentCount: number;
-  /** Subset of `agentCount` with `type === "subagent"`. */
+  /** Subset of `agentCount` with `type === "subagent"` (excludes the main agent). */
   subagentCount: number;
-  /** Sum of all token buckets (input+output+cache read+cache write). */
+  /** Sum of all token buckets (input+output+cache read+cache write). The token
+   *  "size" of the session; another complexity axis. */
   totalTokens: number;
+  /** Session model id; null when unknown. */
   model: string | null;
 }
 
 /** Data for the Workflows page's compaction-impact panel - how much context
  *  compression is happening and its token savings. From `getCompactionImpact`. */
 export interface CompactionImpactData {
+  /** Total compaction pseudo-agents across all sessions considered (matches
+   *  {@link WorkflowStats.totalCompactions}). */
   totalCompactions: number;
   /** Sum of `baseline_*` token columns across all usage rows - the tokens that
-   *  would have been re-billed had compaction not reset the running context. */
+   *  would have been re-billed had compaction not reset the running context.
+   *  The headline "tokens saved by compaction" figure. */
   tokensRecovered: number;
-  /** Top 50 sessions by compaction count, most-compacted first. */
+  /** Top 50 sessions by compaction count, most-compacted first. Each row links
+   *  a session to how many times its context was compacted. */
   perSession: Array<{ session_id: string; compactions: number }>;
+  /** Distinct sessions that had at least one compaction. */
   sessionsWithCompactions: number;
+  /** Total sessions considered (denominator for the impact ratio). */
   totalSessions: number;
 }
 
@@ -964,34 +1443,55 @@ export interface CompactionImpactData {
  *  workflow-intelligence panels shown on the Workflows page, all computed
  *  against the same optional session-status filter. */
 export interface WorkflowData {
+  /** Headline metric cards; see {@link WorkflowStats}. */
   stats: WorkflowStats;
+  /** Delegation graph data; see {@link OrchestrationData}. */
   orchestration: OrchestrationData;
+  /** Tool→tool adjacency graph data; see {@link ToolFlowData}. */
   toolFlow: ToolFlowData;
+  /** Per-subagent-type effectiveness rows; see {@link SubagentEffectivenessItem}. */
   effectiveness: SubagentEffectivenessItem[];
+  /** Recurring delegation-sequence patterns; see {@link WorkflowPatternsData}. */
   patterns: WorkflowPatternsData;
+  /** Model-choice-by-role breakdown; see {@link ModelDelegationData}. */
   modelDelegation: ModelDelegationData;
+  /** Error-location breakdown; see {@link ErrorPropagationData}. */
   errorPropagation: ErrorPropagationData;
+  /** Timeline-position lanes; see {@link ConcurrencyData}. */
   concurrency: ConcurrencyData;
+  /** Per-session complexity rows; see {@link SessionComplexityItem}. */
   complexity: SessionComplexityItem[];
+  /** Compaction-savings panel; see {@link CompactionImpactData}. */
   compaction: CompactionImpactData;
   /** Directed subagent-type co-occurrence edges (source ran before target in
-   *  the same session, weight >= 2), for the co-occurrence graph. */
+   *  the same session, weight >= 2), for the co-occurrence graph. Unlike
+   *  {@link OrchestrationEdge} (direct parent→child delegation), these capture
+   *  "tends to appear together in a session" ordering, not spawning. */
   cooccurrence: Array<{ source: string; target: string; weight: number }>;
 }
 
 /** Response shape of GET /api/workflows/session/:id - the single-session
  *  drill-in view (agent tree, tool timeline, swim lanes, raw events). */
 export interface SessionDrillIn {
+  /** The full session row this drill-in is for. */
   session: Session;
   /** Agents nested into a parent→child tree (roots = agents with no parent). */
   tree: Array<{
+    /** Agent id. */
     id: string;
+    /** Agent display name. */
     name: string;
+    /** "main" or "subagent" (typed loosely as string here). */
     type: string;
+    /** The agent's `subagent_type`; null for main agents. */
     subagent_type: string | null;
+    /** Agent status string. */
     status: string;
+    /** The agent's task description; null when not captured. */
     task: string | null;
+    /** ISO timestamp the agent started. */
     started_at: string;
+    /** ISO timestamp the agent finished; null if still running. */
     ended_at: string | null;
     /** Recursively nested child agents (empty array for leaves). */
     children: SessionDrillIn["tree"];
@@ -999,58 +1499,80 @@ export interface SessionDrillIn {
   /** Every tool-invoking event in the session, chronological, flattened for
    *  the horizontal tool-usage timeline. */
   toolTimeline: Array<{
+    /** Source `DashboardEvent.id`. */
     id: number;
+    /** Tool that was invoked. */
     tool_name: string;
+    /** Originating event type (e.g. "PreToolUse"/"PostToolUse"). */
     event_type: string;
+    /** Agent that invoked the tool; null for session-level events. */
     agent_id: string | null;
+    /** ISO timestamp of the event. */
     created_at: string;
+    /** Short summary for the timeline row; null when none. */
     summary: string | null;
   }>;
   /** Flat per-agent metadata (no nesting) for rendering horizontal swim lanes
    *  against the session timeline; `parent_agent_id` lets the UI draw links. */
   swimLanes: Array<{
+    /** Agent id. */
     id: string;
+    /** Agent display name. */
     name: string;
+    /** "main" or "subagent" (typed loosely as string here). */
     type: string;
+    /** The agent's `subagent_type`; null for main agents. */
     subagent_type: string | null;
+    /** Agent status string. */
     status: string;
+    /** ISO timestamp the agent started (left edge of its lane). */
     started_at: string;
+    /** ISO timestamp the agent finished; null if still running. */
     ended_at: string | null;
+    /** Parent agent id, so the UI can draw delegation links; null for roots. */
     parent_agent_id: string | null;
   }>;
-  /** Up to the first 500 raw events for this session, chronological. */
+  /** Up to the first 500 raw events for this session, chronological. Powers the
+   *  raw-events tab of the drill-in; capped so a huge session stays responsive. */
   events: DashboardEvent[];
 }
 
-// ── Workflow-tool runs (issue #167) ──────────────────────────────────────────
+// ───── Workflow-tool runs (issue #167) ─────────────────────────────────────
 // Fleets of inner sub-agents spawned by the Claude Code "Workflow" tool,
 // ingested from the on-disk run journal. Distinct from WorkflowData above
 // (which is events-derived analytics).
 /** One named phase marker from a run journal's `phases[]` array - free-form,
  *  since the Workflow tool script defines its own phase structure. */
 export interface WorkflowPhase {
-  /** Phase name, e.g. "Plan", "Implement", "Review". */
+  /** Phase name, e.g. "Plan", "Implement", "Review". Matched against
+   *  {@link WorkflowProgressEntry.phaseTitle} to group agents under a phase. */
   title?: string;
-  /** Optional longer description of what the phase covers. */
+  /** Optional longer description of what the phase covers. Shown as the phase
+   *  header's subtitle. */
   detail?: string;
-  /** Additional script-defined fields pass through untyped. */
+  /** Additional script-defined fields pass through untyped. The index signature
+   *  keeps the journal's forward-compatible extra keys accessible. */
   [key: string]: unknown;
 }
 
 /** One entry in a `WorkflowRun.progress` log - a mixed timeline of phase
  *  markers and inner-agent lifecycle updates, in journal order. */
 export interface WorkflowProgressEntry {
-  /** "workflow_agent" (a real inner agent) or "workflow_phase" (a phase marker). */
+  /** "workflow_agent" (a real inner agent) or "workflow_phase" (a phase marker).
+   *  Discriminates whether this entry describes an agent or a phase boundary. */
   type?: string;
   /** For workflow_agent entries: matches the `agent-<agentId>.jsonl` transcript
    *  basename, and is linked into the `agents` table as
-   *  `${sessionId}-jsonl-<agentId>`. */
+   *  `${sessionId}-jsonl-<agentId>`. The join key back to a real `Agent` row. */
   agentId?: string;
-  /** Freeform inner-agent role/type as reported by the launch script. */
+  /** Freeform inner-agent role/type as reported by the launch script. Example:
+   *  `"reviewer"`. */
   agentType?: string | null;
-  /** Model the inner agent ran with, if known. */
+  /** Model the inner agent ran with, if known; overrides
+   *  {@link WorkflowRun.default_model} for this agent. */
   model?: string | null;
-  /** Inner-agent lifecycle state, e.g. "running", "done", "error". */
+  /** Inner-agent lifecycle state, e.g. "running", "done", "error". Freeform,
+   *  chosen by the launch script (not the closed {@link AgentStatus} enum). */
   state?: string | null;
   /** Short display label for the agent (falls back to prompt preview). */
   label?: string | null;
@@ -1060,17 +1582,23 @@ export interface WorkflowProgressEntry {
   /** When the agent/phase started - ISO string or epoch depending on the
    *  script that emitted it. */
   startedAt?: string | number | null;
-  /** Tokens consumed by this inner agent, once known. */
+  /** Tokens consumed by this inner agent, once known. Summed into
+   *  {@link WorkflowRun.total_tokens}. */
   tokens?: number;
-  /** Tool calls made by this inner agent, once known. */
+  /** Tool calls made by this inner agent, once known. Summed into
+   *  {@link WorkflowRun.total_tool_calls}. */
   toolCalls?: number;
-  /** Wall-clock runtime in milliseconds; null while still running. */
+  /** Wall-clock runtime in milliseconds; null while still running. Epoch-relative
+   *  duration, not an ISO string. */
   durationMs?: number | null;
-  /** Most recent tool name the agent invoked, for a live "what's it doing" hint. */
+  /** Most recent tool name the agent invoked, for a live "what's it doing" hint.
+   *  Example: `"Edit"`. */
   lastToolName?: string | null;
-  /** Truncated preview of the task/prompt handed to this inner agent. */
+  /** Truncated preview of the task/prompt handed to this inner agent, for the
+   *  card subtitle. */
   promptPreview?: string | null;
-  /** Truncated preview of the inner agent's final result, once done. */
+  /** Truncated preview of the inner agent's final result, once done; shown when
+   *  the agent card is expanded. */
   resultPreview?: string | null;
   /** Additional script-defined fields pass through untyped. */
   [key: string]: unknown;
@@ -1082,96 +1610,135 @@ export interface WorkflowProgressEntry {
  * on-disk run journal (see server/lib/workflow-ingest.js). Distinct from the
  * events-derived {@link WorkflowData} above. Returned by GET /api/workflows/runs
  * and /api/workflows/runs/:runId; pushed live via `workflow_upserted`.
+ *
+ * A run starts life as `source: "live"` (only the launch script has been seen)
+ * and is promoted to `source: "journal"` once the completed run journal exists
+ * on disk. The `total_*`/`agent_count` fields are rolled up from `progress`.
  */
 export interface WorkflowRun {
-  /** Stable run id, matching the `wf_<runId>.json` journal / launch script name. */
+  /** Stable run id, matching the `wf_<runId>.json` journal / launch script name.
+   *  Primary key for the run. Example: `"wf_20260319_140322"`. */
   run_id: string;
-  /** Session that launched this run. */
+  /** Session that launched this run. FK into `Session.id`; inner agents are
+   *  linked under this session as `${sessionId}-jsonl-<agentId>`. */
   session_id: string;
-  /** Correlates to a TaskCreate/TaskList task, if the run was tied to one; null otherwise. */
+  /** Correlates to a TaskCreate/TaskList task, if the run was tied to one; null
+   *  otherwise. Lets the UI cross-link a run with its originating to-do task. */
   task_id: string | null;
-  /** Display name for the run, if the launch script provided one. */
+  /** Display name for the run, if the launch script provided one. Example:
+   *  `"Refactor auth module"`. Null falls back to `run_id` in the UI. */
   name: string | null;
-  /** Run lifecycle, e.g. "running", "completed", "error" (freeform; not a closed enum). */
+  /** Run lifecycle, e.g. "running", "completed", "error" (freeform; not a closed
+   *  enum, since the launch script chooses its own status vocabulary). */
   status: string;
-  /** Default model inner agents used unless overridden per-agent; null if unset. */
+  /** Default model inner agents used unless overridden per-agent; null if unset.
+   *  Example: `"claude-sonnet-4-5"`. */
   default_model: string | null;
-  /** ISO timestamp the run started; null if not yet known (e.g. mid-launch). */
+  /** ISO timestamp the run started; null if not yet known (e.g. mid-launch).
+   *  Left edge of the run's overall timeline. */
   started_at: string | null;
-  /** ISO timestamp the run finished; null while still running. */
+  /** ISO timestamp the run finished; null while still running. Set once the
+   *  completed journal is observed. */
   ended_at: string | null;
-  /** Total wall-clock runtime in milliseconds; null while still running. */
+  /** Total wall-clock runtime in milliseconds; null while still running.
+   *  Note: epoch-relative duration in ms, not an ISO string. */
   duration_ms: number | null;
-  /** Number of inner agents spawned by this run. */
+  /** Number of inner agents spawned by this run. Rolled up from `progress`
+   *  (count of `workflow_agent` entries). */
   agent_count: number;
-  /** Sum of tokens consumed across all inner agents. */
+  /** Sum of tokens consumed across all inner agents. Rolled up from each
+   *  `progress` entry's `tokens`. */
   total_tokens: number;
-  /** Sum of tool calls made across all inner agents. */
+  /** Sum of tool calls made across all inner agents. Rolled up from each
+   *  `progress` entry's `toolCalls`. */
   total_tool_calls: number;
+  /** Phase markers for the run; see {@link WorkflowPhase}. */
   phases: WorkflowPhase[];
+  /** Interleaved phase + inner-agent timeline; see {@link WorkflowProgressEntry}. */
   progress: WorkflowProgressEntry[];
-  /** Path to the generated launch script under `workflows/scripts/`; null if unknown. */
+  /** Path to the generated launch script under `workflows/scripts/`; null if
+   *  unknown. Example: `"workflows/scripts/wf_20260319_140322.sh"`. */
   script_path: string | null;
-  /** Path to the `wf_<runId>.json` journal file; null for a run not yet completed. */
+  /** Path to the `wf_<runId>.json` journal file; null for a run not yet
+   *  completed (i.e. while `source === "live"`). */
   journal_path: string | null;
   /** "journal" once a completed run journal exists; "live" while only the
-   *  launch script (no journal yet) has been observed. */
+   *  launch script (no journal yet) has been observed. Promotion from "live" to
+   *  "journal" happens when the on-disk journal is ingested. */
   source: "journal" | "live";
-  /** ISO timestamp this row was first ingested. */
+  /** ISO timestamp this row was first ingested (first seen by the watcher). */
   created_at: string;
-  /** ISO timestamp this row was last updated (re-ingested/upserted). */
+  /** ISO timestamp this row was last updated (re-ingested/upserted). Bumped on
+   *  every `workflow_upserted` broadcast. */
   updated_at: string;
 }
 
 /** Response shape of GET /api/workflows/runs - a paginated, optionally
  *  status/session-filtered list of workflow-tool runs. */
 export interface WorkflowRunsResponse {
+  /** The page of runs for the current `limit`/`offset`. */
   runs: WorkflowRun[];
   /** Total matching runs (ignores `limit`/`offset`, respects the status filter). */
   total: number;
   /** Run count keyed by `status`, across all runs (ignores any filter). */
   counts: Record<string, number>;
+  /** Page size that was applied. */
   limit: number;
+  /** Zero-based offset of this page into the filtered result set. */
   offset: number;
 }
 
 /** Response shape of GET /api/workflows/runs/:runId - a single run plus its
  *  linked inner agents (as regular `Agent` rows) and their attributed events. */
 export interface WorkflowRunDetail {
+  /** The run itself; see {@link WorkflowRun}. */
   workflow: WorkflowRun;
-  /** Inner agents linked to this run via the `${sessionId}-jsonl-<agentId>` id scheme. */
+  /** Inner agents linked to this run via the `${sessionId}-jsonl-<agentId>` id
+   *  scheme. Regular {@link Agent} rows, so the same UI can render them. */
   agents: Agent[];
-  /** Events attributed to this run's inner agents, chronological (up to 5000). */
+  /** Events attributed to this run's inner agents, chronological (up to 5000).
+   *  Capped to keep the payload bounded for very long runs. */
   events: DashboardEvent[];
 }
+
+// ───── Status presentation lookup (agents) ─────
 
 /**
  * UI presentation lookup for {@link EffectiveAgentStatus}: the i18n key, text
  * color, badge background, and status-dot Tailwind classes for each state.
  * `labelKey` is passed to `i18n.t()`; the rest are applied directly as classes.
+ *
+ * Keyed by every {@link EffectiveAgentStatus} value, so the record is exhaustive
+ * for the agent status set. See {@link SESSION_STATUS_CONFIG} for the parallel
+ * session-status lookup, which additionally covers "abandoned".
  */
 export const STATUS_CONFIG: Record<
   EffectiveAgentStatus,
   { labelKey: string; color: string; bg: string; dot: string }
 > = {
+  // Green: the agent is actively running a tool / doing work.
   working: {
     labelKey: "common:status.working",
     color: "text-emerald-400",
     bg: "bg-emerald-500/10 border-emerald-500/20",
     dot: "bg-emerald-400",
   },
+  // Yellow: idle-between-turns, or (via the AWAITING_STATUS overlay) blocked
+  // on user input - attention may be required.
   waiting: {
     labelKey: "common:status.waiting",
     color: "text-yellow-400",
     bg: "bg-yellow-500/10 border-yellow-500/20",
     dot: "bg-yellow-400",
   },
+  // Violet: the agent finished cleanly.
   completed: {
     labelKey: "common:status.completed",
     color: "text-violet-400",
     bg: "bg-violet-500/10 border-violet-500/20",
     dot: "bg-violet-400",
   },
+  // Red: the agent ended in an error state.
   error: {
     labelKey: "common:status.error",
     color: "text-red-400",
@@ -1180,18 +1747,25 @@ export const STATUS_CONFIG: Record<
   },
 };
 
-// ── Transcript / Conversation types ──
+// ───── Transcript / Conversation types ─────
+// Shapes for the raw JSONL transcript viewer in SessionDetail: individual
+// content blocks, whole messages, a paginated page of messages, and the picker
+// that lists a session's available transcripts (main, each subagent, compaction).
 
 /** One content block within a {@link TranscriptMessage}, mirroring the
  *  Anthropic Messages API content-block shapes as they appear in a Claude
  *  Code session's raw JSONL transcript. */
 export interface TranscriptContent {
+  /** Block kind; selects which of the optional fields below are populated.
+   *  "thinking" is the model's extended-reasoning trace; "text" is normal prose;
+   *  "tool_use"/"tool_result" are the two halves of a tool round-trip. */
   type: "text" | "tool_use" | "tool_result" | "thinking";
-  /** Present for "text"/"thinking" blocks: the rendered prose. */
+  /** Present for "text"/"thinking" blocks: the rendered prose (or reasoning). */
   text?: string;
-  /** Present for "tool_use" blocks: the invoked tool's name. */
+  /** Present for "tool_use" blocks: the invoked tool's name. Example: `"Bash"`. */
   name?: string;
-  /** Present for "tool_use"/"tool_result" blocks: correlates a result to its call. */
+  /** Present for "tool_use"/"tool_result" blocks: correlates a result to its
+   *  call (both halves share the same `id`). */
   id?: string;
   /** Present for "tool_use" blocks: the tool call's arguments, or a
    *  `{ _truncated }` placeholder when the original input was too large to keep. */
@@ -1211,21 +1785,33 @@ export type TranscriptSender = "user" | "assistant" | "orchestrator" | "system" 
  * One parsed line from a session's (or subagent's) raw transcript JSONL,
  * as returned by GET /api/sessions/:id/transcript. Rendered by the
  * conversation viewer in SessionDetail.
+ *
+ * The synthetic `type: "session_event"` line is not a real transcript entry -
+ * the server injects it to mark in-band TUI actions (currently only `/rename`),
+ * carrying its detail in `event_kind`/`title` rather than `content`.
  */
 export interface TranscriptMessage {
   /** Raw JSONL line type. "session_event" is a synthetic marker (see
    *  `event_kind`/`title`) injected by the server, not a real transcript line. */
   type: "user" | "assistant" | "session_event";
-  /** True sender, classified server-side. Falls back to `type` when absent. */
+  /** True sender, classified server-side. Falls back to `type` when absent.
+   *  Distinguishes, e.g., a human "user" line from a tool-result "user" line;
+   *  see {@link TranscriptSender}. */
   sender?: TranscriptSender;
-  /** ISO timestamp from the transcript line; null if the line had none. */
+  /** ISO timestamp from the transcript line; null if the line had none.
+   *  Used to order and time-stamp messages in the conversation view. */
   timestamp: string | null;
+  /** The message's content blocks; see {@link TranscriptContent}. A single
+   *  message can mix text, thinking, tool_use, and tool_result blocks. */
   content: TranscriptContent[];
-  /** Model that produced an assistant message; absent for user/session_event. */
+  /** Model that produced an assistant message; absent for user/session_event.
+   *  Example: `"claude-opus-4-8"`. */
   model?: string;
   /** Token accounting reported alongside an assistant message; absent otherwise. */
   usage?: {
+    /** Fresh (non-cached) input tokens for this message. */
     input_tokens: number;
+    /** Output/completion tokens generated for this message. */
     output_tokens: number;
     /** Tokens served from prompt cache reads. */
     cache_read_input_tokens?: number;
@@ -1243,6 +1829,7 @@ export interface TranscriptMessage {
  *  transcript messages, paginated by JSONL line number rather than offset so
  *  the client can page forward/backward through a live-growing file. */
 export interface TranscriptResult {
+  /** The messages on this page; see {@link TranscriptMessage}. */
   messages: TranscriptMessage[];
   /** Valid messages seen so far; exact for a fully-read file, a lower bound
    *  when the scan stopped early once `limit` was satisfied. */
@@ -1264,20 +1851,28 @@ export interface TranscriptInfo {
   id: string;
   /** Display name for the picker entry. */
   name: string;
+  /** Which kind of transcript this entry points at. */
   type: "main" | "subagent" | "compaction";
+  /** The subagent type for subagent entries; null/absent otherwise (e.g. the
+   *  main or compaction entries). */
   subagent_type?: string | null;
   /** Whether a JSONL transcript file was actually found on disk for this entry -
-   *  false means the entry exists in the DB but its transcript isn't available. */
+   *  false means the entry exists in the DB but its transcript isn't available
+   *  (e.g. the raw file was pruned), so the UI disables that picker option. */
   has_transcript: boolean;
   /** Underlying `Agent.id`, when this entry corresponds to a real agent row;
    *  null/absent for the synthetic main-session entry. */
   db_agent_id?: string | null;
 }
 
-/** Response shape of GET /api/sessions/:id/transcripts. */
+/** Response shape of GET /api/sessions/:id/transcripts - the list of transcripts
+ *  available for a session, used to populate the transcript picker. */
 export interface TranscriptListResult {
+  /** All picker entries for the session; see {@link TranscriptInfo}. */
   transcripts: TranscriptInfo[];
 }
+
+// ───── Status presentation lookup (sessions) ─────
 
 /** Same UI presentation lookup as {@link STATUS_CONFIG}, but keyed by
  *  {@link EffectiveSessionStatus} - adds an "abandoned" entry that
@@ -1286,30 +1881,36 @@ export const SESSION_STATUS_CONFIG: Record<
   EffectiveSessionStatus,
   { labelKey: string; color: string; bg: string; dot: string }
 > = {
+  // Green: the session is live and running.
   active: {
     labelKey: "common:status.active",
     color: "text-emerald-400",
     bg: "bg-emerald-500/10 border-emerald-500/20",
     dot: "bg-emerald-400",
   },
+  // Yellow: blocked on user input via the AWAITING_STATUS overlay.
   waiting: {
     labelKey: "common:status.waiting",
     color: "text-yellow-400",
     bg: "bg-yellow-500/10 border-yellow-500/20",
     dot: "bg-yellow-400",
   },
+  // Violet: the session ended cleanly (SessionEnd).
   completed: {
     labelKey: "common:status.completed",
     color: "text-violet-400",
     bg: "bg-violet-500/10 border-violet-500/20",
     dot: "bg-violet-400",
   },
+  // Red: the session ended in an error state.
   error: {
     labelKey: "common:status.error",
     color: "text-red-400",
     bg: "bg-red-500/10 border-red-500/20",
     dot: "bg-red-400",
   },
+  // Slate: stale session swept as "abandoned" (never cleanly ended); has no
+  // equivalent in STATUS_CONFIG since agents don't get abandoned.
   abandoned: {
     // Muted slate distinguishes "given up / faded out" from yellow Waiting
     // (attention required).


### PR DESCRIPTION
## Summary

Restores **TypeScript as the repository's top language** on GitHub Linguist by adding comprehensive TSDoc/JSDoc documentation to the client's core `lib/` modules. JS had drifted back ahead by ~1 KB; TS now leads by **~150 KB**.

This is a **comments-only** change — not a single byte of emitted code changed.

## What changed

Every exported interface, type, function, and const — plus the fields inside the data-model interfaces — now carries an accurate doc comment (units, nullability, example values, DB-column and API/WebSocket mappings), with module overviews and section banners throughout.

| File | Comment bytes added | Focus |
| ---- | -------------------: | ----- |
| `lib/types.ts` | +38.8 KB | data-model, WS envelope, workflow-intelligence types; per-field TSDoc with DB/endpoint mappings |
| `lib/api.ts` | +43.7 KB | REST layer — per-endpoint HTTP method+path, `@param`/`@returns`/`@throws`, request-shaping notes |
| `lib/event-grouping.ts` | +18.6 KB | event → title heuristics, per-tool cases |
| `lib/event-summary.ts` | +10.9 KB | `tool_response` summarization rules |
| `lib/highlight.ts` | +22.6 KB | syntax highlighter, regex tables |
| `lib/format.ts` | +12.5 KB | 4-locale (en/zh/vi/ko) number/date/currency |
| `lib/eventBus.ts` | +2.4 KB | client event bus |
| `lib/push.ts` | +4.7 KB | web-push subscription lifecycle |
| **Total** | **~+154 KB** | |

## Verification

- **Code unchanged (proof):** each file was transpiled with `removeComments` and diffed against `HEAD` → all 8 emit byte-identical code (`IDENTICAL`).
- **`tsc --noEmit -p .`** → exit 0, no errors.
- **`npm run test:client`** → 251/251 pass (incl. per-screen render snapshots).
- **Prettier** → clean.
- **Header audit** (`check-headers.sh`) → exit 0; every existing `@author` line preserved verbatim.
- **Linguist margin:** TS (ts+tsx) = 1,896,740 B vs JS (js+mjs) = 1,743,375 B → **TS +153 KB**.

## How to Test

1. `cd client && npx tsc --noEmit -p .` — clean.
2. `npm run test:client` — 251/251.
3. Strip-and-diff any file: transpiling with `removeComments` yields the same output as `master`.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/hoangsonww/Claude-Code-Agent-Monitor/blob/master/.github/CONTRIBUTING.md)
- [x] I have signed the [CLA](https://github.com/hoangsonww/Claude-Code-Agent-Monitor/blob/master/CLA.md)
- [x] My code follows the project's coding standards
- [x] I have added/updated tests that prove my fix or feature works (comments-only; existing suite passes 251/251)
- [x] All new and existing tests pass (`npm test`)
- [x] Code is formatted (`npm run format:check`)
- [x] I have updated documentation where necessary

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146oeseRLX17wL3iTqc1trq
