### PR TITLE
fix(ci): harden production dependency audits

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -45,6 +45,8 @@ npm run deploy:validate
 
 It checks Dockerfiles, Compose profiles, Nginx syntax, Helm lint and schema rejection, every Kustomize overlay and optional component, Terraform formatting/provider validation, production dependency audits, file headers, and the one-writer invariant.
 
+The dependency audit retries malformed registry or transport responses up to three times with bounded backoff. A valid report containing any vulnerability fails immediately and prints the complete audit payload; malformed reports never pass as clean.
+
 ## Secrets
 
 Production deployments use three independent tokens:

--- a/deployments/scripts/validate-deployment.sh
+++ b/deployments/scripts/validate-deployment.sh
@@ -14,6 +14,70 @@ readonly KUSTOMIZE_DIR="${PROJECT_ROOT}/deployments/kubernetes"
 log() { printf '[deployment-check] %s\n' "$*"; }
 fatal() { printf '[deployment-check] ERROR: %s\n' "$*" >&2; exit 1; }
 
+audit_production_dependencies() {
+  local label="$1"
+  shift
+  local attempt=1
+  local max_attempts=3
+  local retry_base_seconds="${CCAM_AUDIT_RETRY_BASE_SECONDS:-2}"
+  local output errors status vulnerabilities stdout_file stderr_file
+
+  if [[ ! "$retry_base_seconds" =~ ^[0-9]+$ ]]; then
+    retry_base_seconds=2
+  fi
+
+  while (( attempt <= max_attempts )); do
+    stdout_file="$(mktemp)"
+    stderr_file="$(mktemp)"
+    "$@" audit --omit=dev --json >"$stdout_file" 2>"$stderr_file" && status=0 || status=$?
+    output="$(cat "$stdout_file")"
+    errors="$(cat "$stderr_file")"
+    rm -f "$stdout_file" "$stderr_file"
+    if ! vulnerabilities="$(
+      printf '%s' "$output" | node -e '
+        let body = "";
+        process.stdin.setEncoding("utf8");
+        process.stdin.on("data", (chunk) => (body += chunk));
+        process.stdin.on("end", () => {
+          try {
+            const parsed = JSON.parse(body);
+            const count = Number(parsed?.metadata?.vulnerabilities?.total);
+            if (!Number.isFinite(count)) process.exit(2);
+            process.stdout.write(String(count));
+          } catch {
+            process.exit(2);
+          }
+        });
+      '
+    )"; then
+      if (( attempt < max_attempts )); then
+        log "${label} audit transport failure (attempt ${attempt}/${max_attempts}); retrying"
+        [[ -n "$errors" ]] && printf '%s\n' "$errors" >&2
+        [[ -n "$output" ]] && printf '%s\n' "$output" >&2
+        sleep $(( attempt * retry_base_seconds ))
+        ((attempt += 1))
+        continue
+      fi
+      [[ -n "$errors" ]] && printf '%s\n' "$errors" >&2
+      [[ -n "$output" ]] && printf '%s\n' "$output" >&2
+      fatal "${label} audit could not retrieve a valid registry report after ${max_attempts} attempts"
+    fi
+
+    if (( vulnerabilities > 0 )); then
+      [[ -n "$errors" ]] && printf '%s\n' "$errors" >&2
+      printf '%s\n' "$output" >&2
+      fatal "${label} production dependency audit found ${vulnerabilities} vulnerability record(s)"
+    fi
+    if (( status != 0 )); then
+      [[ -n "$errors" ]] && printf '%s\n' "$errors" >&2
+      printf '%s\n' "$output" >&2
+      fatal "${label} production dependency audit exited ${status} despite reporting zero vulnerabilities"
+    fi
+    log "${label} production dependency audit passed"
+    return
+  done
+}
+
 need() {
   command -v "$1" >/dev/null 2>&1 || fatal "missing required command: $1"
 }
@@ -134,8 +198,8 @@ YAML
 
 validate_repo() {
   log "Production dependency audits"
-  (cd "${PROJECT_ROOT}" && npm audit --omit=dev >/dev/null)
-  (cd "${PROJECT_ROOT}" && npm --prefix mcp audit --omit=dev >/dev/null)
+  (cd "${PROJECT_ROOT}" && audit_production_dependencies "root" npm)
+  (cd "${PROJECT_ROOT}" && audit_production_dependencies "MCP" npm --prefix mcp)
   log "Authorship headers"
   bash "${PROJECT_ROOT}/.claude/skills/file-headers/scripts/check-headers.sh" >/dev/null
 }
@@ -176,4 +240,6 @@ main() {
   log "all deployment checks passed"
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -45,6 +45,8 @@ npm run deploy:validate
 
 It checks Dockerfiles, Compose profiles, Nginx syntax, Helm lint and schema rejection, every Kustomize overlay and optional component, Terraform formatting/provider validation, production dependency audits, file headers, and the one-writer invariant.
 
+The dependency audit retries malformed registry or transport responses up to three times with bounded backoff. A valid report containing any vulnerability fails immediately and prints the complete audit payload; malformed reports never pass as clean.
+
 ## Secrets
 
 Production deployments use three independent tokens:

--- a/package-lock.json
+++ b/package-lock.json
@@ -139,28 +139,6 @@
         "npm": ">=9.5.0"
       }
     },
-    "node_modules/@redocly/openapi-core/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/@scarf/scarf": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -128,6 +128,9 @@
   "optionalDependencies": {
     "better-sqlite3": "^12.0.0"
   },
