### PR TITLE
fix(husky): quote prettier invocation so pre-commit works from paths with spaces

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -23,10 +23,14 @@ cd "$ROOT"
 STAGED="$(git diff --cached --name-only --diff-filter=ACMR)"
 if [ -n "$STAGED" ]; then
   PRETTIER="$ROOT/node_modules/.bin/prettier"
-  [ -x "$PRETTIER" ] || PRETTIER="npx --no-install prettier"
+  if [ -x "$PRETTIER" ]; then
+    set -- "$PRETTIER"
+  else
+    set -- npx --no-install prettier
+  fi
 
   echo "🎨 Formatting staged files with Prettier..."
-  git diff --cached --name-only --diff-filter=ACMR -z | xargs -0 $PRETTIER --write --ignore-unknown
+  git diff --cached --name-only --diff-filter=ACMR -z | xargs -0 "$@" --write --ignore-unknown
   git diff --cached --name-only --diff-filter=ACMR -z | xargs -0 git add
 else
   echo "🎨 No staged files to format."


### PR DESCRIPTION
### Problem
The `pre-commit` hook resolves `PRETTIER="$ROOT/node_modules/.bin/prettier"` and then uses it **unquoted** in `xargs -0 $PRETTIER --write`. When the repository lives in a directory whose path contains spaces (e.g. `~/Desktop/My Projects/...`), `$ROOT` word-splits and `xargs` fails with `No such file or directory` — which blocks **every** commit in that clone.

### Fix
Put the resolved command into positional parameters and invoke via `"$@"`:

```sh
if [ -x "$PRETTIER" ]; then
  set -- "$PRETTIER"
else
  set -- npx --no-install prettier
fi
...
git diff --cached ... -z | xargs -0 "$@" --write --ignore-unknown
```

Behavior is identical for space-free paths; it only stops the path from being word-split. One file changed (`.husky/pre-commit`).
