### PR TITLE
chore: add .github/FUNDING.yml sponsor button (GitHub Sponsors)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+# Sponsor button configuration for this repository.
+# Sponsorships are handled exclusively through GitHub Sponsors.
+# Docs: https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+github: hoangsonww


### PR DESCRIPTION
## What

Adds `.github/FUNDING.yml` on the default branch so GitHub renders a **Sponsor** button on the repository header and in the contributor sidebar.

```yaml
github: hoangsonww
```

## Why

Surfaces funding options to the community. Per the maintainer, all sponsorships go through **GitHub Sponsors only** — no Patreon, Ko-fi, or other platforms — so the file intentionally sets a single `github:` entry and nothing else.

## Notes

- Location and key follow the [GitHub docs for the sponsor button](https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository).
- No code, behavior, schema, or interface changes — repo metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)