### PR TITLE
feat: health version, monitoring JSON verify, ccam health

### DIFF
--- a/bin/ccam.js
+++ b/bin/ccam.js
@@ -551,7 +551,8 @@ const offlineData = {
 
 async function cmdHealth() {
   const h = await get("/api/health");
-  console.log(`${c.green("●")} Dashboard ${c.bold("up")} at ${baseUrl()} (${h.timestamp})`);
+  const ver = h.version ? ` v${h.version}` : "";
+  console.log(`${c.green("●")} Dashboard ${c.bold("up")}${ver} at ${baseUrl()} (${h.timestamp})`);
 }
 
 function renderStats(s, source) {

--- a/monitoring/scripts/verify.js
+++ b/monitoring/scripts/verify.js
@@ -9,6 +9,21 @@ const { GRAFANA_ADMIN_USER, GRAFANA_ADMIN_PASSWORD } = require("./paths");
 const DASHBOARD_URL = process.env.CCAM_DASHBOARD_URL || "http://127.0.0.1:4820";
 const PROMETHEUS_URL = process.env.CCAM_PROMETHEUS_URL || "http://127.0.0.1:9090";
 const GRAFANA_URL = process.env.CCAM_GRAFANA_URL || "http://127.0.0.1:3000";
+const JSON_MODE = process.argv.includes("--json");
+
+async function checkDashboardHealth() {
+  try {
+    const res = await fetch(`${DASHBOARD_URL}/api/health`);
+    if (!res.ok) {
+      return { name: "Dashboard /api/health", ok: false, detail: `HTTP ${res.status}` };
+    }
+    const body = await res.json();
+    const detail = body.version ? `v${body.version}` : undefined;
+    return { name: "Dashboard /api/health", ok: true, detail, version: body.version };
+  } catch (err) {
+    return { name: "Dashboard /api/health", ok: false, detail: err.message };
+  }
+}
 
 async function check(name, url, ok = (res) => res.ok) {
   try {
@@ -127,7 +142,7 @@ async function checkPrometheusConsole() {
 
 async function main() {
   const checks = [
-    await check("Dashboard /api/health", `${DASHBOARD_URL}/api/health`),
+    await checkDashboardHealth(),
     await check(
       "Dashboard /api/metrics",
       `${DASHBOARD_URL}/api/metrics`,
@@ -144,11 +159,30 @@ async function main() {
   let failed = 0;
   for (const c of checks) {
     if (c.ok) {
-      console.log(`✔ ${c.name}${c.detail ? ` (${c.detail})` : ""}`);
+      if (!JSON_MODE) {
+        console.log(`✔ ${c.name}${c.detail ? ` (${c.detail})` : ""}`);
+      }
     } else {
       failed += 1;
-      console.error(`✖ ${c.name}: ${c.detail || "failed"}`);
+      if (!JSON_MODE) {
+        console.error(`✖ ${c.name}: ${c.detail || "failed"}`);
+      }
     }
+  }
+
+  if (JSON_MODE) {
+    const payload = {
+      ok: failed === 0,
+      checks,
+      urls: {
+        dashboard: DASHBOARD_URL,
+        prometheus: PROMETHEUS_URL,
+        grafana: GRAFANA_URL,
+        metrics: `${DASHBOARD_URL}/api/metrics`,
+      },
+    };
+    console.log(JSON.stringify(payload, null, 2));
+    process.exit(failed > 0 ? 1 : 0);
   }
 
   if (failed > 0) {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -353,11 +353,16 @@ components:
       required:
         - status
         - timestamp
+        - version
       properties:
         status:
           type: string
           enum:
             - ok
+        version:
+          type: string
+          description: Dashboard release version from package.json
+          example: 1.4.1
         timestamp:
           type: string
           format: date-time

--- a/server/__tests__/api.test.js
+++ b/server/__tests__/api.test.js
@@ -170,6 +170,7 @@ describe("GET /api/health", () => {
     const res = await fetch("/api/health");
     assert.equal(res.status, 200);
     assert.equal(res.body.status, "ok");
+    assert.equal(res.body.version, pkg.version);
     assert.ok(res.body.timestamp);
   });
 });

--- a/server/__tests__/ccam-cli.test.js
+++ b/server/__tests__/ccam-cli.test.js
@@ -113,6 +113,7 @@ describe("ccam CLI — monitoring", () => {
     assert.equal(code, 0);
     assert.match(out, /Dashboard/);
     assert.match(out, /up/);
+    assert.match(out, /v\d+\.\d+\.\d+/);
     assert.match(out, new RegExp(String(PORT)));
   });
 

--- a/server/index.js
+++ b/server/index.js
@@ -66,6 +66,14 @@ const webhooksRouter = require("./routes/webhooks");
 const remoteSourcesRouter = require("./routes/remote-sources");
 const metricsRouter = require("./routes/metrics");
 
+const APP_VERSION = (() => {
+  try {
+    return require("../package.json").version || "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+})();
+
 function createApp() {
   const app = express();
   const openApiSpec = createOpenApiSpec();
@@ -127,7 +135,7 @@ function createApp() {
   });
 
   app.get("/api/health", (_req, res) => {
-    res.json({ status: "ok", timestamp: new Date().toISOString() });
+    res.json({ status: "ok", version: APP_VERSION, timestamp: new Date().toISOString() });
   });
 
   return app;

--- a/server/openapi.js
+++ b/server/openapi.js
@@ -322,9 +322,14 @@ function createOpenApiSpec() {
         },
         HealthResponse: {
           type: "object",
-          required: ["status", "timestamp"],
+          required: ["status", "timestamp", "version"],
           properties: {
             status: { type: "string", enum: ["ok"] },
+            version: {
+              type: "string",
+              description: "Dashboard release version from package.json",
+              example: "1.4.1",
+            },
             timestamp: { type: "string", format: "date-time" },
           },
         },


### PR DESCRIPTION
## Summary
- Exposes `version` on `GET /api/health` for lightweight release checks.
- Documents the field in OpenAPI / `openapi.yaml`.
- Adds `--json` mode to `monitoring/scripts/verify.js` for CI-friendly stack verification.
- Prints the dashboard version in `ccam health`.

## Commits (5)
1. feat(server): expose app version in GET /api/health
2. test(server): assert /api/health returns package version
3. docs(openapi): document version on HealthResponse schema
4. feat(monitoring): add --json output to verify script
5. feat(ccam): print dashboard version in health command

## Test plan
- [x] `npm run test:server`
- [x] `npm run test:client`


Made with [Cursor](https://cursor.com)