### PR TITLE
feat(cli): scope ccam cost to a session and surface tool surcharges

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -633,8 +633,9 @@ ccam events   [--session id] [--limit n]
 ccam analytics                    # token 总量、常用工具、agent 类型
 ccam workflows [--session id]     # 工作流智能统计与模式
 ccam runs [--session id]          # 动态 Workflow 工具运行
-ccam cost                         # 按模型细分的总预估成本
-                                  # （对有用量但无定价规则的模型发出警告）
+ccam cost [--session <id>]        # 按模型细分的总预估成本
+                                  # （--session 限定为单个会话；显示服务器工具附加费用；
+                                  #  对有用量但无定价规则的模型发出警告）
 
 # 告警 & webhook
 ccam alerts [--unacked]           # 触发告警流

--- a/README-KO.md
+++ b/README-KO.md
@@ -640,8 +640,9 @@ ccam events   [--session id] [--limit n]
 ccam analytics                    # 토큰 총계, 상위 도구, 에이전트 유형
 ccam workflows [--session id]     # 워크플로 인텔리전스 통계 및 패턴
 ccam runs [--session id]          # 동적 Workflow 도구 실행
-ccam cost                         # 모델별 내역이 포함된 총 예상 비용
-                                  # (사용량은 있지만 가격 책정 규칙이 없는 모델에 대해 경고)
+ccam cost [--session <id>]        # 모델별 내역이 포함된 총 예상 비용
+                                  # (--session 은 단일 세션으로 범위 지정; 서버 도구 추가 요금 표시;
+                                  #  사용량은 있지만 가격 책정 규칙이 없는 모델에 대해 경고)
 
 # 알림 및 웹훅
 ccam alerts [--unacked]           # 발생한 알림 피드

--- a/README-VN.md
+++ b/README-VN.md
@@ -631,8 +631,9 @@ ccam events   [--session id] [--limit n]
 ccam analytics                    # tổng token, công cụ hàng đầu, loại agent
 ccam workflows [--session id]     # thống kê workflow-intelligence và các mẫu
 ccam runs [--session id]          # các lần chạy Workflow động
-ccam cost                         # tổng chi phí ước tính theo model
-                                  # (cảnh báo model có mức dùng nhưng chưa có quy tắc định giá)
+ccam cost [--session <id>]        # tổng chi phí ước tính theo model
+                                  # (--session giới hạn ở một phiên; hiển thị phụ phí công cụ máy chủ;
+                                  #  cảnh báo model có mức dùng nhưng chưa có quy tắc định giá)
 
 # Cảnh báo & webhook
 ccam alerts [--unacked]           # luồng cảnh báo đã kích hoạt

--- a/README.md
+++ b/README.md
@@ -640,8 +640,9 @@ ccam events   [--session id] [--limit n]
 ccam analytics                    # token totals, top tools, agent types
 ccam workflows [--session id]     # workflow intelligence stats and patterns
 ccam runs [--session id]          # dynamic Workflow-tool runs
-ccam cost                         # total estimated cost with per-model breakdown
-                                  # (warns about models with usage but no pricing rule)
+ccam cost [--session <id>]        # total estimated cost with per-model breakdown
+                                  # (--session scopes to one; shows tool surcharges;
+                                  #  warns about models with usage but no pricing rule)
 
 # Alerts & webhooks
 ccam alerts [--unacked]           # fired-alert feed

--- a/bin/ccam.js
+++ b/bin/ccam.js
@@ -884,8 +884,15 @@ async function cmdRuns(flags) {
   table(["Run", "Status", "Name", "Agents", "Tokens", "Tools", "Duration"], rows);
 }
 
