### PR TITLE
feat: v1.4.6 polish — a11y, remotes MCP/CLI, UI UX, version bump

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -122,14 +122,6 @@ graph LR
     style D fill:#10b981,stroke:#34d399,color:#fff
 ```
 
-<a href="https://www.star-history.com/?repos=hoangsonww%2FClaude-Code-Agent-Monitor&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=hoangsonww/Claude-Code-Agent-Monitor&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=hoangsonww/Claude-Code-Agent-Monitor&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=hoangsonww/Claude-Code-Agent-Monitor&type=date&legend=top-left" />
- </picture>
-</a>
-
 ### 多语言支持（i18n）
 
 Dashboard 内置多语言界面，支持 `en`、`zh`、`vi`、`ko` 四种语言，适用于跨语言协作和团队共享。

--- a/README-KO.md
+++ b/README-KO.md
@@ -124,14 +124,6 @@ graph LR
 
 실시간 모니터링 대시보드 외에도, `mcp/`에 대시보드 자체를 조사하고 관리하기 위한 도구 카탈로그를 노출하는 로컬 MCP 서버 구현이 포함되어 있어 대시보드 작업을 Claude Code 워크플로에 직접 통합하기 쉽습니다. 또한 대시보드 상호작용, 분석, 워크플로 인텔리전스를 위한 Claude Code 플러그인, 스킬, 서브에이전트를 제공하는 에이전트 확장 레이어도 있습니다.
 
-<a href="https://www.star-history.com/?repos=hoangsonww%2FClaude-Code-Agent-Monitor&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=hoangsonww/Claude-Code-Agent-Monitor&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=hoangsonww/Claude-Code-Agent-Monitor&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=hoangsonww/Claude-Code-Agent-Monitor&type=date&legend=top-left" />
- </picture>
-</a>
-
 ### 국제화 (i18n)
 
 UI에는 영어(`en`), 중국어(`zh`), 베트남어(`vi`), 한국어(`ko`)를 위한 내장 로케일 전환 기능이 탑재되어 있습니다. 언어 리소스는 네임스페이스별로 로드되며, 새로고침 후에도 사용자 선호가 안정적으로 유지되도록 브라우저 스토리지를 통해 저장됩니다.

--- a/README-VN.md
+++ b/README-VN.md
@@ -124,14 +124,6 @@ graph LR
 
 Ngoài bảng thông tin giám sát thời gian thực, nó còn bao gồm triển khai máy chủ MCP cục bộ trong `mcp/` hiển thị danh mục các công cụ để xem xét nội tâm và quản lý bảng thông tin, giúp dễ dàng tích hợp trực tiếp các hoạt động của bảng thông tin vào quy trình làm việc của Claude Code của bạn. Ngoài ra còn có một lớp mở rộng tác nhân, cung cấp các plugin, kỹ năng và tác nhân phụ của Claude Code để tương tác trên trang tổng quan, phân tích và thông tin về quy trình làm việc.
 
-<a href="https://www.star-history.com/?repos=hoangsonww%2FClaude-Code-Agent-Monitor&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=hoangsonww/Claude-Code-Agent-Monitor&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=hoangsonww/Claude-Code-Agent-Monitor&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=hoangsonww/Claude-Code-Agent-Monitor&type=date&legend=top-left" />
- </picture>
-</a>
-
 ### Quốc tế hóa (i18n)
 
 Giao diện người dùng đi kèm với tính năng chuyển đổi ngôn ngữ tích hợp cho tiếng Anh (`en`), tiếng Trung (`zh`), tiếng Việt (`vi`) và tiếng Hàn (`ko`). Tài nguyên ngôn ngữ được tải theo không gian tên và được lưu giữ trong bộ nhớ của trình duyệt để mang lại ưu tiên người dùng ổn định trong các lần làm mới.

--- a/README.md
+++ b/README.md
@@ -124,14 +124,6 @@ graph LR
 
 In addition to the real-time monitoring dashboard, it also includes a local MCP server implementation in `mcp/` that exposes a catalog of tools for introspecting and managing the dashboard itself, making it easy to integrate dashboard operations directly into your Claude Code workflows. There is also an agent extension layer, which provides Claude Code plugins, skills, and subagents for dashboard interaction, analytics, and workflow intelligence.
 
-<a href="https://www.star-history.com/?repos=hoangsonww%2FClaude-Code-Agent-Monitor&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=hoangsonww/Claude-Code-Agent-Monitor&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=hoangsonww/Claude-Code-Agent-Monitor&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=hoangsonww/Claude-Code-Agent-Monitor&type=date&legend=top-left" />
- </picture>
-</a>
-
 ### Internationalization (i18n)
 
 The UI ships with built-in locale switching for English (`en`), Chinese (`zh`), Vietnamese (`vi`), and Korean (`ko`). Language resources are loaded by namespace and persisted through browser storage for stable user preference across refreshes.

--- a/bin/ccam.js
+++ b/bin/ccam.js
@@ -1238,18 +1238,20 @@ async function cmdImport(flags, positional) {
 // ── Administration ──────────────────────────────────────────────────────────
 
 async function cmdDoctor() {
+  let failed = false;
   await get("/api/health");
   heading("ccam doctor", baseUrl());
   console.log(`${c.green("✔")}  API reachable  ${baseUrl()}`);
   const info = await get("/api/settings/info");
   const hooks = info.hooks || {};
-  console.log(
-    `${hooks.installed ? c.green("✔") : c.red("✖")}  Claude Code hooks  ${
-      hooks.installed
-        ? `installed (${hooks.path || "~/.claude/settings.json"})`
-        : "NOT installed — run: npm run install-hooks"
-    }`
-  );
+  if (hooks.installed) {
+    console.log(
+      `${c.green("✔")}  Claude Code hooks  installed (${hooks.path || "~/.claude/settings.json"})`
+    );
+  } else {
+    failed = true;
+    console.log(`${c.red("✖")}  Claude Code hooks  NOT installed — run: npm run install-hooks`);
+  }
   const db = info.db || {};
   console.log(
     `${c.green("✔")}  Database  ${db.path || "?"} (${((db.size || 0) / 1048576).toFixed(1)} MB)`
@@ -1262,6 +1264,34 @@ async function cmdDoctor() {
     `${c.green("✔")}  Server uptime  ${Math.floor((srv.uptime || 0) / 60)} min (node ${srv.node_version || "?"})`
   );
   console.log(`${c.green("✔")}  WS connections  ${srv.ws_connections ?? 0}`);
+
+  try {
+    const { sources = [] } = await get("/api/remote-sources");
+    if (sources.length === 0) {
+      console.log(`${c.green("✔")}  Remote sources  none configured`);
+    } else {
+      const errored = sources.filter((s) => s.status === "error");
+      console.log(
+        `${errored.length ? c.yellow("!") : c.green("✔")}  Remote sources  ${sources.length} configured` +
+          (errored.length ? ` (${errored.length} in error)` : "")
+      );
+      for (const s of sources) {
+        const mark =
+          s.status === "error" ? c.red("✖") : s.status === "ok" ? c.green("·") : c.dim("·");
+        console.log(
+          `${mark}    ${s.label || s.id}  ${s.status}` +
+            (s.last_sync_at ? `  last sync ${s.last_sync_at}` : "") +
+            (s.last_error ? `  ${c.red(s.last_error)}` : "")
+        );
+      }
+      if (errored.length) failed = true;
+    }
+  } catch (err) {
+    failed = true;
+    console.log(`${c.red("✖")}  Remote sources  ${err.message || err}`);
+  }
+
+  if (failed) process.exit(1);
 }
 
 async function cmdInfo() {
@@ -1520,7 +1550,7 @@ const COMMAND_GROUPS = [
   [
     "Administration",
     [
-      ["doctor", "", "Connectivity, hooks, and database diagnosis"],
+      ["doctor", "", "Connectivity, hooks, database, and remote sources diagnosis"],
       ["info", "", "Raw system info JSON"],
       ["export", "[file.json]", "Export all data as JSON"],
       ["cleanup", "--hours N --days M", "Abandon stale / purge old sessions"],
@@ -1729,8 +1759,12 @@ const OFFLINE_HANDLERS = {
   },
   async doctor() {
     heading("ccam doctor", "offline");
+    let failed = true; // offline is always a failure for live monitoring
     console.log(
       `${c.red("○")}  Dashboard server  NOT running ${c.dim(`(tried ${baseUrl()})`)} — start with: ${c.bold("ccam start")}`
+    );
+    console.log(
+      `${c.dim("·")}  Remote sources  require a live server (ccam remote-sources / Settings)`
     );
     const file = dbPath();
     if (fs.existsSync(file)) {
@@ -1748,6 +1782,7 @@ const OFFLINE_HANDLERS = {
         }
       }
     } else {
+      failed = true;
       console.log(`${c.red("✖")}  Database  not found at ${file}`);
     }
     try {
@@ -1758,12 +1793,16 @@ const OFFLINE_HANDLERS = {
       const installed =
         fs.existsSync(settingsPath) &&
         fs.readFileSync(settingsPath, "utf8").includes("hook-handler.js");
-      console.log(
-        `${installed ? c.green("✔") : c.red("✖")}  Claude Code hooks  ${installed ? `installed (${settingsPath})` : "NOT installed — run: npm run install-hooks"}`
-      );
+      if (installed) {
+        console.log(`${c.green("✔")}  Claude Code hooks  installed (${settingsPath})`);
+      } else {
+        failed = true;
+        console.log(`${c.red("✖")}  Claude Code hooks  NOT installed — run: npm run install-hooks`);
+      }
     } catch {
       console.log(`${c.dim("·")}  Claude Code hooks  could not be checked`);
     }
+    if (failed) process.exit(1);
   },
 };
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -69,6 +69,7 @@
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { useCallback } from "react";
 import { Layout } from "./components/Layout";
+import { DocumentTitle } from "./components/DocumentTitle";
 import { SplashScreen } from "./components/SplashScreen";
 import { Dashboard } from "./pages/Dashboard";
 import { KanbanBoard } from "./pages/KanbanBoard";
@@ -102,6 +103,7 @@ export default function App() {
     <>
       <SplashScreen />
       <BrowserRouter>
+        <DocumentTitle />
         <Routes>
           <Route element={<Layout wsConnected={connected} />}>
             <Route index element={<Dashboard />} />

--- a/client/src/components/ConfirmModal.tsx
+++ b/client/src/components/ConfirmModal.tsx
@@ -9,61 +9,14 @@
  * Clicking the backdrop, pressing Escape, or clicking the X cancels. The confirm
  * button can be styled non-destructive for neutral confirmations.
  *
+ * ## Accessibility
+ * Focus moves to Cancel on open (safer default), Tab cycles within the dialog,
+ * Escape cancels, and focus restores to the previously focused element on close.
+ *
  * @author Son Nguyen <hoangson091104@gmail.com>
  */
-/* =============================================================================
- * MODULE_GUIDE — extended in-file reference (comments only; safe to read, never executed)
- * =============================================================================
- * **Path:** `/Users/davidnguyen/WebstormProjects/Claude-Code-Agent-Monitor/client/src/components/ConfirmModal.tsx`
- * **Purpose:** Dashboard module consumed by the React client, MCP tools, or desktop shell depending on deployment mode.
- *
- * ## Design constraints
- * - Local-first: no telemetry leaves the machine unless the user configures webhooks.
- * - Fail-safe hooks path on the server must never block Claude Code; UI mirrors that
- *   philosophy by degrading gracefully (empty states, stale badges, reconnect loops).
- * - Destructive flows stay behind explicit confirmation modals and server-side gates.
- * - Internationalization: user-visible strings belong in i18n JSON, not literals here.
- *
- * ## Remote data & SSH
- * Remote Data Sources let operators aggregate multiple machines. SSH entries describe
- * how to reach a peer dashboard; the global data scope (`dataScope.ts`) narrows every
- * scoped GET via `?sources=`. Health checks and import history surface in Settings.
- *
- * ## Observability
- * Prometheus scrapes `GET /api/metrics` (see `monitoring/`). Grafana ships four
- * provisioned boards (overview, sessions, tools, alerts). Native npm scripts and
- * Docker Compose profiles are documented in `monitoring/README.md`.
- *
- * ## Public surface
- * - `ConfirmModalProps` — exported API; see TSDoc on the symbol for behavior.
- * - `ConfirmModal` — exported API; see TSDoc on the symbol for behavior.
- *
- * ## Testing pointers
- * - Prefer colocated `__tests__` with Vitest + Testing Library for UI.
- * - Server contract changes require `npm run test:server` and OpenAPI sync.
- * - MCP edits: `npm run mcp:typecheck` and `npm run mcp:build`.
- *
- * ## Related docs
- * - `ARCHITECTURE.md` — hooks → API → SQLite → WebSocket → UI pipeline.
- * - `docs/API.md` — REST reference.
- * - `.claude/skills/file-headers/` — mandatory `@author` header policy.
- * ============================================================================= */
-/* -----------------------------------------------------------------------------
- * EXPORT CATALOG — quick index of symbols defined below (documentation only).
- * -----------------------------------------------------------------------------
- * **ConfirmModalProps**
- *   Part of this module's public contract. Downstream imports should treat
- *   the signature and return type as stable unless release notes say otherwise.
- *   When behavior changes, update the `@file` overview and relevant tests.
- *
- * **ConfirmModal**
- *   Part of this module's public contract. Downstream imports should treat
- *   the signature and return type as stable unless release notes say otherwise.
- *   When behavior changes, update the `@file` overview and relevant tests.
- *
- * ----------------------------------------------------------------------------- */
 
-import { useEffect } from "react";
+import { useEffect, useId, useRef } from "react";
 import { AlertTriangle, X } from "lucide-react";
 
 /** Props for {@link ConfirmModal}. */
@@ -103,13 +56,51 @@ export function ConfirmModal({
   onConfirm,
   onCancel,
 }: ConfirmModalProps) {
+  const titleId = useId();
+  const messageId = useId();
+  const panelRef = useRef<HTMLDivElement>(null);
+  const cancelRef = useRef<HTMLButtonElement>(null);
+  const previouslyFocused = useRef<HTMLElement | null>(null);
+
   useEffect(() => {
     if (!open) return;
+
+    previouslyFocused.current =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    // Prefer Cancel so Enter/activation doesn't immediately destroy data.
+    const focusTimer = window.setTimeout(() => cancelRef.current?.focus(), 0);
+
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onCancel();
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onCancel();
+        return;
+      }
+      if (e.key !== "Tab" || !panelRef.current) return;
+
+      const focusable = panelRef.current.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      );
+      if (focusable.length === 0) return;
+      const first = focusable.item(0);
+      const last = focusable.item(focusable.length - 1);
+      if (!first || !last) return;
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
     };
+
     document.addEventListener("keydown", onKey);
-    return () => document.removeEventListener("keydown", onKey);
+    return () => {
+      window.clearTimeout(focusTimer);
+      document.removeEventListener("keydown", onKey);
+      previouslyFocused.current?.focus?.();
+      previouslyFocused.current = null;
+    };
   }, [open, onCancel]);
 
   if (!open) return null;
@@ -118,12 +109,16 @@ export function ConfirmModal({
     <div
       className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4"
       onClick={onCancel}
-      role="dialog"
-      aria-modal="true"
+      role="presentation"
     >
       <div
+        ref={panelRef}
         className="relative w-full max-w-md rounded-xl border border-border bg-surface-1 shadow-xl shadow-black/40"
         onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={message ? messageId : undefined}
       >
         <div className="flex items-start gap-3 p-5">
           {destructive && (
@@ -132,10 +127,17 @@ export function ConfirmModal({
             </div>
           )}
           <div className="min-w-0 flex-1">
-            <h3 className="text-sm font-semibold text-gray-100">{title}</h3>
-            {message && <p className="text-xs text-gray-400 mt-1 leading-relaxed">{message}</p>}
+            <h3 id={titleId} className="text-sm font-semibold text-gray-100">
+              {title}
+            </h3>
+            {message && (
+              <p id={messageId} className="text-xs text-gray-400 mt-1 leading-relaxed">
+                {message}
+              </p>
+            )}
           </div>
           <button
+            type="button"
             onClick={onCancel}
             className="text-gray-500 hover:text-gray-300 p-1 -mt-1 -mr-1"
             aria-label={cancelLabel}
@@ -144,10 +146,16 @@ export function ConfirmModal({
           </button>
         </div>
         <div className="flex items-center justify-end gap-2 px-5 pb-5">
-          <button onClick={onCancel} className="btn-ghost border border-border text-xs">
+          <button
+            ref={cancelRef}
+            type="button"
+            onClick={onCancel}
+            className="btn-ghost border border-border text-xs"
+          >
             {cancelLabel}
           </button>
           <button
+            type="button"
             onClick={onConfirm}
             disabled={busy}
             className={`inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-md transition-colors disabled:opacity-50 ${

--- a/client/src/components/DocumentTitle.tsx
+++ b/client/src/components/DocumentTitle.tsx
@@ -1,0 +1,47 @@
+/**
+ * @file DocumentTitle.tsx
+ * @description Route-aware document title setter nested under BrowserRouter so
+ * `useLocation` works. Keeps multi-tab window switchers readable.
+ * @author Son Nguyen <hoangson091104@gmail.com>
+ */
+
+import { useLocation } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { useDocumentTitle } from "../hooks/useDocumentTitle";
+
+/**
+ * Maps the current pathname to a localized browser tab title.
+ */
+export function DocumentTitle() {
+  const { t } = useTranslation("nav");
+  const location = useLocation();
+
+  let title = t("dashboard");
+  const path = location.pathname;
+  const sessionId = path.match(/^\/sessions\/([^/]+)/)?.[1];
+
+  if (sessionId) {
+    title = `${t("sessions")} · ${sessionId.slice(0, 8)}`;
+  } else if (path.startsWith("/sessions")) {
+    title = t("sessions");
+  } else if (path.startsWith("/kanban")) {
+    title = t("agentBoard");
+  } else if (path.startsWith("/activity")) {
+    title = t("activityFeed");
+  } else if (path.startsWith("/analytics")) {
+    title = t("analytics");
+  } else if (path.startsWith("/workflows")) {
+    title = t("workflows");
+  } else if (path.startsWith("/cc-config")) {
+    title = t("ccConfig");
+  } else if (path.startsWith("/run")) {
+    title = t("run");
+  } else if (path.startsWith("/settings")) {
+    title = t("settings");
+  } else if (path !== "/") {
+    title = t("notFound");
+  }
+
+  useDocumentTitle(title);
+  return null;
+}

--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -71,6 +71,7 @@
 
 import { useState, useCallback } from "react";
 import { Outlet } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import { Sidebar, SIDEBAR_STORAGE_KEY, loadCollapsed } from "./Sidebar";
 import { UpdateNotifier } from "./UpdateNotifier";
 import { Tabby } from "./Tabby/Tabby";
@@ -86,6 +87,7 @@ interface LayoutProps {
  * @param props See {@link LayoutProps}.
  */
 export function Layout({ wsConnected }: LayoutProps) {
+  const { t } = useTranslation("nav");
   const [collapsed, setCollapsed] = useState(loadCollapsed);
 
   const toggle = useCallback(() => {
@@ -100,11 +102,16 @@ export function Layout({ wsConnected }: LayoutProps) {
 
   return (
     <div className="min-h-screen bg-surface-0">
+      <a href="#main-content" className="skip-to-content">
+        {t("skipToContent")}
+      </a>
       <UpdateNotifier />
       <Tabby />
       <Sidebar wsConnected={wsConnected} collapsed={collapsed} onToggle={toggle} />
       <main
-        className="min-h-screen min-w-0 transition-[margin-left,width] duration-200"
+        id="main-content"
+        tabIndex={-1}
+        className="min-h-screen min-w-0 transition-[margin-left,width] duration-200 outline-none"
         style={{
           marginLeft: collapsed ? "4.25rem" : "15rem",
           width: collapsed ? "calc(100% - 4.25rem)" : "calc(100% - 15rem)",

--- a/client/src/hooks/useDocumentTitle.ts
+++ b/client/src/hooks/useDocumentTitle.ts
@@ -1,0 +1,25 @@
+/**
+ * @file useDocumentTitle.ts
+ * @description Sets `document.title` for the current route/page and restores the
+ * previous title on unmount so browser tabs stay distinguishable.
+ * @author Son Nguyen <hoangson091104@gmail.com>
+ */
+
+import { useEffect } from "react";
+
+const APP_SUFFIX = "Claude Code Agent Monitor";
+
+/**
+ * Update the browser tab title while this component is mounted.
+ * @param title Page-specific title segment (without the app suffix), or null to skip.
+ */
+export function useDocumentTitle(title: string | null | undefined): void {
+  useEffect(() => {
+    if (!title) return;
+    const previous = document.title;
+    document.title = `${title} · ${APP_SUFFIX}`;
+    return () => {
+      document.title = previous;
+    };
+  }, [title]);
+}

--- a/client/src/i18n/locales/en/nav.json
+++ b/client/src/i18n/locales/en/nav.json
@@ -14,6 +14,7 @@
   "language": "Language",
   "github": "GitHub",
   "website": "Website",
+  "notFound": "Not found",
   "skipToContent": "Skip to content",
   "expand": "Expand sidebar",
   "collapse": "Collapse sidebar",

--- a/client/src/i18n/locales/en/nav.json
+++ b/client/src/i18n/locales/en/nav.json
@@ -14,6 +14,7 @@
   "language": "Language",
   "github": "GitHub",
   "website": "Website",
+  "skipToContent": "Skip to content",
   "expand": "Expand sidebar",
   "collapse": "Collapse sidebar",
   "collapseShort": "Collapse",

--- a/client/src/i18n/locales/en/sessions.json
+++ b/client/src/i18n/locales/en/sessions.json
@@ -34,7 +34,10 @@
     "unparented": "Unparented Subagents",
     "costBreakdown": "Cost Breakdown",
     "eventTimeline": "Event Timeline",
-    "noEvents": "No events recorded."
+    "noEvents": "No events recorded.",
+    "conversation": "Conversation",
+    "timeline": "Timeline ({{shown}}/{{total}})",
+    "transcriptNotFound": "Conversation transcript not found for this agent. The transcript file may be missing or not yet linked."
   },
   "remoteSourceBadgeTitle": "Collected from a remote machine"
 }

--- a/client/src/i18n/locales/ko/nav.json
+++ b/client/src/i18n/locales/ko/nav.json
@@ -14,6 +14,7 @@
   "language": "언어",
   "github": "GitHub",
   "website": "웹사이트",
+  "notFound": "페이지를 찾을 수 없음",
   "skipToContent": "본문으로 건너뛰기",
   "expand": "사이드바 펼치기",
   "collapse": "사이드바 접기",

--- a/client/src/i18n/locales/ko/nav.json
+++ b/client/src/i18n/locales/ko/nav.json
@@ -14,6 +14,7 @@
   "language": "언어",
   "github": "GitHub",
   "website": "웹사이트",
+  "skipToContent": "본문으로 건너뛰기",
   "expand": "사이드바 펼치기",
   "collapse": "사이드바 접기",
   "collapseShort": "접기",

--- a/client/src/i18n/locales/ko/sessions.json
+++ b/client/src/i18n/locales/ko/sessions.json
@@ -34,6 +34,9 @@
     "unparented": "상위가 없는 Subagent",
     "costBreakdown": "비용 내역",
     "eventTimeline": "이벤트 타임라인",
-    "noEvents": "기록된 이벤트가 없습니다."
+    "noEvents": "기록된 이벤트가 없습니다.",
+    "conversation": "대화",
+    "timeline": "타임라인 ({{shown}}/{{total}})",
+    "transcriptNotFound": "이 Agent의 대화 기록을 찾을 수 없습니다. Transcript 파일이 없거나 아직 연결되지 않았을 수 있습니다."
   }
 }

--- a/client/src/i18n/locales/vi/nav.json
+++ b/client/src/i18n/locales/vi/nav.json
@@ -14,6 +14,7 @@
   "language": "Ngôn ngữ",
   "github": "GitHub",
   "website": "Website",
+  "notFound": "Không tìm thấy",
   "skipToContent": "Bỏ qua đến nội dung",
   "expand": "Mở rộng thanh bên",
   "collapse": "Thu gọn thanh bên",

--- a/client/src/i18n/locales/vi/nav.json
+++ b/client/src/i18n/locales/vi/nav.json
@@ -14,6 +14,7 @@
   "language": "Ngôn ngữ",
   "github": "GitHub",
   "website": "Website",
+  "skipToContent": "Bỏ qua đến nội dung",
   "expand": "Mở rộng thanh bên",
   "collapse": "Thu gọn thanh bên",
   "collapseShort": "Thu gọn",

--- a/client/src/i18n/locales/vi/sessions.json
+++ b/client/src/i18n/locales/vi/sessions.json
@@ -34,6 +34,9 @@
     "unparented": "Subagent không có cha",
     "costBreakdown": "Phân rã chi phí",
     "eventTimeline": "Dòng thời gian sự kiện",
-    "noEvents": "Chưa có sự kiện được ghi nhận."
+    "noEvents": "Chưa có sự kiện được ghi nhận.",
+    "conversation": "Hội thoại",
+    "timeline": "Dòng thời gian ({{shown}}/{{total}})",
+    "transcriptNotFound": "Không tìm thấy bản ghi hội thoại cho agent này. Tệp transcript có thể bị thiếu hoặc chưa được liên kết."
   }
 }

--- a/client/src/i18n/locales/zh/nav.json
+++ b/client/src/i18n/locales/zh/nav.json
@@ -14,6 +14,7 @@
   "language": "语言",
   "github": "GitHub",
   "website": "网站",
+  "skipToContent": "跳到主要内容",
   "expand": "展开侧边栏",
   "collapse": "收起侧边栏",
   "collapseShort": "收起",

--- a/client/src/i18n/locales/zh/nav.json
+++ b/client/src/i18n/locales/zh/nav.json
@@ -14,6 +14,7 @@
   "language": "语言",
   "github": "GitHub",
   "website": "网站",
+  "notFound": "未找到页面",
   "skipToContent": "跳到主要内容",
   "expand": "展开侧边栏",
   "collapse": "收起侧边栏",

--- a/client/src/i18n/locales/zh/sessions.json
+++ b/client/src/i18n/locales/zh/sessions.json
@@ -34,6 +34,9 @@
     "unparented": "独立Subagent",
     "costBreakdown": "费用明细",
     "eventTimeline": "事件时间线",
-    "noEvents": "暂无事件记录。"
+    "noEvents": "暂无事件记录。",
+    "conversation": "对话",
+    "timeline": "时间线 ({{shown}}/{{total}})",
+    "transcriptNotFound": "未找到此 Agent 的对话记录。Transcript 文件可能缺失或尚未关联。"
   }
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -89,6 +89,29 @@
   .no-scrollbar::-webkit-scrollbar {
     display: none;
   }
+
+  /* Visually hidden until focused — first Tab lands here before the sidebar. */
+  .skip-to-content {
+    position: absolute;
+    left: 0.75rem;
+    top: 0.75rem;
+    z-index: 100;
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.5rem;
+    border: 1px solid #363650;
+    background: #15151f;
+    color: #e4e4ed;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    text-decoration: none;
+    transform: translateY(-150%);
+    transition: transform 0.15s ease;
+  }
+  .skip-to-content:focus {
+    transform: translateY(0);
+    outline: 2px solid #6366f1;
+    outline-offset: 2px;
+  }
 }
 
 @keyframes pulse-dot {

--- a/client/src/pages/SessionDetail.tsx
+++ b/client/src/pages/SessionDetail.tsx
@@ -764,7 +764,7 @@ export function SessionDetail() {
           }`}
         >
           <MessageSquare className="w-4 h-4" />
-          Conversation
+          {t("detail.conversation")}
         </button>
         <button
           onClick={() => {
@@ -778,7 +778,7 @@ export function SessionDetail() {
           }`}
         >
           <List className="w-4 h-4" />
-          Timeline ({events.length}/{eventsTotal})
+          {t("detail.timeline", { shown: events.length, total: eventsTotal })}
         </button>
       </div>
 
@@ -786,10 +786,7 @@ export function SessionDetail() {
       {transcriptNotFound && (
         <div className="flex items-center gap-2 px-4 py-2.5 mb-3 text-sm text-amber-400 bg-amber-500/10 border border-amber-500/20 rounded-lg">
           <AlertCircle className="w-4 h-4 flex-shrink-0" />
-          <span>
-            Conversation transcript not found for this agent. The transcript file may be missing or
-            not yet linked.
-          </span>
+          <span>{t("detail.transcriptNotFound")}</span>
           <button
             onClick={() => setTranscriptNotFound(false)}
             className="ml-auto text-amber-400/60 hover:text-amber-400 transition-colors"

--- a/client/src/pages/SessionDetail.tsx
+++ b/client/src/pages/SessionDetail.tsx
@@ -92,6 +92,7 @@ import { AgentCard } from "../components/AgentCard";
 import { SessionOverview } from "../components/SessionOverview";
 import { ConversationView } from "../components/conversation/ConversationView";
 import { SessionStatusBadge, AgentStatusBadge, REASON_ICONS } from "../components/StatusBadge";
+import { CopyButton } from "../components/event-views/primitives";
 import {
   effectiveSessionStatus,
   isSessionAwaitingInput,
@@ -603,8 +604,9 @@ export function SessionDetail() {
             />
           </div>
           <div className="flex flex-wrap items-center gap-x-4 gap-y-1 mt-1">
-            <span className="inline-flex items-center gap-1.5 text-xs text-gray-500 font-mono bg-surface-2 px-2 py-1 rounded">
-              {session.id.slice(0, 16)}
+            <span className="inline-flex items-center gap-1 text-xs text-gray-500 font-mono bg-surface-2 px-2 py-1 rounded">
+              <span title={session.id}>{session.id.slice(0, 16)}</span>
+              <CopyButton text={session.id} />
             </span>
             {session.model && (
               <span className="inline-flex items-center gap-1.5 text-xs text-gray-400 bg-surface-2 px-2 py-1 rounded">
@@ -629,9 +631,12 @@ export function SessionDetail() {
             )}
           </div>
           {session.cwd && (
-            <div className="flex items-center gap-1.5 text-xs text-gray-500 mt-2">
+            <div className="flex items-center gap-1.5 text-xs text-gray-500 mt-2 min-w-0">
               <FolderOpen className="w-3 h-3 flex-shrink-0" />
-              <span className="font-mono truncate">{session.cwd}</span>
+              <span className="font-mono truncate" title={session.cwd}>
+                {session.cwd}
+              </span>
+              <CopyButton text={session.cwd} />
             </div>
           )}
         </div>

--- a/client/src/pages/__tests__/__snapshots__/screens.snapshot.test.tsx.snap
+++ b/client/src/pages/__tests__/__snapshots__/screens.snapshot.test.tsx.snap
@@ -10203,7 +10203,7 @@ exports[`screen snapshots > Settings 1`] = `
             <p
               class="text-[10px] text-amber-400/90 mt-1"
             >
-              UI build v1.4.5 (rebuild client to match)
+              UI build v1.4.6 (rebuild client to match)
             </p>
           </div>
           <div

--- a/client/src/pages/__tests__/__snapshots__/screens.snapshot.test.tsx.snap
+++ b/client/src/pages/__tests__/__snapshots__/screens.snapshot.test.tsx.snap
@@ -6414,9 +6414,44 @@ exports[`screen snapshots > Session detail 1`] = `
           class="flex flex-wrap items-center gap-x-4 gap-y-1 mt-1"
         >
           <span
-            class="inline-flex items-center gap-1.5 text-xs text-gray-500 font-mono bg-surface-2 px-2 py-1 rounded"
+            class="inline-flex items-center gap-1 text-xs text-gray-500 font-mono bg-surface-2 px-2 py-1 rounded"
           >
-            sess-1
+            <span
+              title="sess-1"
+            >
+              sess-1
+            </span>
+            <button
+              aria-label="Copy"
+              class="flex items-center gap-1 text-[10px] py-0.5 px-1.5 rounded text-gray-400 hover:text-gray-200 hover:bg-surface-2 cursor-pointer"
+              type="button"
+            >
+              <svg
+                class="lucide lucide-copy w-3 h-3"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  height="14"
+                  rx="2"
+                  ry="2"
+                  width="14"
+                  x="8"
+                  y="8"
+                />
+                <path
+                  d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"
+                />
+              </svg>
+              Copy
+            </button>
           </span>
           <span
             class="inline-flex items-center gap-1.5 text-xs text-gray-400 bg-surface-2 px-2 py-1 rounded"
@@ -6502,7 +6537,7 @@ exports[`screen snapshots > Session detail 1`] = `
           </span>
         </div>
         <div
-          class="flex items-center gap-1.5 text-xs text-gray-500 mt-2"
+          class="flex items-center gap-1.5 text-xs text-gray-500 mt-2 min-w-0"
         >
           <svg
             class="lucide lucide-folder-open w-3 h-3 flex-shrink-0"
@@ -6522,9 +6557,41 @@ exports[`screen snapshots > Session detail 1`] = `
           </svg>
           <span
             class="font-mono truncate"
+            title="/test"
           >
             /test
           </span>
+          <button
+            aria-label="Copy"
+            class="flex items-center gap-1 text-[10px] py-0.5 px-1.5 rounded text-gray-400 hover:text-gray-200 hover:bg-surface-2 cursor-pointer"
+            type="button"
+          >
+            <svg
+              class="lucide lucide-copy w-3 h-3"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <rect
+                height="14"
+                rx="2"
+                ry="2"
+                width="14"
+                x="8"
+                y="8"
+              />
+              <path
+                d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"
+              />
+            </svg>
+            Copy
+          </button>
         </div>
       </div>
       <button

--- a/client/src/pages/__tests__/__snapshots__/screens.snapshot.test.tsx.snap
+++ b/client/src/pages/__tests__/__snapshots__/screens.snapshot.test.tsx.snap
@@ -6725,11 +6725,7 @@ exports[`screen snapshots > Session detail 1`] = `
             d="M8 6h13"
           />
         </svg>
-        Timeline (
-        0
-        /
-        0
-        )
+        Timeline (0/0)
       </button>
     </div>
     <div>

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-dashboard-desktop",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-dashboard-desktop",
-      "version": "1.4.5",
+      "version": "1.4.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-dashboard-desktop",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "private": true,
   "description": "Native macOS and Windows desktop shell for Claude Code Agent Monitor.",
   "author": "Son Nguyen <hoangson091104@gmail.com>",

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -158,6 +158,7 @@ Read-focused tools:
 - `dashboard_get_pricing_rules`
 - `dashboard_get_total_cost`
 - `dashboard_get_session_cost`
+- `dashboard_list_remote_sources`
 
 Mutation tools (require `MCP_DASHBOARD_ALLOW_MUTATIONS=true`):
 
@@ -172,6 +173,8 @@ Mutation tools (require `MCP_DASHBOARD_ALLOW_MUTATIONS=true`):
 - `dashboard_cleanup_data`
 - `dashboard_reimport_history`
 - `dashboard_reinstall_hooks`
+- `dashboard_sync_remote_source`
+- `dashboard_sync_all_remote_sources`
 
 Destructive tools (require mutation flag + destructive flag):
 

--- a/mcp/__tests__/tool-collector.test.ts
+++ b/mcp/__tests__/tool-collector.test.ts
@@ -107,6 +107,11 @@ describe("collectAllTools", () => {
     assert.ok(names.has("dashboard_reimport_history"));
     assert.ok(names.has("dashboard_reinstall_hooks"));
     assert.ok(names.has("dashboard_clear_all_data"));
+
+    // Remote Data Sources
+    assert.ok(names.has("dashboard_list_remote_sources"));
+    assert.ok(names.has("dashboard_sync_remote_source"));
+    assert.ok(names.has("dashboard_sync_all_remote_sources"));
   });
 
   it("mutation tools throw when mutations disabled", async () => {

--- a/mcp/src/tools/domains/remote-tools.ts
+++ b/mcp/src/tools/domains/remote-tools.ts
@@ -1,0 +1,50 @@
+/**
+ * @file remote-tools.ts
+ * @description MCP tools for Remote Data Sources — list configured SSH sources
+ * and trigger on-demand syncs so agents can operate remotes without the UI/CLI.
+ * @author Son Nguyen <hoangson091104@gmail.com>
+ */
+
+import { z } from "zod";
+import { createToolRegistrar } from "../../core/tool-registry.js";
+import { assertMutationsEnabled } from "../../policy/tool-guards.js";
+import type { ToolContext } from "../../types/tool-context.js";
+
+/**
+ * Registers remote-source tools against `/api/remote-sources/*`.
+ * List is read-only; sync tools require the mutations policy gate.
+ */
+export function registerRemoteTools(context: ToolContext): void {
+  const { api, logger, server, config } = context;
+  const register = createToolRegistrar(server, logger);
+
+  register(
+    "dashboard_list_remote_sources",
+    "List configured Remote Data Sources (SSH machines) with status and last sync.",
+    {},
+    async () => api.get("/api/remote-sources")
+  );
+
+  register(
+    "dashboard_sync_remote_source",
+    "Trigger an immediate SSH pull+import for one Remote Data Source by id.",
+    {
+      source_id: z.string().min(1).describe("Remote source id (src_…)"),
+    },
+    async (args) => {
+      assertMutationsEnabled(config);
+      const id = encodeURIComponent(args.source_id as string);
+      return api.post(`/api/remote-sources/${id}/sync`);
+    }
+  );
+
+  register(
+    "dashboard_sync_all_remote_sources",
+    "Trigger an immediate SSH pull+import for every enabled Remote Data Source.",
+    {},
+    async () => {
+      assertMutationsEnabled(config);
+      return api.post("/api/remote-sources/sync-all");
+    }
+  );
+}

--- a/mcp/src/tools/index.ts
+++ b/mcp/src/tools/index.ts
@@ -65,9 +65,10 @@ import { registerAgentTools } from "./domains/agent-tools.js";
 import { registerEventTools } from "./domains/event-tools.js";
 import { registerPricingTools } from "./domains/pricing-tools.js";
 import { registerMaintenanceTools } from "./domains/maintenance-tools.js";
+import { registerRemoteTools } from "./domains/remote-tools.js";
 
 /**
- * Registers all 26 `dashboard_*` tools with the given {@link ToolContext} in
+ * Registers all 29 `dashboard_*` tools with the given {@link ToolContext} in
  * one call. `server.ts`'s `buildServer` calls this per `McpServer` instance;
  * `transports/tool-collector.ts`'s `collectAllTools` independently
  * re-implements the same registrations for REPL mode (no live server), so
@@ -80,4 +81,5 @@ export function registerAllTools(context: ToolContext): void {
   registerEventTools(context);
   registerPricingTools(context);
   registerMaintenanceTools(context);
+  registerRemoteTools(context);
 }

--- a/mcp/src/transports/tool-collector.ts
+++ b/mcp/src/transports/tool-collector.ts
@@ -79,7 +79,7 @@ import {
  * Used by REPL mode to invoke tools directly.
  *
  * A hand-maintained, server-less mirror of `tools/index.ts`'s
- * `registerAllTools`/`tools/domains/*.ts`: it re-declares the same 26
+ * `registerAllTools`/`tools/domains/*.ts`: it re-declares the same 29
  * `dashboard_*` tools using {@link createCollectorRegistrar} instead of
  * {@link createToolRegistrar}, so no `McpServer` or MCP protocol overhead is
  * needed — the REPL calls handlers directly and renders results with its
@@ -323,6 +323,34 @@ export function collectAllTools(
     assertDestructiveEnabled(config, args.confirmation_token as string);
     return api.post("/api/settings/clear-data");
   });
+
+  // ── Remote Data Sources ─────────────────────────────────────
+  register(
+    "dashboard_list_remote_sources",
+    "List configured Remote Data Sources (SSH machines).",
+    {},
+    async () => api.get("/api/remote-sources")
+  );
+  register(
+    "dashboard_sync_remote_source",
+    "Trigger an immediate SSH pull+import for one Remote Data Source.",
+    {
+      source_id: z.string().min(1),
+    },
+    async (args) => {
+      assertMutationsEnabled(config);
+      return api.post(`/api/remote-sources/${encodeURIComponent(args.source_id as string)}/sync`);
+    }
+  );
+  register(
+    "dashboard_sync_all_remote_sources",
+    "Trigger an immediate SSH pull+import for every enabled Remote Data Source.",
+    {},
+    async () => {
+      assertMutationsEnabled(config);
+      return api.post("/api/remote-sources/sync-all");
+    }
+  );
 
   return tools;
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.0.3
 info:
   title: Agent Dashboard for Claude Code API
-  version: 1.4.5
+  version: 1.4.6
   description: HTTP API for real-time Claude Code session monitoring, agent lifecycle tracking, analytics, pricing, hooks ingestion, and workflow intelligence.
   contact:
     name: Son Nguyen
@@ -362,7 +362,7 @@ components:
         version:
           type: string
           description: Dashboard release version from package.json
-          example: 1.4.5
+          example: 1.4.6
         timestamp:
           type: string
           format: date-time

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-dashboard",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-dashboard",
-      "version": "1.4.5",
+      "version": "1.4.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-dashboard",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "bin": {
     "ccam": "bin/ccam.js"
   },

--- a/server/__tests__/ccam-cli.test.js
+++ b/server/__tests__/ccam-cli.test.js
@@ -355,13 +355,15 @@ describe("ccam CLI — import & administration", () => {
     assert.match(err, /Usage: ccam import/);
   });
 
-  it("doctor reports API, hooks, database, and uptime lines", async () => {
+  it("doctor reports API, hooks, database, remotes, and uptime lines", async () => {
     const { code, out } = await ccam("doctor");
-    assert.equal(code, 0);
+    // Exit 1 when hooks are missing (common in the test harness) — still prints a full report.
+    assert.ok(code === 0 || code === 1, `unexpected exit ${code}`);
     assert.match(out, /API reachable/);
     assert.match(out, /Claude Code hooks/);
     assert.match(out, /Database/);
     assert.match(out, /Server uptime/);
+    assert.match(out, /Remote sources/);
   });
 
   it("info dumps system info JSON", async () => {
@@ -509,10 +511,11 @@ describe("ccam CLI — offline mode (server down, DB read directly)", () => {
 
   it("doctor works offline and reports the server as down", async () => {
     const { code, out } = await offline("doctor");
-    assert.equal(code, 0);
+    assert.equal(code, 1);
     assert.match(out, /NOT running/);
     assert.match(out, /Database/);
     assert.match(out, /rows: sessions/);
+    assert.match(out, /Remote sources/);
   });
 
   it("cost refuses offline with the server-side-math reason", async () => {

--- a/server/openapi.js
+++ b/server/openapi.js
@@ -328,7 +328,7 @@ function createOpenApiSpec() {
             version: {
               type: "string",
               description: "Dashboard release version from package.json",
-              example: "1.4.5",
+              example: "1.4.6",
             },
             timestamp: { type: "string", format: "date-time" },
           },

--- a/wiki/index.html
+++ b/wiki/index.html
@@ -1568,55 +1568,6 @@
             </div>
           </div>
 
-          <h3>GitHub Star History</h3>
-          <p class="star-history-intro">
-            This chart tracks how interest in Claude Code Agent Monitor has grown over time. The
-            curve keeps climbing as more developers discover the project, share it, and use it in
-            real workflows. Each new star is a small vote of confidence from the community.
-          </p>
-          <div class="screenshot-gallery gallery-single">
-            <div class="screenshot-card star-history-card">
-              <a
-                class="star-history-link"
-                href="https://www.star-history.com/?repos=hoangsonww%2FClaude-Code-Agent-Monitor&type=date&legend=top-left"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <picture>
-                  <source
-                    media="(prefers-color-scheme: dark)"
-                    srcset="https://api.star-history.com/chart?repos=hoangsonww/Claude-Code-Agent-Monitor&type=date&theme=dark&legend=top-left"
-                  />
-                  <source
-                    media="(prefers-color-scheme: light)"
-                    srcset="https://api.star-history.com/chart?repos=hoangsonww/Claude-Code-Agent-Monitor&type=date&legend=top-left"
-                  />
-                  <img
-                    alt="GitHub star history chart for Claude Code Agent Monitor"
-                    src="https://api.star-history.com/chart?repos=hoangsonww/Claude-Code-Agent-Monitor&type=date&legend=top-left"
-                   
-                    width="1140"
-                    height="560"
-                  />
-                </picture>
-              </a>
-              <div class="screenshot-caption">
-                <span class="caption-icon">⭐</span>
-                <span>
-                  Enjoying the project?
-                  <a
-                    class="star-history-caption-link"
-                    href="https://github.com/hoangsonww/Claude-Code-Agent-Monitor"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    >Give it a star on GitHub</a
-                  >
-                  and help more builders discover it.
-                </span>
-              </div>
-            </div>
-          </div>
-
           <h3>Hook Events Captured</h3>
           <div class="table-wrap">
             <table>


### PR DESCRIPTION
## Summary
- Remove GitHub star-history embeds from README (all locales) and wiki
- Accessibility: skip-to-content link, ConfirmModal focus trap + labelled dialog
- SessionDetail UX: copy full session id/cwd; localized Conversation/Timeline tabs
- Per-route browser document titles for multi-tab clarity
- `ccam doctor` reports remote sources and exits non-zero on failures
- MCP: `dashboard_list_remote_sources` + sync-one/sync-all tools
- **Bump global project version to v1.4.6** (final commit)

## Commits (9)
1. `docs: remove GitHub star history charts from README and wiki`
2. `feat(a11y): add skip-to-content link on app Layout`
3. `feat(a11y): focus trap and labelled dialog for ConfirmModal`
4. `feat(ui): copy full session id and cwd from SessionDetail`
5. `feat(ui): set per-route browser document titles`
6. `i18n: localize SessionDetail Conversation and Timeline tabs`
7. `feat(cli): report remote sources in ccam doctor with exit codes`
8. `feat(mcp): add remote source list and sync tools`
9. `chore(release): bump version to 1.4.6`

## Test plan
- [ ] `npm run test:client` — snapshots updated for SessionDetail + Settings About
- [ ] `npm run test:server` — doctor CLI assertions updated for remotes/exit codes
- [ ] `npm run mcp:typecheck && npm run mcp:build` (+ `cd mcp && npm test`)
- [ ] Manual: Tab to skip link → main content; ConfirmModal Escape/Tab trap
- [ ] Manual: SessionDetail copy id/cwd; tab title changes per route
- [ ] Manual: `ccam doctor` shows Remote sources; exits 1 when offline / hooks missing
- [ ] Manual: MCP tools list includes the three new remote tools
- [ ] Confirm `/api/health` and Settings About show `1.4.6` after bump


Made with [Cursor](https://cursor.com)