### PR TITLE
release: v1.4.2 — settings version UI + full version bump

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -57,8 +57,6 @@
 ![Helm](https://img.shields.io/badge/Helm-3-0F1689?style=flat-square&logo=helm&logoColor=white)
 ![Kustomize](https://img.shields.io/badge/Kustomize-5.0-326CE5?style=flat-square&logo=kubernetes&logoColor=white)
 ![Nginx](https://img.shields.io/badge/Nginx-Ingress-009639?style=flat-square&logo=nginx&logoColor=white)
-![Prometheus](https://img.shields.io/badge/Prometheus-2.x-E6522C?style=flat-square&logo=prometheus&logoColor=white)
-![Grafana](https://img.shields.io/badge/Grafana-10.x-F46800?style=flat-square&logo=grafana&logoColor=white)
 ![Coralogix](https://img.shields.io/badge/Coralogix-Observability-1a1a2e?style=flat-square&logo=datadog&logoColor=white)
 ![OpenTelemetry](https://img.shields.io/badge/OpenTelemetry-Collector-4f46e5?style=flat-square&logo=opentelemetry&logoColor=white)
 ![AWS](https://img.shields.io/badge/AWS-ECS%20%7C%20RDS-232F3E?style=flat-square&logo=task&logoColor=white)

--- a/README-KO.md
+++ b/README-KO.md
@@ -57,8 +57,6 @@ Claude Code 에이전트 세션, 도구 사용, 서브에이전트 오케스트�
 ![Helm](https://img.shields.io/badge/Helm-3-0F1689?style=flat-square&logo=helm&logoColor=white)
 ![Kustomize](https://img.shields.io/badge/Kustomize-5.0-326CE5?style=flat-square&logo=kubernetes&logoColor=white)
 ![Nginx](https://img.shields.io/badge/Nginx-Ingress-009639?style=flat-square&logo=nginx&logoColor=white)
-![Prometheus](https://img.shields.io/badge/Prometheus-2.x-E6522C?style=flat-square&logo=prometheus&logoColor=white)
-![Grafana](https://img.shields.io/badge/Grafana-10.x-F46800?style=flat-square&logo=grafana&logoColor=white)
 ![Coralogix](https://img.shields.io/badge/Coralogix-Observability-1a1a2e?style=flat-square&logo=datadog&logoColor=white)
 ![OpenTelemetry](https://img.shields.io/badge/OpenTelemetry-Collector-4f46e5?style=flat-square&logo=opentelemetry&logoColor=white)
 ![AWS](https://img.shields.io/badge/AWS-ECS%20%7C%20RDS-232F3E?style=flat-square&logo=task&logoColor=white)

--- a/README-VN.md
+++ b/README-VN.md
@@ -57,8 +57,6 @@ Bảng điều khiển chuyên nghiệp để theo dõi và trực quan hóa cá
 ![Helm](https://img.shields.io/badge/Helm-3-0F1689?style=flat-square&logo=helm&logoColor=white)
 ![Kustomize](https://img.shields.io/badge/Kustomize-5.0-326CE5?style=flat-square&logo=kubernetes&logoColor=white)
 ![Nginx](https://img.shields.io/badge/Nginx-Ingress-009639?style=flat-square&logo=nginx&logoColor=white)
-![Prometheus](https://img.shields.io/badge/Prometheus-2.x-E6522C?style=flat-square&logo=prometheus&logoColor=white)
-![Grafana](https://img.shields.io/badge/Grafana-10.x-F46800?style=flat-square&logo=grafana&logoColor=white)
 ![Coralogix](https://img.shields.io/badge/Coralogix-Observability-1a1a2e?style=flat-square&logo=datadog&logoColor=white)
 ![OpenTelemetry](https://img.shields.io/badge/OpenTelemetry-Collector-4f46e5?style=flat-square&logo=opentelemetry&logoColor=white)
 ![AWS](https://img.shields.io/badge/AWS-ECS%20%7C%20RDS-232F3E?style=flat-square&logo=task&logoColor=white)

--- a/README.md
+++ b/README.md
@@ -57,8 +57,6 @@ A professional dashboard to track and visualize your Claude Code agent sessions,
 ![Helm](https://img.shields.io/badge/Helm-3-0F1689?style=flat-square&logo=helm&logoColor=white)
 ![Kustomize](https://img.shields.io/badge/Kustomize-5.0-326CE5?style=flat-square&logo=kubernetes&logoColor=white)
 ![Nginx](https://img.shields.io/badge/Nginx-Ingress-009639?style=flat-square&logo=nginx&logoColor=white)
-![Prometheus](https://img.shields.io/badge/Prometheus-2.x-E6522C?style=flat-square&logo=prometheus&logoColor=white)
-![Grafana](https://img.shields.io/badge/Grafana-10.x-F46800?style=flat-square&logo=grafana&logoColor=white)
 ![Coralogix](https://img.shields.io/badge/Coralogix-Observability-1a1a2e?style=flat-square&logo=datadog&logoColor=white)
 ![OpenTelemetry](https://img.shields.io/badge/OpenTelemetry-Collector-4f46e5?style=flat-square&logo=opentelemetry&logoColor=white)
 ![AWS](https://img.shields.io/badge/AWS-ECS%20%7C%20RDS-232F3E?style=flat-square&logo=task&logoColor=white)

--- a/client/src/i18n/locales/en/settings.json
+++ b/client/src/i18n/locales/en/settings.json
@@ -179,6 +179,8 @@
   "about": {
     "title": "About",
     "description": "Server runtime information.",
+    "release": "Release",
+    "uiBuild": "UI build v{{version}} (rebuild client to match)",
     "uptime": "Uptime",
     "nodejs": "Node.js",
     "platform": "Platform",

--- a/client/src/i18n/locales/ko/settings.json
+++ b/client/src/i18n/locales/ko/settings.json
@@ -179,6 +179,8 @@
   "about": {
     "title": "정보",
     "description": "서버 런타임 정보입니다.",
+    "release": "릴리스",
+    "uiBuild": "UI 빌드 v{{version}} (일치하려면 클라이언트를 다시 빌드하세요)",
     "uptime": "가동 시간",
     "nodejs": "Node.js",
     "platform": "플랫폼",

--- a/client/src/i18n/locales/vi/settings.json
+++ b/client/src/i18n/locales/vi/settings.json
@@ -179,6 +179,8 @@
   "about": {
     "title": "Giới thiệu",
     "description": "Thông tin runtime của máy chủ.",
+    "release": "Phiên bản",
+    "uiBuild": "UI build v{{version}} (hãy build lại client để khớp)",
     "uptime": "Thời gian chạy",
     "nodejs": "Node.js",
     "platform": "Nền tảng",

--- a/client/src/i18n/locales/zh/settings.json
+++ b/client/src/i18n/locales/zh/settings.json
@@ -179,6 +179,8 @@
   "about": {
     "title": "关于",
     "description": "服务器运行时信息。",
+    "release": "版本",
+    "uiBuild": "UI 构建 v{{version}}（请重新构建客户端以匹配）",
     "uptime": "运行时间",
     "nodejs": "Node.js",
     "platform": "平台",

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -883,9 +883,9 @@ export const api = {
      *     `load_stats` (5-/15-/60-minute rates).
      *   - `hooks`: whether the dashboard's Claude Code hooks are installed, the
      *     settings.json path, and a per-hook installed map.
-     *   - `server`: process uptime, Node version, platform/arch, live WebSocket
-     *     connection count, process memory, CPU load averages, and host memory/
-     *     cpu counts.
+     *   - `server`: dashboard release `version`, process uptime, Node version,
+     *     platform/arch, live WebSocket connection count, process memory, CPU
+     *     load averages, and host memory/cpu counts.
      *   - `transcript_cache`: LRU cache occupancy, capacity, hit/miss counts,
      *     and the currently-cached keys.
      *
@@ -909,6 +909,7 @@ export const api = {
         };
         hooks: { installed: boolean; path: string; hooks: Record<string, boolean> };
         server: {
+          version: string;
           uptime: number;
           node_version: string;
           platform: string;

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -224,7 +224,13 @@ const emptyRow: EditRow = {
 interface SystemInfo {
   db: { path: string; size: number; counts: Record<string, number> };
   hooks: { installed: boolean; path: string; hooks: Record<string, boolean> };
-  server: { uptime: number; node_version: string; platform: string; ws_connections: number };
+  server: {
+    version: string;
+    uptime: number;
+    node_version: string;
+    platform: string;
+    ws_connections: number;
+  };
 }
 
 function formatTimestamp(iso: string): string {
@@ -1780,7 +1786,23 @@ export function Settings() {
 
         {sysInfo ? (
           <div className="card p-5">
-            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+            <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
+              <div className="bg-surface-2 rounded-lg px-4 py-3">
+                <div className="flex items-center gap-2 mb-1.5">
+                  <Server className="w-4 h-4 text-indigo-400" />
+                  <p className="text-[11px] text-gray-500 uppercase tracking-wider">
+                    {t("about.release")}
+                  </p>
+                </div>
+                <p className="text-sm font-semibold text-gray-200 font-mono">
+                  v{sysInfo.server.version}
+                </p>
+                {sysInfo.server.version !== __APP_VERSION__ && (
+                  <p className="text-[10px] text-amber-400/90 mt-1">
+                    {t("about.uiBuild", { version: __APP_VERSION__ })}
+                  </p>
+                )}
+              </div>
               <div className="bg-surface-2 rounded-lg px-4 py-3">
                 <div className="flex items-center gap-2 mb-1.5">
                   <Clock className="w-4 h-4 text-blue-400" />

--- a/client/src/pages/__tests__/__snapshots__/screens.snapshot.test.tsx.snap
+++ b/client/src/pages/__tests__/__snapshots__/screens.snapshot.test.tsx.snap
@@ -10062,8 +10062,72 @@ exports[`screen snapshots > Settings 1`] = `
         class="card p-5"
       >
         <div
-          class="grid grid-cols-2 sm:grid-cols-4 gap-3"
+          class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3"
         >
+          <div
+            class="bg-surface-2 rounded-lg px-4 py-3"
+          >
+            <div
+              class="flex items-center gap-2 mb-1.5"
+            >
+              <svg
+                class="lucide lucide-server w-4 h-4 text-indigo-400"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  height="8"
+                  rx="2"
+                  ry="2"
+                  width="20"
+                  x="2"
+                  y="2"
+                />
+                <rect
+                  height="8"
+                  rx="2"
+                  ry="2"
+                  width="20"
+                  x="2"
+                  y="14"
+                />
+                <line
+                  x1="6"
+                  x2="6.01"
+                  y1="6"
+                  y2="6"
+                />
+                <line
+                  x1="6"
+                  x2="6.01"
+                  y1="18"
+                  y2="18"
+                />
+              </svg>
+              <p
+                class="text-[11px] text-gray-500 uppercase tracking-wider"
+              >
+                Release
+              </p>
+            </div>
+            <p
+              class="text-sm font-semibold text-gray-200 font-mono"
+            >
+              v
+            </p>
+            <p
+              class="text-[10px] text-amber-400/90 mt-1"
+            >
+              UI build v1.4.1 (rebuild client to match)
+            </p>
+          </div>
           <div
             class="bg-surface-2 rounded-lg px-4 py-3"
           >

--- a/client/src/pages/__tests__/__snapshots__/screens.snapshot.test.tsx.snap
+++ b/client/src/pages/__tests__/__snapshots__/screens.snapshot.test.tsx.snap
@@ -10125,7 +10125,7 @@ exports[`screen snapshots > Settings 1`] = `
             <p
               class="text-[10px] text-amber-400/90 mt-1"
             >
-              UI build v1.4.1 (rebuild client to match)
+              UI build v1.4.2 (rebuild client to match)
             </p>
           </div>
           <div

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-dashboard-desktop",
-  "version": "1.4.0",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-dashboard-desktop",
-      "version": "1.4.0",
+      "version": "1.4.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-dashboard-desktop",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "private": true,
   "description": "Native macOS and Windows desktop shell for Claude Code Agent Monitor.",
   "author": "Son Nguyen <hoangson091104@gmail.com>",

--- a/docs/API.md
+++ b/docs/API.md
@@ -68,6 +68,8 @@ Authentication is **off by default** (the loopback bind is the trust boundary). 
 
 These paths stay exempt even when a token is configured: `/api/health`, `/api/openapi.json`, `/api/docs`, and `/api/hooks` (local Claude Code hook ingestion). Requests that fail the check get `401` with error code `EUNAUTHORIZED`.
 
+`GET /api/settings/info` includes `server.version` (the running dashboard release). Pair with `ccam version` or the Settings About panel to confirm client and server builds match after deploy.
+
 ```mermaid
 sequenceDiagram
     participant Client

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1457,11 +1457,15 @@ components:
         server:
           type: object
           required:
+            - version
             - uptime
             - node_version
             - platform
             - ws_connections
           properties:
+            version:
+              type: string
+              description: Dashboard release version from package.json
             uptime:
               type: number
             node_version:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.0.3
 info:
   title: Agent Dashboard for Claude Code API
-  version: 1.4.1
+  version: 1.4.2
   description: HTTP API for real-time Claude Code session monitoring, agent lifecycle tracking, analytics, pricing, hooks ingestion, and workflow intelligence.
   contact:
     name: Son Nguyen

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-dashboard",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-dashboard",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-dashboard",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "bin": {
     "ccam": "bin/ccam.js"
   },

--- a/server/README.md
+++ b/server/README.md
@@ -452,7 +452,7 @@ The OpenAPI spec is generated from `server/openapi.js` (`createOpenApiSpec()`), 
 
 | Method  | Path                | Description                                      |
 | ------- | ------------------- | ------------------------------------------------ |
-| `GET`   | `/api/health`       | Server health check                              |
+| `GET`   | `/api/health`       | Server health check (`status`, `version`, `timestamp`) |
 | `GET`   | `/api/sessions`     | List sessions (`status`, `limit`, `offset`)     |
 | `GET`   | `/api/sessions/:id` | Session detail (includes `agents` + `events`)   |
 | `POST`  | `/api/sessions`     | Create session (idempotent by `id`)             |

--- a/server/__tests__/api.test.js
+++ b/server/__tests__/api.test.js
@@ -1856,6 +1856,12 @@ describe("Transcript cache integration", () => {
     assert.ok(Array.isArray(res.body.transcript_cache.keys), "should have keys array");
   });
 
+  it("should include server version in settings info", async () => {
+    const res = await fetch("/api/settings/info");
+    assert.strictEqual(res.status, 200);
+    assert.equal(res.body.server.version, pkg.version);
+  });
+
   it("should evict cache entry on SessionEnd", async () => {
     const tmpTranscript = path.join(os.tmpdir(), `test-evict-${Date.now()}.jsonl`);
     fs.writeFileSync(

--- a/server/openapi.js
+++ b/server/openapi.js
@@ -1135,8 +1135,12 @@ function createOpenApiSpec() {
             },
             server: {
               type: "object",
-              required: ["uptime", "node_version", "platform", "ws_connections"],
+              required: ["version", "uptime", "node_version", "platform", "ws_connections"],
               properties: {
+                version: {
+                  type: "string",
+                  description: "Dashboard release version from package.json",
+                },
                 uptime: { type: "number" },
                 node_version: { type: "string" },
                 platform: { type: "string" },

--- a/server/routes/settings.js
+++ b/server/routes/settings.js
@@ -13,6 +13,14 @@ const { transcriptCache } = require("./hooks");
 
 const router = Router();
 
+const APP_VERSION = (() => {
+  try {
+    return require("../../package.json").version || "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+})();
+
 const { getSettingsPath, getClaudeHome, setClaudeHome } = require("../lib/claude-home");
 const CLAUDE_SETTINGS_PATH = getSettingsPath();
 
@@ -108,6 +116,7 @@ router.get("/info", (req, res) => {
     },
     hooks: hookStatus,
     server: {
+      version: APP_VERSION,
       uptime: process.uptime(),
       node_version: process.version,
       platform: process.platform,

--- a/wiki/sw.js
+++ b/wiki/sw.js
@@ -3,7 +3,7 @@
  * @author Son Nguyen <hoangson091104@gmail.com>
  */
 
-const CACHE_NAME = "wiki-v48";
+const CACHE_NAME = "wiki-v49";
 const PRECACHE = [
   "./",
   "./index.html",


### PR DESCRIPTION
## Summary
- Expose `server.version` on `GET /api/settings/info` (OpenAPI + tests) so clients can detect mismatched builds.
- Settings About panel shows the bundled release version and warns when UI and API versions differ (i18n: en/zh/vi/ko).
- Bump project version to **1.4.2** across root + desktop `package.json`, both lockfiles, and OpenAPI.
- Sync observability/docs for the release (API.md, server README, wiki service-worker cache bump).

## Commits (4)
1. `feat(settings): expose dashboard version in settings info API`
2. `feat(client): show release version in Settings About panel`
3. `chore(release): bump version to 1.4.2`
4. `docs: sync v1.4.2 release notes and observability docs`

## Merge order
- Can land independently of #258 (health/CLI/monitoring enhancements).
- Merge **last** when cutting the v1.4.2 GitHub release (CI publishes when version on `master` has no existing release).

## Test plan
- [x] `npm run test:server` (settings info version assertion)
- [x] `npm run test:client` (Settings About snapshot)
- [ ] Settings → About shows **1.4.2** and no mismatch warning on a fresh deploy
- [ ] `curl -s http://127.0.0.1:3001/api/settings/info | jq .server.version` → `1.4.2`


Made with [Cursor](https://cursor.com)