-async function cmdCost() {
-  const cost = await get("/api/pricing/cost");
+async function cmdCost(flags) {
+  // Mirror the two cost endpoints: the whole-database aggregate, or one
+  // session's cost when --session is given (same response shape, so the
+  // rendering below is shared).
+  const sessionId = flags.session;
+  const cost = sessionId
+    ? await get(`/api/pricing/cost/${encodeURIComponent(sessionId)}`)
+    : await get("/api/pricing/cost");
+  if (sessionId) heading("Session cost", sessionId);
   console.log(`${c.bold("Total estimated cost:")} ${c.cyan(c.bold(fmtCost(cost.total_cost)))}`);
   const breakdown = (cost.breakdown || []).slice(0, 15);
   if (breakdown.length) {
@@ -897,6 +904,20 @@ async function cmdCost() {
         `  ${fmtModel(b.model).padEnd(w)}  ${bar(b.cost, max, 20, c.green)} ${c.bold(fmtCost(b.cost))}`
       );
     }
+  }
+  // Server-tool surcharges billed on top of tokens (web search $/1k, code
+  // execution container-time beyond the org free allowance). The API always
+  // returns feature_costs; show the line only when something is actually
+  // billed so a plain token-only total stays uncluttered.
+  const fc = cost.feature_costs || {};
+  const featureLines = [];
+  if ((fc.web_search_cost || 0) > 0)
+    featureLines.push(`web search ${c.bold(fmtCost(fc.web_search_cost))}`);
+  if ((fc.code_execution_cost || 0) > 0)
+    featureLines.push(`code execution ${c.bold(fmtCost(fc.code_execution_cost))}`);
+  if (featureLines.length) {
+    console.log();
+    console.log(`${c.dim("Server-tool surcharges:")} ${featureLines.join(c.dim(" · "))}`);
   }
   // The API prices unmatched models at $0 and reports them in unpriced_models
   // so the total stays honest — surface that here instead of silently showing
@@ -1327,7 +1348,7 @@ const COMMAND_GROUPS = [
       ["analytics", "", "Token totals, top-tool and agent-type charts"],
       ["workflows", "[--session id]", "Workflow intelligence stats and patterns"],
       ["runs", "[--session id]", "Dynamic Workflow-tool runs"],
-      ["cost", "", "Total estimated cost (per-model chart)"],
+      ["cost", "[--session id]", "Total estimated cost (per-model chart; --session scopes to one)"],
     ],
   ],
   [
@@ -2100,7 +2121,7 @@ async function runCommand(argv) {
     case "runs":
       return cmdRuns(flags);
     case "cost":
-      return cmdCost();
+      return cmdCost(flags);
     case "alerts":
       return cmdAlerts(flags, positional);
     case "rules":

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -171,7 +171,7 @@ When the server is down, **read-only commands automatically fall back to reading
 | `ccam analytics` | Token totals (input / output / cache read / cache write), top tools by call count, agent-type distribution, average events per session |
 | `ccam workflows [--session id]` | Workflow-intelligence stats (sessions analyzed, subagents, success rate, depth, compactions) and the top detected patterns; `--session` drills into one session |
 | `ccam runs [--session id]` | Dynamic Workflow-tool runs: status, agent count, tokens, tool calls, duration |
-| `ccam cost` | Total estimated cost with a per-model bar-chart breakdown. Models with usage but **no matching pricing rule** (priced at $0 and excluded from the total) are listed in a warning with their token volume and the `ccam pricing set` invocation that fixes it |
+| `ccam cost [--session <id>]` | Total estimated cost with a per-model bar-chart breakdown; `--session` scopes it to one session (mirrors `/api/pricing/cost/:sessionId`). Any billed **server-tool surcharges** (web search $/1k, code-execution container-time) are shown on a surcharges line. Models with usage but **no matching pricing rule** (priced at $0 and excluded from the total) are listed in a warning with their token volume and the `ccam pricing set` invocation that fixes it |
 
 ### Alerts & Webhooks
 

--- a/server/__tests__/ccam-cli.test.js
+++ b/server/__tests__/ccam-cli.test.js
@@ -203,6 +203,32 @@ describe("ccam CLI — insights", () => {
     assert.match(out, /Total estimated cost: \$/);
   });
 
+  it("cost --session scopes the total to one session", async () => {
+    const { code, out } = await ccam("cost", "--session", "cli-test-session-0001");
+    assert.equal(code, 0);
+    assert.match(out, /Session cost/);
+    assert.match(out, /cli-test-session-0001/);
+    assert.match(out, /Total estimated cost: \$/);
+  });
+
+  it("cost surfaces server-tool surcharges when web search was billed", async () => {
+    // Feature surcharges accrue independent of per-model pricing rules, so a
+    // web_search_requests count alone drives the line ($10 / 1k searches).
+    db.prepare(
+      "INSERT INTO token_usage (session_id, model, web_search_requests) VALUES (?, ?, ?)"
+    ).run("cli-test-session-0001", "claude-sonnet-5", 200);
+    try {
+      const { code, out } = await ccam("cost", "--session", "cli-test-session-0001");
+      assert.equal(code, 0);
+      assert.match(out, /Server-tool surcharges/);
+      assert.match(out, /web search \$/);
+    } finally {
+      db.prepare(
+        "DELETE FROM token_usage WHERE session_id = 'cli-test-session-0001' AND model = 'claude-sonnet-5'"
+      ).run();
+    }
+  });
+
   it("cost warns about models with usage but no pricing rule", async () => {
     // Usage on a model no default pattern matches: the API prices it at $0
     // and reports it via unpriced_models; the CLI must surface that.

--- a/wiki/i18n-content.js
+++ b/wiki/i18n-content.js
@@ -24,8 +24,8 @@ window.__WIKI_CONTENT_I18N = {
     "Filterable tables plus a per-session deep dive with an indented agent tree, per-session cost, and the most recent events":
       "可筛选的表格，外加按会话的深入视图：缩进的 agent 树、单会话成本以及最近的事件",
     Insights: "洞察",
-    "Token totals and top tools, workflow-intelligence stats with detected patterns, dynamic Workflow-tool runs, and the per-model cost breakdown, which warns about models with usage but no matching pricing rule (priced at $0, excluded from the total) and points to <code>ccam pricing set</code>":
-      "Token 总量与最常用工具、带已检测模式的工作流智能统计、动态 Workflow 工具运行，以及按模型的成本细分——当某个模型有用量却没有匹配的定价规则时会发出警告（按 $0 计价并从总额中排除），并提示用 <code>ccam pricing set</code> 修复",
+    "Token totals and top tools, workflow-intelligence stats with detected patterns, dynamic Workflow-tool runs, and the per-model cost breakdown, which can be scoped to a single session with <code>--session</code>, surfaces server-tool surcharges (web search / code execution), warns about models with usage but no matching pricing rule (priced at $0, excluded from the total), and points to <code>ccam pricing set</code>":
+      "Token 总量与最常用工具、带已检测模式的工作流智能统计、动态 Workflow 工具运行，以及按模型的成本细分——可用 <code>--session</code> 限定到单个会话，会显示服务器工具附加费用（网页搜索 / 代码执行），当某个模型有用量却没有匹配的定价规则时会发出警告（按 $0 计价并从总额中排除），并提示用 <code>ccam pricing set</code> 修复",
     "Alerts &amp; Webhooks": "告警 &amp; Webhook",
     "The fired-alert feed with acknowledge / acknowledge-all, the rule list, and synthetic test deliveries against any webhook target":
       "触发告警流（支持单条/全部确认）、规则列表，以及对任意 webhook 目标的合成测试投递",
@@ -1265,8 +1265,8 @@ window.__WIKI_CONTENT_I18N = {
     "Filterable tables plus a per-session deep dive with an indented agent tree, per-session cost, and the most recent events":
       "Các bảng có bộ lọc, cộng thêm góc nhìn sâu theo phiên: cây agent thụt lề, chi phí từng phiên và các sự kiện gần nhất",
     Insights: "Phân tích",
-    "Token totals and top tools, workflow-intelligence stats with detected patterns, dynamic Workflow-tool runs, and the per-model cost breakdown, which warns about models with usage but no matching pricing rule (priced at $0, excluded from the total) and points to <code>ccam pricing set</code>":
-      "Tổng token và các công cụ dùng nhiều nhất, thống kê workflow-intelligence với các mẫu được phát hiện, các lần chạy Workflow động, và phân tích chi phí theo model — cảnh báo khi một model có mức sử dụng nhưng không có quy tắc định giá khớp (tính giá $0, bị loại khỏi tổng) và chỉ tới <code>ccam pricing set</code>",
+    "Token totals and top tools, workflow-intelligence stats with detected patterns, dynamic Workflow-tool runs, and the per-model cost breakdown, which can be scoped to a single session with <code>--session</code>, surfaces server-tool surcharges (web search / code execution), warns about models with usage but no matching pricing rule (priced at $0, excluded from the total), and points to <code>ccam pricing set</code>":
+      "Tổng token và các công cụ dùng nhiều nhất, thống kê workflow-intelligence với các mẫu được phát hiện, các lần chạy Workflow động, và phân tích chi phí theo model — có thể giới hạn vào một phiên duy nhất bằng <code>--session</code>, hiển thị phụ phí công cụ máy chủ (tìm kiếm web / thực thi mã), cảnh báo khi một model có mức sử dụng nhưng không có quy tắc định giá khớp (tính giá $0, bị loại khỏi tổng) và chỉ tới <code>ccam pricing set</code>",
     "Alerts &amp; Webhooks": "Cảnh báo &amp; Webhook",
     "The fired-alert feed with acknowledge / acknowledge-all, the rule list, and synthetic test deliveries against any webhook target":
       "Luồng cảnh báo đã kích hoạt (xác nhận từng cái / tất cả), danh sách quy tắc, và gửi thử tổng hợp tới bất kỳ đích webhook nào",
@@ -2534,8 +2534,8 @@ window.__WIKI_CONTENT_I18N = {
     "Filterable tables plus a per-session deep dive with an indented agent tree, per-session cost, and the most recent events":
       "필터링 가능한 테이블과 세션별 심층 보기: 들여쓰기된 에이전트 트리, 세션별 비용, 최근 이벤트",
     Insights: "인사이트",
-    "Token totals and top tools, workflow-intelligence stats with detected patterns, dynamic Workflow-tool runs, and the per-model cost breakdown, which warns about models with usage but no matching pricing rule (priced at $0, excluded from the total) and points to <code>ccam pricing set</code>":
-      "토큰 총량과 상위 도구, 감지된 패턴이 포함된 워크플로 인텔리전스 통계, 동적 Workflow 도구 실행, 모델별 비용 분석 — 사용량은 있지만 일치하는 가격 규칙이 없는 모델($0으로 계산되어 총액에서 제외)을 경고하고 <code>ccam pricing set</code>을 안내합니다",
+    "Token totals and top tools, workflow-intelligence stats with detected patterns, dynamic Workflow-tool runs, and the per-model cost breakdown, which can be scoped to a single session with <code>--session</code>, surfaces server-tool surcharges (web search / code execution), warns about models with usage but no matching pricing rule (priced at $0, excluded from the total), and points to <code>ccam pricing set</code>":
+      "토큰 총량과 상위 도구, 감지된 패턴이 포함된 워크플로 인텔리전스 통계, 동적 Workflow 도구 실행, 모델별 비용 분석 — <code>--session</code>으로 단일 세션에 한정할 수 있고, 서버 도구 추가 요금(웹 검색 / 코드 실행)을 표시하며, 사용량은 있지만 일치하는 가격 규칙이 없는 모델($0으로 계산되어 총액에서 제외)을 경고하고 <code>ccam pricing set</code>을 안내합니다",
     "Alerts &amp; Webhooks": "알림 &amp; Webhook",
     "The fired-alert feed with acknowledge / acknowledge-all, the rule list, and synthetic test deliveries against any webhook target":
       "발생 알림 피드(개별/전체 확인), 규칙 목록, 그리고 임의의 webhook 대상에 대한 합성 테스트 전송",

--- a/wiki/index.html
+++ b/wiki/index.html
@@ -2253,8 +2253,10 @@ npm run mcp:start:repl         # interactive CLI with tab completion</code></pre
                   <td>
                     Token totals and top tools, workflow-intelligence stats with detected
                     patterns, dynamic Workflow-tool runs, and the per-model cost breakdown,
-                    which warns about models with usage but no matching pricing rule (priced
-                    at $0, excluded from the total) and points to <code>ccam pricing set</code>
+                    which can be scoped to a single session with <code>--session</code>,
+                    surfaces server-tool surcharges (web search / code execution), warns about
+                    models with usage but no matching pricing rule (priced at $0, excluded from
+                    the total), and points to <code>ccam pricing set</code>
                   </td>
                 </tr>
                 <tr>
@@ -6265,7 +6267,7 @@ npm run install-hooks</code></pre>
     <!-- Body-content translations (zh/vi) — must load before script.js so the
          i18n engine sees window.__WIKI_CONTENT_I18N. Both are deferred, so they
          run in document order. -->
-    <script src="i18n-content.js?v=32" defer></script>
+    <script src="i18n-content.js?v=33" defer></script>
     <script src="script.js?v=31" defer></script>
     <script>
       (function () {

--- a/wiki/sw.js
+++ b/wiki/sw.js
@@ -3,7 +3,7 @@
  * @author Son Nguyen <hoangson091104@gmail.com>
  */
 
-const CACHE_NAME = "wiki-v41";
+const CACHE_NAME = "wiki-v42";
 const PRECACHE = [
   "./",
   "./index.html",


### PR DESCRIPTION
## Summary

A single, self-contained enhancement to the `ccam cost` command. It was calling only the whole-database aggregate endpoint and rendering the token total + per-model chart, leaving two things the API already returns invisible from the terminal:

- **Per-session cost** — `ccam cost --session <id>` now hits `GET /api/pricing/cost/:sessionId` (the same route the dashboard uses, previously unreachable from the CLI). Same response shape, so the per-model breakdown and unpriced-model warning render exactly as they do for the aggregate. Faster than the full `ccam session <id>` view when cost is all you want, and scriptable.
- **Server-tool surcharges** — `feature_costs` carries the web-search ($10/1k) and code-execution (container-time beyond the org free allowance) charges billed on top of tokens. `ccam cost` now prints a **Server-tool surcharges** line whenever either is non-zero, so the total's composition is explainable instead of reading as pure token cost. The line is omitted when nothing is surcharged, keeping the common case clean.

## Testing

- `npm run test:server` / `npm run test:client` — full suite green via the pre-commit hook (new CLI tests: `cost --session` scoping, web-search surcharge line)
- `bash .claude/skills/file-headers/scripts/check-headers.sh` — exit 0

## Docs

Synced across the surface: `docs/CLI.md`, README + VN/CN/KO CLI blocks, and the wiki Insights row with zh/vi/ko i18n entries and the required cache bump (`wiki-v42` / `i18n-content.js?v=33`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)