### PR TITLE
fix(cc-discovery): follow symlinked skill directories in Config Explorer

### DIFF
--- a/server/__tests__/cc-discovery-helpers.test.js
+++ b/server/__tests__/cc-discovery-helpers.test.js
@@ -11,11 +11,14 @@
 
 const { describe, it } = require("node:test");
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
 const path = require("node:path");
 const {
   parseFrontmatter,
   redactSettings,
   isUnder,
+  readSkills,
   MAX_FILE_BYTES,
   HOOK_EVENT_TYPES,
 } = require("../lib/cc-discovery");
@@ -210,6 +213,42 @@ describe("isUnder", () => {
     const outside = path.resolve("/tmp/elsewhere/file");
     assert.equal(isUnder(root, inside), true);
     assert.equal(isUnder(root, outside), false);
+  });
+});
+
+describe("readSkills (symlinked skill directories)", () => {
+  it("includes a skill directory that is a symlink to a real directory", () => {
+    // Dirent.isDirectory() returns false for a symlink even when it points
+    // to a directory (Node fs quirk) — readSkillsAt must still follow it.
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "cc-discovery-symlink-"));
+    const realDir = path.join(tmp, "real-skills", "second-brain");
+    fs.mkdirSync(realDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(realDir, "SKILL.md"),
+      "---\nname: second-brain\n---\n\nBody text.\n"
+    );
+    const projectRoot = path.join(tmp, "project");
+    const skillsDir = path.join(projectRoot, ".claude", "skills");
+    fs.mkdirSync(skillsDir, { recursive: true });
+    fs.symlinkSync(realDir, path.join(skillsDir, "second-brain"), "dir");
+
+    const items = readSkills({ scope: "project", cwd: projectRoot });
+    const names = items.map((s) => s.name);
+    assert.ok(names.includes("second-brain"), `expected symlinked skill in ${names}`);
+  });
+
+  it("skips a broken symlink without throwing", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "cc-discovery-broken-symlink-"));
+    const projectRoot = path.join(tmp, "project");
+    const skillsDir = path.join(projectRoot, ".claude", "skills");
+    fs.mkdirSync(skillsDir, { recursive: true });
+    fs.symlinkSync(path.join(tmp, "does-not-exist"), path.join(skillsDir, "broken"), "dir");
+
+    let items;
+    assert.doesNotThrow(() => {
+      items = readSkills({ scope: "project", cwd: projectRoot });
+    });
+    assert.ok(!items.map((s) => s.name).includes("broken"));
   });
 });
 

--- a/server/lib/cc-discovery.js
+++ b/server/lib/cc-discovery.js
@@ -140,6 +140,23 @@ function listDir(absPath) {
   }
 }
 
+/**
+ * True if `ent` is a directory, OR a symlink that resolves to one.
+ * Dirent.isDirectory() returns false for symlinks even when they point at a
+ * directory (e.g. a skill installed via `ln -s` so it can live in a git
+ * repo) — this follows the link with statSync so those aren't skipped.
+ * Broken symlinks are treated as non-directories rather than throwing.
+ */
+function isDirLike(ent, absPath) {
+  if (ent.isDirectory()) return true;
+  if (!ent.isSymbolicLink()) return false;
+  try {
+    return fs.statSync(absPath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
 // ── Skills ──────────────────────────────────────────────────────────────
 
 function readSkillsAt(scope, claudeDir) {
@@ -147,8 +164,8 @@ function readSkillsAt(scope, claudeDir) {
   const entries = listDir(dir);
   const skills = [];
   for (const ent of entries) {
-    if (!ent.isDirectory()) continue;
     const skillDir = path.join(dir, ent.name);
+    if (!isDirLike(ent, skillDir)) continue;
     const skillFile = path.join(skillDir, "SKILL.md");
     const read = safeReadText(skillFile);
     if (!read) continue;
@@ -237,7 +254,7 @@ function countMdIn(dir) {
 function countSkillDirsIn(dir) {
   try {
     return fs.readdirSync(dir, { withFileTypes: true }).filter((e) => {
-      if (!e.isDirectory()) return false;
+      if (!isDirLike(e, path.join(dir, e.name))) return false;
       try {
         return fs.statSync(path.join(dir, e.name, "SKILL.md")).isFile();
       } catch {


### PR DESCRIPTION
### Problem
`readSkillsAt()` and `countSkillDirsIn()` in `server/lib/cc-discovery.js` filter directory entries with `Dirent.isDirectory()`. Node returns `false` from `Dirent.isDirectory()` for a **symlink**, even when it points at a directory. So a skill installed via `ln -s` — a common pattern so a skill can live in a version-controlled repo and be symlinked into `~/.claude/skills/` — is silently omitted from the Claude Config Explorer, even though Claude Code itself resolves and uses it.

### Fix
Add a small helper that follows symlinks via `statSync` (broken symlinks are treated as non-directories rather than throwing), and use it at both call sites:

```js
function isDirLike(ent, absPath) {
  if (ent.isDirectory()) return true;
  if (!ent.isSymbolicLink()) return false;
  try { return fs.statSync(absPath).isDirectory(); }
  catch { return false; }
}
```

Includes tests for the symlinked-skill and broken-symlink cases. Two files changed (`server/lib/cc-discovery.js`, `server/__tests__/cc-discovery-helpers.test.js`).
