### PR TITLE
fix(client): show the real project version in the sidebar, not a hardcoded v1.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,10 @@ WORKDIR /app/client
 COPY client/package.json client/package-lock.json ./
 RUN npm ci
 COPY client/ ./
+# vite.config.ts stamps the UI version from the repo-root package.json (one level
+# up from the client dir). Provide it here so the built client shows the real
+# release version; the config falls back gracefully if it is ever absent.
+COPY package.json /app/package.json
 RUN npm run build
 
 # ── Stage 3: Production runtime ───────────────────────────────────────

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -519,7 +519,9 @@ export function Sidebar({ wsConnected, collapsed, onToggle }: SidebarProps) {
                 </span>
               )}
             </span>
-            {!collapsed && <span className="text-[11px] font-medium text-gray-600">v1.0.0</span>}
+            {!collapsed && (
+              <span className="text-[11px] font-medium text-gray-600">{`v${__APP_VERSION__}`}</span>
+            )}
           </div>
         </button>
         {collapsed ? (

--- a/client/src/components/__tests__/Sidebar.test.tsx
+++ b/client/src/components/__tests__/Sidebar.test.tsx
@@ -48,8 +48,11 @@ describe("Sidebar", () => {
   });
 
   it("should show version number", () => {
+    // `__APP_VERSION__` is injected by Vite from the repo-root package.json
+    // (see vite.config.ts) and replaced at transform time in tests too, so this
+    // stays correct as the project version changes.
     renderSidebar(true);
-    expect(screen.getByText("v1.0.0")).toBeInTheDocument();
+    expect(screen.getByText(`v${__APP_VERSION__}`)).toBeInTheDocument();
   });
 
   it("should have correct navigation hrefs", () => {

--- a/client/src/vite-env.d.ts
+++ b/client/src/vite-env.d.ts
@@ -1,0 +1,10 @@
+/**
+ * @file vite-env.d.ts
+ * @description Ambient type declarations for the client build — Vite client types plus the build-time-injected `__APP_VERSION__` global (the repo-root project version; see vite.config.ts).
+ * @author Son Nguyen <hoangson091104@gmail.com>
+ */
+
+/// <reference types="vite/client" />
+
+/** Repo-root project version, injected by Vite `define` at build time. */
+declare const __APP_VERSION__: string;

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,11 +1,22 @@
 /**
  * @file vite.config.ts
- * @description Vite build and dev-server configuration for the dashboard client — React plugin plus an API/WebSocket proxy that honours DASHBOARD_PORT.
+ * @description Vite build and dev-server configuration for the dashboard client — React plugin, an API/WebSocket proxy that honours DASHBOARD_PORT, and build-time injection of the project version as `__APP_VERSION__`.
  * @author Son Nguyen <hoangson091104@gmail.com>
  */
 
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+
+// The dashboard's displayed version is the canonical project version from the
+// repo-root package.json (the version CI cuts releases from), injected at build
+// time as the `__APP_VERSION__` global so the UI footer always shows the real
+// version instead of a hardcoded string. Vite always runs from the client dir
+// (npm scripts `cd client` first), so the root manifest is one level up. The
+// global is declared in `client/src/vite-env.d.ts`.
+const APP_VERSION = JSON.parse(readFileSync(resolve(process.cwd(), "..", "package.json"), "utf8"))
+  .version as string;
 
 // Honour DASHBOARD_PORT so the proxy follows when `npm run dev:server` is
 // moved off the default 4820 (e.g. when an SSH `LocalForward` already holds
@@ -22,6 +33,9 @@ const DASHBOARD_PORT = parseInt(process.env.DASHBOARD_PORT || "4820", 10);
 
 export default defineConfig({
   plugins: [react()],
+  define: {
+    __APP_VERSION__: JSON.stringify(APP_VERSION),
+  },
   server: {
     port: 5173,
     proxy: {

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -12,11 +12,23 @@ import react from "@vitejs/plugin-react";
 // The dashboard's displayed version is the canonical project version from the
 // repo-root package.json (the version CI cuts releases from), injected at build
 // time as the `__APP_VERSION__` global so the UI footer always shows the real
-// version instead of a hardcoded string. Vite always runs from the client dir
-// (npm scripts `cd client` first), so the root manifest is one level up. The
-// global is declared in `client/src/vite-env.d.ts`.
-const APP_VERSION = JSON.parse(readFileSync(resolve(process.cwd(), "..", "package.json"), "utf8"))
-  .version as string;
+// version instead of a hardcoded string. Vite runs from the client dir, so the
+// root manifest is normally one level up; fall back to the client manifest, and
+// finally a placeholder, so the build never fails when the root file is absent
+// (e.g. a Docker stage that only copies client/). The global is declared in
+// `client/src/vite-env.d.ts`.
+function resolveAppVersion(): string {
+  for (const rel of ["../package.json", "package.json"]) {
+    try {
+      const { version } = JSON.parse(readFileSync(resolve(process.cwd(), rel), "utf8"));
+      if (version) return version as string;
+    } catch {
+      // Not found or unreadable at this path — try the next candidate.
+    }
+  }
+  return "0.0.0";
+}
+const APP_VERSION = resolveAppVersion();
 
 // Honour DASHBOARD_PORT so the proxy follows when `npm run dev:server` is
 // moved off the default 4820 (e.g. when an SSH `LocalForward` already holds

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -1,14 +1,24 @@
 /**
  * @file vitest.config.ts
- * @description Vitest configuration for the client test suite — jsdom environment, React plugin, and test globals.
+ * @description Vitest configuration for the client test suite — jsdom environment, React plugin, test globals, and the same build-time `__APP_VERSION__` injection as vite.config.ts so version-dependent components render identically under test.
  * @author Son Nguyen <hoangson091104@gmail.com>
  */
 
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 
+// Mirror vite.config.ts: inject the repo-root project version as `__APP_VERSION__`
+// so components that render it (e.g. the sidebar footer) behave the same in tests.
+const APP_VERSION = JSON.parse(readFileSync(resolve(process.cwd(), "..", "package.json"), "utf8"))
+  .version as string;
+
 export default defineConfig({
   plugins: [react()],
+  define: {
+    __APP_VERSION__: JSON.stringify(APP_VERSION),
+  },
   test: {
     environment: "jsdom",
     setupFiles: ["./src/test-setup.ts"],

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -11,8 +11,19 @@ import react from "@vitejs/plugin-react";
 
 // Mirror vite.config.ts: inject the repo-root project version as `__APP_VERSION__`
 // so components that render it (e.g. the sidebar footer) behave the same in tests.
-const APP_VERSION = JSON.parse(readFileSync(resolve(process.cwd(), "..", "package.json"), "utf8"))
-  .version as string;
+// Fail-safe resolution (root -> client -> placeholder) matches vite.config.ts.
+function resolveAppVersion(): string {
+  for (const rel of ["../package.json", "package.json"]) {
+    try {
+      const { version } = JSON.parse(readFileSync(resolve(process.cwd(), rel), "utf8"));
+      if (version) return version as string;
+    } catch {
+      // Not found or unreadable at this path — try the next candidate.
+    }
+  }
+  return "0.0.0";
+}
+const APP_VERSION = resolveAppVersion();
 
 export default defineConfig({
   plugins: [react()],


### PR DESCRIPTION
## Summary

The dashboard sidebar footer hardcoded **`v1.0.0`** (`client/package.json` is `1.0.0` and was never bumped in lockstep with the project), so the UI reported `v1.0.0` on every build regardless of the actual release — the project is at **1.4.0**. Surfaced while testing the desktop app: a freshly-built 1.4.0 `.app` still showed `v1.0.0` in the footer.

## Fix

Inject the **canonical project version** (repo-root `package.json` — the version CI cuts releases from) at build time as a `__APP_VERSION__` global via Vite `define`, and render `` `v${__APP_VERSION__}` `` in the sidebar footer. No more hardcoded string to drift.

- `client/vite.config.ts` — read repo-root `package.json` version, add `define: { __APP_VERSION__ }`.
- `client/vitest.config.ts` — mirror the same `define` so components render the identical value under test.
- `client/src/vite-env.d.ts` *(new)* — ambient `declare const __APP_VERSION__: string` (+ `vite/client` types).
- `client/src/components/Sidebar.tsx` — render the injected version instead of the literal.
- `client/src/components/__tests__/Sidebar.test.tsx` — assert against `__APP_VERSION__`, so the test tracks the version automatically.

## Verification

- `npm run build` → built bundle contains **`v1.4.0`** and **zero** `v1.0.0`.
- `tsc --noEmit` clean (`__APP_VERSION__` resolves via the new declaration).
- All **261** client tests pass (screen snapshots unaffected — they don't capture the footer).
- `prettier --check` clean; file-header audit passes.

Behavior-only version-label fix — no API, schema, env var, or config surface changed; no doc references the old string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