+  "overrides": {
+    "js-yaml": "4.3.1"
+  },
   "devDependencies": {
     "concurrently": "^9.1.2",
     "js-yaml": "4.3.1",

--- a/server/__tests__/deployment-audit-gate.test.js
+++ b/server/__tests__/deployment-audit-gate.test.js
@@ -1,0 +1,119 @@
+/**
+ * @file Tests the deployment validator's production dependency audit gate.
+ * It verifies transient registry failures retry, vulnerability reports fail
+ * closed without retry, and successful audit reports pass deterministically.
+ * @author Son Nguyen <hoangson091104@gmail.com>
+ */
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const ROOT = path.resolve(__dirname, "..", "..");
+const VALIDATOR = path.join(ROOT, "deployments", "scripts", "validate-deployment.sh");
+
+function runAuditScenario(fakeNpmBody) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "ccam-audit-gate-"));
+  const fakeNpm = path.join(tmp, "npm");
+  const attempts = path.join(tmp, "attempts");
+  fs.writeFileSync(
+    fakeNpm,
+    `#!/usr/bin/env bash
+set -euo pipefail
+attempts_file=${JSON.stringify(attempts)}
+count=0
+[[ -f "$attempts_file" ]] && count="$(cat "$attempts_file")"
+count=$((count + 1))
+printf '%s' "$count" >"$attempts_file"
+${fakeNpmBody}
+`
+  );
+  fs.chmodSync(fakeNpm, 0o755);
+
+  const command = `
+    source ${JSON.stringify(VALIDATOR)}
+    audit_production_dependencies test npm
+  `;
+  const result = spawnSync("bash", ["-c", command], {
+    cwd: ROOT,
+    env: {
+      ...process.env,
+      PATH: `${tmp}:${process.env.PATH}`,
+      CCAM_AUDIT_RETRY_BASE_SECONDS: "0",
+    },
+    encoding: "utf8",
+    timeout: 15_000,
+  });
+  const attemptCount = Number(fs.readFileSync(attempts, "utf8"));
+  fs.rmSync(tmp, { recursive: true, force: true });
+  return { ...result, attemptCount };
+}
+
+describe("deployment production dependency audit gate", () => {
+  it("passes one valid zero-vulnerability report", () => {
+    const result = runAuditScenario(`
+cat <<'JSON'
+{"metadata":{"vulnerabilities":{"total":0}}}
+JSON
+exit 0
+`);
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.attemptCount, 1);
+    assert.match(result.stdout, /production dependency audit passed/);
+  });
+
+  it("accepts valid JSON when npm also prints a warning on stderr", () => {
+    const result = runAuditScenario(`
+echo "npm warn registry using cached advisory metadata" >&2
+cat <<'JSON'
+{"metadata":{"vulnerabilities":{"total":0}}}
+JSON
+exit 0
+`);
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.attemptCount, 1);
+    assert.match(result.stdout, /production dependency audit passed/);
+  });
+
+  it("retries malformed transport output and then accepts a valid report", () => {
+    const result = runAuditScenario(`
+if [[ "$count" -lt 3 ]]; then
+  echo "registry connection reset" >&2
+  exit 1
+fi
+cat <<'JSON'
+{"metadata":{"vulnerabilities":{"total":0}}}
+JSON
+exit 0
+`);
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.attemptCount, 3);
+    assert.match(result.stdout, /transport failure .* retrying/);
+  });
+
+  it("fails immediately when the registry returns a real vulnerability report", () => {
+    const result = runAuditScenario(`
+cat <<'JSON'
+{"vulnerabilities":{"js-yaml":{"severity":"high"}},"metadata":{"vulnerabilities":{"total":1}}}
+JSON
+exit 1
+`);
+    assert.notEqual(result.status, 0);
+    assert.equal(result.attemptCount, 1, "real vulnerabilities must not be retried");
+    assert.match(result.stderr, /found 1 vulnerability record/);
+    assert.match(result.stderr, /js-yaml/);
+  });
+
+  it("fails closed after repeated malformed reports", () => {
+    const result = runAuditScenario(`
+echo "not-json"
+exit 1
+`);
+    assert.notEqual(result.status, 0);
+    assert.equal(result.attemptCount, 3);
+    assert.match(result.stderr, /could not retrieve a valid registry report/);
+  });
+});


### PR DESCRIPTION
## Summary
- override Redoc's transitive `js-yaml` to patched `4.3.1` and remove the vulnerable nested `4.3.0` lock entry
- replace silent `npm audit` calls with a JSON-aware production audit gate
- retry only malformed registry/transport responses with bounded backoff
- fail immediately on valid vulnerability reports and print the full advisory payload
- add contract tests for clean reports, stderr warnings, transport retries, real vulnerabilities, and fail-closed malformed output

## Root cause
The merged master deployment job passed Docker, Nginx, Helm, Kustomize, and Terraform, then failed at the root production dependency audit. A newly published advisory (`GHSA-5p4m-2wfm-xmqj`) flagged `js-yaml@4.3.0`, which was pinned transitively under `redoc -> @redocly/openapi-core`. The previous validation redirected audit output to `/dev/null`, so the job exposed only an exit code.

## Compatibility
- production Redoc remains `2.5.3`
- all `js-yaml` consumers resolve to patched `4.3.1`
- real vulnerability findings remain blocking
- MCP audit behavior remains blocking and now receives the same diagnostics
- no application, schema, Docker topology, Kubernetes, Helm, Kustomize, or Terraform behavior changes

## Validation
- clean `npm ci`: pass
- `npm audit --omit=dev`: 0 vulnerabilities
- `npm --prefix mcp audit --omit=dev`: 0 vulnerabilities
- `npm run deploy:validate`: pass end to end with Docker, Compose, Nginx, Helm, Kustomize, Terraform, audits, and headers
- `npm run test:server`: 898 passed
- audit-gate contract tests: 5 passed
- formatting, shell syntax, file headers, and diff checks: pass
