### PR TITLE
fix: restore deployment audit and complete skills docs

### DIFF
--- a/.codex/README.md
+++ b/.codex/README.md
@@ -8,7 +8,7 @@ This directory contains all project-scoped Codex extensions:
 - reusable skills in [`skills/`](./skills)
 - runtime configuration in [`config.toml`](./config.toml)
 - a repository plugin marketplace in [`.agents/plugins/marketplace.json`](../.agents/plugins/marketplace.json)
-- 13 shared plugins under [`plugins/`](../plugins), each with `.codex-plugin/plugin.json`
+- 14 shared plugins under [`plugins/`](../plugins), each with `.codex-plugin/plugin.json`
 
 ## What Codex reads
 
@@ -41,18 +41,44 @@ codex plugin list --marketplace claude-code-agent-monitor-plugins --available --
 codex plugin add ccam-platform@claude-code-agent-monitor-plugins
 ```
 
-The marketplace contains 13 plugins and 62 bundled skills. The same plugin
+The marketplace contains 14 plugins and 66 bundled skills. The same plugin
 directories also carry Claude Code manifests, so product metadata stays
 separate while skill instructions remain shared.
 
 ## skills.sh-compatible installation
 
 ```bash
+# List all repository skills without installing
 npx skills add hoangsonww/Claude-Code-Agent-Monitor --list
+
+# Install mcp-server into the current project for Codex
 npx skills add hoangsonww/Claude-Code-Agent-Monitor \
-  --skill mcp-server --agent codex
+  --skill mcp-server \
+  --agent codex \
+  --yes
+
+# Verify the project install
+npx skills list --json
+
+# Install and verify globally
+npx skills add hoangsonww/Claude-Code-Agent-Monitor \
+  --skill mcp-server \
+  --agent codex \
+  --global \
+  --yes
+npx skills list --global --json
+
+# Update or remove the project-scoped skill
+npx skills update --project --yes
+npx skills remove mcp-server --yes
+
+# Update or remove the global skill
+npx skills update --global --yes
+npx skills remove --global mcp-server --yes
 ```
 
-The skills CLI discovers 70 repository skills. Run `npm run extensions:sync`
+The skills CLI discovers 74 repository skills. Project installs use
+`.agents/skills/`; global installs use `~/.agents/skills/`. Run
+`npm run extensions:sync`
 after changing a plugin skill or Claude manifest, then
 `npm run extensions:validate`.

--- a/.codex/README.md
+++ b/.codex/README.md
@@ -77,8 +77,9 @@ npx skills update --global --yes
 npx skills remove --global mcp-server --yes
 ```
 
-The skills CLI discovers 74 repository skills. Project installs use
-`.agents/skills/`; global installs use `~/.agents/skills/`. Run
-`npm run extensions:sync`
+The skills CLI discovers 74 repository skills. Codex project installs use
+`.agents/skills/`; global installs use `${CODEX_HOME:-~/.codex}/skills/`.
+Multi-agent installs may deduplicate files through a shared store and create
+agent-specific links. Run `npm run extensions:sync`
 after changing a plugin skill or Claude manifest, then
 `npm run extensions:validate`.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -45,6 +45,8 @@ npm run deploy:validate
 
 It checks Dockerfiles, Compose profiles, Nginx syntax, Helm lint and schema rejection, every Kustomize overlay and optional component, Terraform formatting/provider validation, production dependency audits, file headers, and the one-writer invariant.
 
+The dependency audit retries malformed registry or transport responses up to three times with bounded backoff. A valid report containing any vulnerability fails immediately and prints the complete audit payload; malformed reports never pass as clean.
+
 ## Secrets
 
 Production deployments use three independent tokens:

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -193,7 +193,7 @@ Render and replace the local image name with an immutable registry reference:
 REGISTRY="ghcr.io/$(gh repo view --json owner -q .owner.login)"
 IMAGE_TAG="$(git rev-parse --short HEAD)"
 kubectl kustomize deployments/kubernetes/overlays/production \
-  | sed "s|ccam-dashboard:2.0.1|${REGISTRY}/claude-code-agent-monitor:${IMAGE_TAG}|g" \
+  | sed "s|ccam-dashboard:2.0.2|${REGISTRY}/claude-code-agent-monitor:${IMAGE_TAG}|g" \
   | kubectl apply --server-side --field-manager=ccam-deployer -f -
 ```
 

--- a/README-CN.md
+++ b/README-CN.md
@@ -1764,13 +1764,46 @@ erDiagram
 
 ## 插件市场
 
-通过官方 Agent Monitor 插件扩展 Claude Code — 分析、生产力工具、开发者工具、AI 洞察和 Dashboard 连接。
+CCAM 为 Claude Code 和 Codex 提供 14 个共享插件、66 个插件技能、18 个 Claude 子 Agent、34 个 Claude 命令、3 个 CLI 工具、3 个 Hook 配置和 2 个支持 MCP 的插件。skills.sh CLI 可发现 74 个仓库技能。
 
 ### 添加市场
 
 ```bash
 claude plugin marketplace add hoangsonww/Claude-Code-Agent-Monitor
+codex plugin marketplace add hoangsonww/Claude-Code-Agent-Monitor
 ```
+
+### 使用 skills.sh 安装技能
+
+```bash
+# 查看全部 74 个技能，不执行安装
+npx skills add hoangsonww/Claude-Code-Agent-Monitor --list
+
+# 在当前项目中为 Claude Code 和 Codex 安装一个技能
+npx skills add hoangsonww/Claude-Code-Agent-Monitor \
+  --skill mcp-server \
+  --agent claude-code \
+  --agent codex \
+  --yes
+
+# 验证、更新和移除项目级技能
+npx skills list --json
+npx skills update --project --yes
+npx skills remove mcp-server --yes
+
+# 添加 --global 以执行用户级安装，并显式管理全局范围
+npx skills add hoangsonww/Claude-Code-Agent-Monitor \
+  --skill mcp-server \
+  --agent claude-code \
+  --agent codex \
+  --global \
+  --yes
+npx skills list --global --json
+npx skills update --global --yes
+npx skills remove --global mcp-server --yes
+```
+
+项目级安装使用 `.agents/skills/` 及各 Agent 的链接。全局安装使用用户主目录中的对应目录。skills.sh CLI 可发现 74 个仓库技能，其中包括 66 个插件技能和仓库维护技能。
 
 ### 可用插件
 

--- a/README-CN.md
+++ b/README-CN.md
@@ -1803,7 +1803,7 @@ npx skills update --global --yes
 npx skills remove --global mcp-server --yes
 ```
 
-项目级安装使用 `.agents/skills/` 及各 Agent 的链接。全局安装使用用户主目录中的对应目录。skills.sh CLI 可发现 74 个仓库技能，其中包括 66 个插件技能和仓库维护技能。
+项目级安装使用 `.agents/skills/` 及各 Agent 的链接。Claude Code 全局技能默认位于 `~/.claude/skills/`，设置 `CLAUDE_CONFIG_DIR` 后位于其 `skills/` 子目录。Codex 全局技能默认位于 `~/.codex/skills/`，设置 `CODEX_HOME` 后位于其 `skills/` 子目录。多 Agent 安装可能通过共享存储去重，并链接到这些目标目录。skills.sh CLI 可发现 74 个仓库技能，其中包括 66 个插件技能和仓库维护技能。
 
 ### 可用插件
 

--- a/README-ES.md
+++ b/README-ES.md
@@ -1825,6 +1825,38 @@ claude plugin marketplace add hoangsonww/Claude-Code-Agent-Monitor
 codex plugin marketplace add hoangsonww/Claude-Code-Agent-Monitor
 ```
 
+### Instalar habilidades con skills.sh
+
+```bash
+# Enumerar las 74 habilidades sin instalarlas
+npx skills add hoangsonww/Claude-Code-Agent-Monitor --list
+
+# Instalar una habilidad para Claude Code y Codex en el proyecto actual
+npx skills add hoangsonww/Claude-Code-Agent-Monitor \
+  --skill mcp-server \
+  --agent claude-code \
+  --agent codex \
+  --yes
+
+# Verificar, actualizar y eliminar la habilidad del proyecto
+npx skills list --json
+npx skills update --project --yes
+npx skills remove mcp-server --yes
+
+# Añadir --global para instalar a nivel de usuario y administrar ese ámbito
+npx skills add hoangsonww/Claude-Code-Agent-Monitor \
+  --skill mcp-server \
+  --agent claude-code \
+  --agent codex \
+  --global \
+  --yes
+npx skills list --global --json
+npx skills update --global --yes
+npx skills remove --global mcp-server --yes
+```
+
+Las instalaciones de proyecto usan `.agents/skills/` y enlaces específicos de cada agente. Las instalaciones globales usan los directorios correspondientes dentro del directorio personal del usuario. La CLI de skills.sh descubre 74 habilidades del repositorio, incluidas 66 habilidades de plugins y las habilidades de mantenimiento del repositorio.
+
 ### Plugins disponibles
 
 | Plugin | Comando de instalación | Habilidades |

--- a/README-ES.md
+++ b/README-ES.md
@@ -1855,7 +1855,7 @@ npx skills update --global --yes
 npx skills remove --global mcp-server --yes
 ```
 
-Las instalaciones de proyecto usan `.agents/skills/` y enlaces específicos de cada agente. Las instalaciones globales usan los directorios correspondientes dentro del directorio personal del usuario. La CLI de skills.sh descubre 74 habilidades del repositorio, incluidas 66 habilidades de plugins y las habilidades de mantenimiento del repositorio.
+Las instalaciones de proyecto usan `.agents/skills/` y enlaces específicos de cada agente. Las habilidades globales de Claude Code se instalan de forma predeterminada en `~/.claude/skills/`, o en el subdirectorio `skills/` de `CLAUDE_CONFIG_DIR` cuando se define. Las habilidades globales de Codex se instalan de forma predeterminada en `~/.codex/skills/`, o en el subdirectorio `skills/` de `CODEX_HOME` cuando se define. Las instalaciones para varios agentes pueden deduplicar archivos en un almacén compartido y enlazar esos destinos. La CLI de skills.sh descubre 74 habilidades del repositorio, incluidas 66 habilidades de plugins y las habilidades de mantenimiento del repositorio.
 
 ### Plugins disponibles
 

--- a/README-KO.md
+++ b/README-KO.md
@@ -1815,6 +1815,38 @@ claude plugin marketplace add hoangsonww/Claude-Code-Agent-Monitor
 codex plugin marketplace add hoangsonww/Claude-Code-Agent-Monitor
 ```
 
+### skills.sh로 스킬 설치
+
+```bash
+# 설치하지 않고 전체 74개 스킬 확인
+npx skills add hoangsonww/Claude-Code-Agent-Monitor --list
+
+# 현재 프로젝트에 Claude Code와 Codex용 스킬 하나 설치
+npx skills add hoangsonww/Claude-Code-Agent-Monitor \
+  --skill mcp-server \
+  --agent claude-code \
+  --agent codex \
+  --yes
+
+# 프로젝트 범위 스킬 확인, 업데이트, 제거
+npx skills list --json
+npx skills update --project --yes
+npx skills remove mcp-server --yes
+
+# --global을 추가해 사용자 범위에 설치하고 해당 범위를 명시적으로 관리
+npx skills add hoangsonww/Claude-Code-Agent-Monitor \
+  --skill mcp-server \
+  --agent claude-code \
+  --agent codex \
+  --global \
+  --yes
+npx skills list --global --json
+npx skills update --global --yes
+npx skills remove --global mcp-server --yes
+```
+
+프로젝트 설치는 `.agents/skills/`와 Agent별 링크를 사용합니다. 전역 설치는 사용자 홈 디렉터리 아래의 해당 디렉터리를 사용합니다. skills.sh CLI는 66개 플러그인 스킬과 저장소 유지보수 스킬을 포함해 총 74개 저장소 스킬을 찾습니다.
+
 ### 사용 가능한 플러그인
 
 | 플러그인 | 설치 명령어 | 스킬 |

--- a/README-KO.md
+++ b/README-KO.md
@@ -1845,7 +1845,7 @@ npx skills update --global --yes
 npx skills remove --global mcp-server --yes
 ```
 
-프로젝트 설치는 `.agents/skills/`와 Agent별 링크를 사용합니다. 전역 설치는 사용자 홈 디렉터리 아래의 해당 디렉터리를 사용합니다. skills.sh CLI는 66개 플러그인 스킬과 저장소 유지보수 스킬을 포함해 총 74개 저장소 스킬을 찾습니다.
+프로젝트 설치는 `.agents/skills/`와 Agent별 링크를 사용합니다. 전역 Claude Code 스킬은 기본적으로 `~/.claude/skills/`에 설치되며, `CLAUDE_CONFIG_DIR`이 설정된 경우 해당 디렉터리의 `skills/` 아래에 설치됩니다. 전역 Codex 스킬은 기본적으로 `~/.codex/skills/`에 설치되며, `CODEX_HOME`이 설정된 경우 해당 디렉터리의 `skills/` 아래에 설치됩니다. 여러 Agent에 설치할 때는 공유 저장소에서 파일을 중복 제거한 뒤 해당 대상 디렉터리로 링크할 수 있습니다. skills.sh CLI는 66개 플러그인 스킬과 저장소 유지보수 스킬을 포함해 총 74개 저장소 스킬을 찾습니다.
 
 ### 사용 가능한 플러그인
 

--- a/README-VN.md
+++ b/README-VN.md
@@ -1779,7 +1779,7 @@ npx skills update --global --yes
 npx skills remove --global mcp-server --yes
 ```
 
-Bản cài theo dự án sử dụng `.agents/skills/` cùng các liên kết dành riêng cho từng agent. Bản cài toàn cục sử dụng các thư mục tương ứng trong thư mục home của người dùng. CLI skills.sh phát hiện 74 skill trong repo, gồm 66 skill plugin và các skill bảo trì repo.
+Bản cài theo dự án sử dụng `.agents/skills/` cùng các liên kết dành riêng cho từng agent. Skill Claude Code toàn cục mặc định nằm trong `~/.claude/skills/`, hoặc trong thư mục `skills/` của `CLAUDE_CONFIG_DIR` khi biến này được đặt. Skill Codex toàn cục mặc định nằm trong `~/.codex/skills/`, hoặc trong thư mục `skills/` của `CODEX_HOME` khi biến này được đặt. Bản cài nhiều agent có thể khử trùng lặp qua một kho dùng chung rồi tạo liên kết đến các thư mục đích đó. CLI skills.sh phát hiện 74 skill trong repo, gồm 66 skill plugin và các skill bảo trì repo.
 
 ### Các plugin có sẵn
 

--- a/README-VN.md
+++ b/README-VN.md
@@ -1749,6 +1749,38 @@ claude plugin marketplace add hoangsonww/Claude-Code-Agent-Monitor
 codex plugin marketplace add hoangsonww/Claude-Code-Agent-Monitor
 ```
 
+### Cài đặt skill bằng skills.sh
+
+```bash
+# Liệt kê toàn bộ 74 skill mà không cài đặt
+npx skills add hoangsonww/Claude-Code-Agent-Monitor --list
+
+# Cài một skill cho Claude Code và Codex trong dự án hiện tại
+npx skills add hoangsonww/Claude-Code-Agent-Monitor \
+  --skill mcp-server \
+  --agent claude-code \
+  --agent codex \
+  --yes
+
+# Xác minh, cập nhật và gỡ skill ở phạm vi dự án
+npx skills list --json
+npx skills update --project --yes
+npx skills remove mcp-server --yes
+
+# Thêm --global để cài ở phạm vi người dùng, rồi quản lý phạm vi đó
+npx skills add hoangsonww/Claude-Code-Agent-Monitor \
+  --skill mcp-server \
+  --agent claude-code \
+  --agent codex \
+  --global \
+  --yes
+npx skills list --global --json
+npx skills update --global --yes
+npx skills remove --global mcp-server --yes
+```
+
+Bản cài theo dự án sử dụng `.agents/skills/` cùng các liên kết dành riêng cho từng agent. Bản cài toàn cục sử dụng các thư mục tương ứng trong thư mục home của người dùng. CLI skills.sh phát hiện 74 skill trong repo, gồm 66 skill plugin và các skill bảo trì repo.
+
 ### Các plugin có sẵn
 
 | Trình cắm | Lệnh cài đặt | Kỹ năng |

--- a/README.md
+++ b/README.md
@@ -1847,9 +1847,32 @@ codex plugin add ccam-platform@claude-code-agent-monitor-plugins
 
 # Open Agent Skills / skills.sh-compatible CLI
 npx skills add hoangsonww/Claude-Code-Agent-Monitor --list
+
+# Install one skill for Claude Code and Codex in the current project
+npx skills add hoangsonww/Claude-Code-Agent-Monitor \
+  --skill mcp-server \
+  --agent claude-code \
+  --agent codex \
+  --yes
+
+# Verify, update, and remove the project-scoped skill
+npx skills list --json
+npx skills update --project --yes
+npx skills remove mcp-server --yes
+
+# Add --global to install at user scope, then manage that scope explicitly
+npx skills add hoangsonww/Claude-Code-Agent-Monitor \
+  --skill mcp-server \
+  --agent claude-code \
+  --agent codex \
+  --global \
+  --yes
+npx skills list --global --json
+npx skills update --global --yes
+npx skills remove --global mcp-server --yes
 ```
 
-The `skills` CLI discovers **74 total repository skills**, including the 66 plugin skills and repository-maintenance skills. Every plugin skill has canonical `name`/`description` frontmatter and `agents/openai.yaml` metadata. No upstream PR to `vercel-labs/skills` is needed for installation. The public GitHub repository is the source, and skills.sh visibility follows publication and real install telemetry.
+The `skills` CLI discovers **74 total repository skills**, including the 66 plugin skills and repository-maintenance skills. Project installs use `.agents/skills/` plus agent-specific links; global installs use the corresponding directories under the user's home directory. Every plugin skill has canonical `name`/`description` frontmatter and `agents/openai.yaml` metadata. No upstream PR to `vercel-labs/skills` is needed for installation. The public GitHub repository is the source, and skills.sh visibility follows publication and real install telemetry.
 
 New focused packs complement the existing analytics, productivity, quality, sessions, workflows, config, and dashboard plugins:
 

--- a/README.md
+++ b/README.md
@@ -1872,7 +1872,7 @@ npx skills update --global --yes
 npx skills remove --global mcp-server --yes
 ```
 
-The `skills` CLI discovers **74 total repository skills**, including the 66 plugin skills and repository-maintenance skills. Project installs use `.agents/skills/` plus agent-specific links; global installs use the corresponding directories under the user's home directory. Every plugin skill has canonical `name`/`description` frontmatter and `agents/openai.yaml` metadata. No upstream PR to `vercel-labs/skills` is needed for installation. The public GitHub repository is the source, and skills.sh visibility follows publication and real install telemetry.
+The `skills` CLI discovers **74 total repository skills**, including the 66 plugin skills and repository-maintenance skills. Project installs use `.agents/skills/` plus agent-specific links. Global Claude Code skills default to `~/.claude/skills/`, or `$CLAUDE_CONFIG_DIR/skills/` when set. Global Codex skills default to `~/.codex/skills/`, or `$CODEX_HOME/skills/` when set. Multi-agent installs may deduplicate files through a shared store and link those destinations. Every plugin skill has canonical `name`/`description` frontmatter and `agents/openai.yaml` metadata. No upstream PR to `vercel-labs/skills` is needed for installation. The public GitHub repository is the source, and skills.sh visibility follows publication and real install telemetry.
 
 New focused packs complement the existing analytics, productivity, quality, sessions, workflows, config, and dashboard plugins:
 

--- a/client/src/pages/__tests__/__snapshots__/screens.snapshot.test.tsx.snap
+++ b/client/src/pages/__tests__/__snapshots__/screens.snapshot.test.tsx.snap
@@ -10553,7 +10553,7 @@ exports[`screen snapshots > Settings 1`] = `
             <p
               class="text-[10px] text-amber-400/90 mt-1"
             >
-              UI build v2.0.1 (rebuild client to match)
+              UI build v2.0.2 (rebuild client to match)
             </p>
           </div>
           <div

--- a/deployments/helm/agent-monitor/Chart.yaml
+++ b/deployments/helm/agent-monitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agent-monitor
 description: Production-safe single-writer CCAM deployment for Claude Code and Codex monitoring
 type: application
-version: 2.0.1
-appVersion: "2.0.1"
+version: 2.0.2
+appVersion: "2.0.2"
 
 home: https://github.com/hoangsonww/Claude-Code-Agent-Monitor
 sources:

--- a/deployments/kubernetes/base/configmap.yaml
+++ b/deployments/kubernetes/base/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: agent-monitor
     app.kubernetes.io/instance: agent-monitor
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/component: config
     app.kubernetes.io/managed-by: kustomize
 data:

--- a/deployments/kubernetes/base/deployment.yaml
+++ b/deployments/kubernetes/base/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: agent-monitor
     app.kubernetes.io/instance: agent-monitor
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/component: server
     app.kubernetes.io/managed-by: kustomize
 spec:
@@ -25,7 +25,7 @@ spec:
       labels:
         app.kubernetes.io/name: agent-monitor
         app.kubernetes.io/instance: agent-monitor
-        app.kubernetes.io/version: "2.0.1"
+        app.kubernetes.io/version: "2.0.2"
         app.kubernetes.io/component: server
         app.kubernetes.io/managed-by: kustomize
     spec:
@@ -44,7 +44,7 @@ spec:
 
       containers:
         - name: agent-monitor
-          image: ccam-dashboard:2.0.1
+          image: ccam-dashboard:2.0.2
           imagePullPolicy: IfNotPresent
 
           ports:

--- a/deployments/kubernetes/base/ingress.yaml
+++ b/deployments/kubernetes/base/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: agent-monitor
     app.kubernetes.io/instance: agent-monitor
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/component: ingress
     app.kubernetes.io/managed-by: kustomize
   annotations:

--- a/deployments/kubernetes/base/kustomization.yaml
+++ b/deployments/kubernetes/base/kustomization.yaml
@@ -8,7 +8,7 @@ labels:
   - pairs:
       app.kubernetes.io/name: agent-monitor
       app.kubernetes.io/instance: agent-monitor
-      app.kubernetes.io/version: "2.0.1"
+      app.kubernetes.io/version: "2.0.2"
       app.kubernetes.io/managed-by: kustomize
 
 resources:
@@ -23,4 +23,4 @@ resources:
 
 images:
   - name: ccam-dashboard
-    newTag: 2.0.1
+    newTag: 2.0.2

--- a/deployments/kubernetes/base/namespace.yaml
+++ b/deployments/kubernetes/base/namespace.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: agent-monitor
     app.kubernetes.io/instance: agent-monitor
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/component: namespace
     app.kubernetes.io/managed-by: kustomize
     # Enable Pod Security Standards (restricted)

--- a/deployments/kubernetes/base/networkpolicy.yaml
+++ b/deployments/kubernetes/base/networkpolicy.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: agent-monitor
     app.kubernetes.io/instance: agent-monitor
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/component: network
     app.kubernetes.io/managed-by: kustomize
 spec:

--- a/deployments/kubernetes/base/pvc.yaml
+++ b/deployments/kubernetes/base/pvc.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: agent-monitor
     app.kubernetes.io/instance: agent-monitor
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/component: storage
     app.kubernetes.io/managed-by: kustomize
 spec:

--- a/deployments/kubernetes/base/service.yaml
+++ b/deployments/kubernetes/base/service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: agent-monitor
     app.kubernetes.io/instance: agent-monitor
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/component: server
     app.kubernetes.io/managed-by: kustomize
 spec:

--- a/deployments/kubernetes/base/serviceaccount.yaml
+++ b/deployments/kubernetes/base/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: agent-monitor
     app.kubernetes.io/instance: agent-monitor
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/component: serviceaccount
     app.kubernetes.io/managed-by: kustomize
 automountServiceAccountToken: false

--- a/deployments/kubernetes/components/mcp-sidecar/deployment-patch.yaml
+++ b/deployments/kubernetes/components/mcp-sidecar/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: mcp-sidecar
-          image: ccam-mcp:2.0.1
+          image: ccam-mcp:2.0.2
           imagePullPolicy: IfNotPresent
 
           ports:

--- a/deployments/kubernetes/components/mcp-sidecar/kustomization.yaml
+++ b/deployments/kubernetes/components/mcp-sidecar/kustomization.yaml
@@ -16,4 +16,4 @@ patches:
 
 images:
   - name: ccam-mcp
-    newTag: 2.0.1
+    newTag: 2.0.2

--- a/deployments/kubernetes/components/monitoring/servicemonitor.yaml
+++ b/deployments/kubernetes/components/monitoring/servicemonitor.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: agent-monitor
     app.kubernetes.io/instance: agent-monitor
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/component: monitoring
     app.kubernetes.io/managed-by: kustomize
     # Common label for Prometheus Operator discovery

--- a/deployments/kubernetes/overlays/dev/kustomization.yaml
+++ b/deployments/kubernetes/overlays/dev/kustomization.yaml
@@ -11,7 +11,7 @@ resources:
 
 images:
   - name: ccam-dashboard
-    newTag: 2.0.1
+    newTag: 2.0.2
 
 patches:
   - path: patches/deployment-patch.yaml

--- a/deployments/kubernetes/overlays/production/kustomization.yaml
+++ b/deployments/kubernetes/overlays/production/kustomization.yaml
@@ -31,4 +31,4 @@ patches:
 
 images:
   - name: ccam-dashboard
-    newTag: 2.0.1
+    newTag: 2.0.2

--- a/deployments/kubernetes/overlays/staging/kustomization.yaml
+++ b/deployments/kubernetes/overlays/staging/kustomization.yaml
@@ -31,4 +31,4 @@ patches:
 
 images:
   - name: ccam-dashboard
-    newTag: 2.0.1
+    newTag: 2.0.2

--- a/deployments/scripts/deploy.sh
+++ b/deployments/scripts/deploy.sh
@@ -85,7 +85,7 @@ ${BOLD}Options:${NC}
 
 ${BOLD}Examples:${NC}
   $(basename "$0") --env dev --method helm
-  $(basename "$0") --env production --method helm --tag v2.0.1
+  $(basename "$0") --env production --method helm --tag v2.0.2
   $(basename "$0") --env staging --method kustomize --dry-run
 
 EOF
@@ -299,7 +299,7 @@ deploy_kustomize() {
 
   local rendered
   rendered="$(mktemp)"
-  kubectl kustomize "${overlay_dir}" | sed "s|ccam-dashboard:2.0.1|${FULL_IMAGE}|g" > "${rendered}"
+  kubectl kustomize "${overlay_dir}" | sed "s|ccam-dashboard:2.0.2|${FULL_IMAGE}|g" > "${rendered}"
   if ! kubectl apply -f "${rendered}" --server-side --field-manager=ccam-deployer; then
     rm -f "${rendered}"
     err "Kustomize deployment failed!"

--- a/deployments/scripts/validate-deployment.sh
+++ b/deployments/scripts/validate-deployment.sh
@@ -24,6 +24,8 @@ audit_production_dependencies() {
 
   if [[ ! "$retry_base_seconds" =~ ^[0-9]+$ ]]; then
     retry_base_seconds=2
+  else
+    retry_base_seconds=$((10#$retry_base_seconds))
   fi
 
   while (( attempt <= max_attempts )); do

--- a/deployments/scripts/validate-deployment.sh
+++ b/deployments/scripts/validate-deployment.sh
@@ -14,6 +14,70 @@ readonly KUSTOMIZE_DIR="${PROJECT_ROOT}/deployments/kubernetes"
 log() { printf '[deployment-check] %s\n' "$*"; }
 fatal() { printf '[deployment-check] ERROR: %s\n' "$*" >&2; exit 1; }
 
+audit_production_dependencies() {
+  local label="$1"
+  shift
+  local attempt=1
+  local max_attempts=3
+  local retry_base_seconds="${CCAM_AUDIT_RETRY_BASE_SECONDS:-2}"
+  local output errors status vulnerabilities stdout_file stderr_file
+
+  if [[ ! "$retry_base_seconds" =~ ^[0-9]+$ ]]; then
+    retry_base_seconds=2
+  fi
+
+  while (( attempt <= max_attempts )); do
+    stdout_file="$(mktemp)"
+    stderr_file="$(mktemp)"
+    "$@" audit --omit=dev --json >"$stdout_file" 2>"$stderr_file" && status=0 || status=$?
+    output="$(cat "$stdout_file")"
+    errors="$(cat "$stderr_file")"
+    rm -f "$stdout_file" "$stderr_file"
+    if ! vulnerabilities="$(
+      printf '%s' "$output" | node -e '
+        let body = "";
+        process.stdin.setEncoding("utf8");
+        process.stdin.on("data", (chunk) => (body += chunk));
+        process.stdin.on("end", () => {
+          try {
+            const parsed = JSON.parse(body);
+            const count = Number(parsed?.metadata?.vulnerabilities?.total);
+            if (!Number.isFinite(count)) process.exit(2);
+            process.stdout.write(String(count));
+          } catch {
+            process.exit(2);
+          }
+        });
+      '
+    )"; then
+      if (( attempt < max_attempts )); then
+        log "${label} audit transport failure (attempt ${attempt}/${max_attempts}); retrying"
+        [[ -n "$errors" ]] && printf '%s\n' "$errors" >&2
+        [[ -n "$output" ]] && printf '%s\n' "$output" >&2
+        sleep $(( attempt * retry_base_seconds ))
+        ((attempt += 1))
+        continue
+      fi
+      [[ -n "$errors" ]] && printf '%s\n' "$errors" >&2
+      [[ -n "$output" ]] && printf '%s\n' "$output" >&2
+      fatal "${label} audit could not retrieve a valid registry report after ${max_attempts} attempts"
+    fi
+
+    if (( vulnerabilities > 0 )); then
+      [[ -n "$errors" ]] && printf '%s\n' "$errors" >&2
+      printf '%s\n' "$output" >&2
+      fatal "${label} production dependency audit found ${vulnerabilities} vulnerability record(s)"
+    fi
+    if (( status != 0 )); then
+      [[ -n "$errors" ]] && printf '%s\n' "$errors" >&2
+      printf '%s\n' "$output" >&2
+      fatal "${label} production dependency audit exited ${status} despite reporting zero vulnerabilities"
+    fi
+    log "${label} production dependency audit passed"
+    return
+  done
+}
+
 need() {
   command -v "$1" >/dev/null 2>&1 || fatal "missing required command: $1"
 }
@@ -134,8 +198,8 @@ YAML
 
 validate_repo() {
   log "Production dependency audits"
-  (cd "${PROJECT_ROOT}" && npm audit --omit=dev >/dev/null)
-  (cd "${PROJECT_ROOT}" && npm --prefix mcp audit --omit=dev >/dev/null)
+  (cd "${PROJECT_ROOT}" && audit_production_dependencies "root" npm)
+  (cd "${PROJECT_ROOT}" && audit_production_dependencies "MCP" npm --prefix mcp)
   log "Authorship headers"
   bash "${PROJECT_ROOT}/.claude/skills/file-headers/scripts/check-headers.sh" >/dev/null
 }
@@ -176,4 +240,6 @@ main() {
   log "all deployment checks passed"
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/deployments/scripts/validate-deployment.sh
+++ b/deployments/scripts/validate-deployment.sh
@@ -56,7 +56,9 @@ audit_production_dependencies() {
         log "${label} audit transport failure (attempt ${attempt}/${max_attempts}); retrying"
         [[ -n "$errors" ]] && printf '%s\n' "$errors" >&2
         [[ -n "$output" ]] && printf '%s\n' "$output" >&2
-        sleep $(( attempt * retry_base_seconds ))
+        local retry_delay=$(( attempt * retry_base_seconds ))
+        log "${label} audit retrying after ${retry_delay}s"
+        sleep "$retry_delay"
         ((attempt += 1))
         continue
       fi

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-dashboard-desktop",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-dashboard-desktop",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-dashboard-desktop",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "private": true,
   "description": "Native macOS and Windows desktop shell for Claude Code Agent Monitor.",
   "author": "Son Nguyen <hoangson091104@gmail.com>",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ name: ccam
 # or run two active containers against the same data volume.
 services:
   agent-monitor:
-    image: ${CCAM_IMAGE:-ccam-dashboard:2.0.1}
+    image: ${CCAM_IMAGE:-ccam-dashboard:2.0.2}
     build:
       context: .
       dockerfile: Dockerfile
@@ -62,7 +62,7 @@ services:
   # Compose network and publishes MCP on host loopback only.
   mcp:
     profiles: ["mcp"]
-    image: ${CCAM_MCP_IMAGE:-ccam-mcp:2.0.1}
+    image: ${CCAM_MCP_IMAGE:-ccam-mcp:2.0.2}
     build:
       context: .
       dockerfile: mcp/Dockerfile

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -45,6 +45,8 @@ npm run deploy:validate
 
 It checks Dockerfiles, Compose profiles, Nginx syntax, Helm lint and schema rejection, every Kustomize overlay and optional component, Terraform formatting/provider validation, production dependency audits, file headers, and the one-writer invariant.
 
+The dependency audit retries malformed registry or transport responses up to three times with bounded backoff. A valid report containing any vulnerability fails immediately and prints the complete audit payload; malformed reports never pass as clean.
+
 ## Secrets
 
 Production deployments use three independent tokens:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -193,7 +193,7 @@ Render and replace the local image name with an immutable registry reference:
 REGISTRY="ghcr.io/$(gh repo view --json owner -q .owner.login)"
 IMAGE_TAG="$(git rev-parse --short HEAD)"
 kubectl kustomize deployments/kubernetes/overlays/production \
-  | sed "s|ccam-dashboard:2.0.1|${REGISTRY}/claude-code-agent-monitor:${IMAGE_TAG}|g" \
+  | sed "s|ccam-dashboard:2.0.2|${REGISTRY}/claude-code-agent-monitor:${IMAGE_TAG}|g" \
   | kubectl apply --server-side --field-manager=ccam-deployer -f -
 ```
 

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -73,7 +73,7 @@ npx skills remove mcp-server --yes
 npx skills remove --global mcp-server --yes
 ```
 
-Project installs use the current repository's `.agents/skills/` directory and create agent-specific links such as `.claude/skills/mcp-server`. Global installs use the corresponding directories under the user's home directory. The CLI records source and hash metadata in `skills-lock.json` for project installs and `~/.agents/.skill-lock.json` for global installs so later `skills update` runs can check the original GitHub source.
+Project installs use the current repository's `.agents/skills/` directory and create agent-specific links such as `.claude/skills/mcp-server`. By default, global Claude Code skills resolve under `~/.claude/skills/` and global Codex skills under `~/.codex/skills/`; `CLAUDE_CONFIG_DIR` and `CODEX_HOME` replace those respective base directories. Multi-agent installs may deduplicate files through a shared store and link the agent-specific destinations. The CLI records source and hash metadata in `skills-lock.json` for project installs and a global skill lockfile so later `skills update` runs can check the original GitHub source.
 
 Every bundled skill carries:
 

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -40,15 +40,40 @@ The repository does not need a PR to the `vercel-labs/skills` source repository.
 # List all 74 repository skills without installing
 npx skills add hoangsonww/Claude-Code-Agent-Monitor --list
 
-# Install one skill for Claude Code and Codex
+# Install one skill into the current project for Claude Code and Codex
 npx skills add hoangsonww/Claude-Code-Agent-Monitor \
   --skill mcp-server \
   --agent claude-code \
-  --agent codex
+  --agent codex \
+  --yes
 
-# Install all discovered skills
+# Verify project-scoped installation
+npx skills list --json
+
+# Install the same skill globally for both agents
+npx skills add hoangsonww/Claude-Code-Agent-Monitor \
+  --skill mcp-server \
+  --agent claude-code \
+  --agent codex \
+  --global \
+  --yes
+
+# Verify global installation
+npx skills list --global --json
+
+# Install all discovered skills for every supported agent in the current project
 npx skills add hoangsonww/Claude-Code-Agent-Monitor --all
+
+# Update project-scoped or global skills
+npx skills update --project --yes
+npx skills update --global --yes
+
+# Remove the selected skill from the current project or global scope
+npx skills remove mcp-server --yes
+npx skills remove --global mcp-server --yes
 ```
+
+Project installs use the current repository's `.agents/skills/` directory and create agent-specific links such as `.claude/skills/mcp-server`. Global installs use the corresponding directories under the user's home directory. The CLI records source and hash metadata in `skills-lock.json` for project installs and `~/.agents/.skill-lock.json` for global installs so later `skills update` runs can check the original GitHub source.
 
 Every bundled skill carries:
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.0.3
 info:
   title: Agent Dashboard for Claude Code API
-  version: 2.0.1
+  version: 2.0.2
   description: HTTP API for real-time Claude Code session monitoring, agent lifecycle tracking, analytics, pricing, hooks ingestion, and workflow intelligence.
   contact:
     name: Son Nguyen
@@ -382,7 +382,7 @@ components:
         version:
           type: string
           description: Dashboard release version from package.json
-          example: 2.0.1
+          example: 2.0.2
         timestamp:
           type: string
           format: date-time

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-dashboard",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-dashboard",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -139,28 +139,6 @@
         "npm": ">=9.5.0"
       }
     },
-    "node_modules/@redocly/openapi-core/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/@scarf/scarf": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -128,6 +128,9 @@
   "optionalDependencies": {
     "better-sqlite3": "^12.0.0"
   },
+  "overrides": {
+    "js-yaml": "4.3.1"
+  },
   "devDependencies": {
     "concurrently": "^9.1.2",
     "js-yaml": "4.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-dashboard",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "bin": {
     "ccam": "bin/ccam.js"
   },

--- a/plugins/ccam-analytics/.claude-plugin/plugin.json
+++ b/plugins/ccam-analytics/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccam-analytics",
   "description": "Deep analytics and monitoring for Claude Code sessions — cost tracking, token usage breakdowns, usage trends, and productivity scoring powered by Agent Monitor.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": { "name": "Son Nguyen", "url": "https://github.com/hoangsonww" },
   "homepage": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",
   "repository": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",

--- a/plugins/ccam-analytics/.codex-plugin/plugin.json
+++ b/plugins/ccam-analytics/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ccam-analytics",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Deep analytics and monitoring for Claude Code sessions — cost tracking, token usage breakdowns, usage trends, and productivity scoring powered by Agent Monitor.",
   "author": {
     "name": "Son Nguyen",

--- a/plugins/ccam-config/.claude-plugin/plugin.json
+++ b/plugins/ccam-config/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccam-config",
   "description": "Audit and govern your Claude Code configuration and file-based memory via the Agent Monitor Config Explorer API — skills, subagents, commands, MCP servers, hooks, settings, and the per-project memory store. Surfaces sprawl, duplication, risky hooks, and stale facts, all read through the dashboard at http://localhost:4820.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": { "name": "Son Nguyen", "url": "https://github.com/hoangsonww" },
   "homepage": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",
   "repository": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",

--- a/plugins/ccam-config/.codex-plugin/plugin.json
+++ b/plugins/ccam-config/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ccam-config",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Audit and govern your Claude Code configuration and file-based memory via the Agent Monitor Config Explorer API — skills, subagents, commands, MCP servers, hooks, settings, and the per-project memory store. Surfaces sprawl, duplication, risky hooks, and stale facts, all read through the dashboard at http://localhost:4820.",
   "author": {
     "name": "Son Nguyen",

--- a/plugins/ccam-cost-guard/.claude-plugin/plugin.json
+++ b/plugins/ccam-cost-guard/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccam-cost-guard",
   "description": "Budget tracking, spend forecasting, and cost-threshold alerts for Claude Code usage via the Agent Monitor pricing engine. Watches spend against a target budget, projects month-end cost from the daily trend, surfaces the priciest sessions, estimates savings from cheaper-model routing, and wires up cost alert rules — all backed by the dashboard at http://localhost:4820.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": { "name": "Son Nguyen", "url": "https://github.com/hoangsonww" },
   "homepage": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",
   "repository": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",

--- a/plugins/ccam-cost-guard/.codex-plugin/plugin.json
+++ b/plugins/ccam-cost-guard/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ccam-cost-guard",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Budget tracking, spend forecasting, and cost-threshold alerts for Claude Code usage via the Agent Monitor pricing engine. Watches spend against a target budget, projects month-end cost from the daily trend, surfaces the priciest sessions, estimates savings from cheaper-model routing, and wires up cost alert rules — all backed by the dashboard at http://localhost:4820.",
   "author": {
     "name": "Son Nguyen",

--- a/plugins/ccam-dashboard/.claude-plugin/plugin.json
+++ b/plugins/ccam-dashboard/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccam-dashboard",
   "description": "Direct MCP integration with the Claude Code Agent Monitor dashboard — real-time session data access, quick stats, and dashboard health monitoring via Model Context Protocol.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": { "name": "Son Nguyen", "url": "https://github.com/hoangsonww" },
   "homepage": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",
   "repository": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",

--- a/plugins/ccam-dashboard/.codex-plugin/plugin.json
+++ b/plugins/ccam-dashboard/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ccam-dashboard",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Direct MCP integration with the Claude Code Agent Monitor dashboard — real-time session data access, quick stats, and dashboard health monitoring via Model Context Protocol.",
   "author": {
     "name": "Son Nguyen",

--- a/plugins/ccam-devtools/.claude-plugin/plugin.json
+++ b/plugins/ccam-devtools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccam-devtools",
   "description": "Developer tools for Claude Code Agent Monitor — session debugging, hook diagnostics, data export, and system health checks for maintaining a healthy monitoring setup.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": { "name": "Son Nguyen", "url": "https://github.com/hoangsonww" },
   "homepage": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",
   "repository": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",

--- a/plugins/ccam-devtools/.codex-plugin/plugin.json
+++ b/plugins/ccam-devtools/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ccam-devtools",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Developer tools for Claude Code Agent Monitor — session debugging, hook diagnostics, data export, and system health checks for maintaining a healthy monitoring setup.",
   "author": {
     "name": "Son Nguyen",

--- a/plugins/ccam-insights/.claude-plugin/plugin.json
+++ b/plugins/ccam-insights/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccam-insights",
   "description": "AI-powered insights for Claude Code — pattern detection, anomaly alerting, optimization recommendations, and session comparison using Agent Monitor analytics.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": { "name": "Son Nguyen", "url": "https://github.com/hoangsonww" },
   "homepage": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",
   "repository": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",

--- a/plugins/ccam-insights/.codex-plugin/plugin.json
+++ b/plugins/ccam-insights/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ccam-insights",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "AI-powered insights for Claude Code — pattern detection, anomaly alerting, optimization recommendations, and session comparison using Agent Monitor analytics.",
   "author": {
     "name": "Son Nguyen",

--- a/plugins/ccam-integrations/.claude-plugin/plugin.json
+++ b/plugins/ccam-integrations/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccam-integrations",
   "description": "Manage CCAM alert rules, universal webhook providers, browser push notifications, and SSH Remote Data Sources with explicit mutation and external-send confirmation.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": { "name": "Son Nguyen", "url": "https://github.com/hoangsonww" },
   "homepage": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",
   "repository": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",

--- a/plugins/ccam-integrations/.codex-plugin/plugin.json
+++ b/plugins/ccam-integrations/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ccam-integrations",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Manage CCAM alert rules, universal webhook providers, browser push notifications, and SSH Remote Data Sources with explicit mutation and external-send confirmation.",
   "author": {
     "name": "Son Nguyen",

--- a/plugins/ccam-platform/.claude-plugin/plugin.json
+++ b/plugins/ccam-platform/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccam-platform",
   "description": "Administer CCAM's Claude Code and Codex configuration explorers, provider-aware history import, backup restore, hook installation, home directories, updates, and MCP server.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": { "name": "Son Nguyen", "url": "https://github.com/hoangsonww" },
   "homepage": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",
   "repository": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",

--- a/plugins/ccam-platform/.codex-plugin/plugin.json
+++ b/plugins/ccam-platform/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ccam-platform",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Administer CCAM's Claude Code and Codex configuration explorers, provider-aware history import, backup restore, hook installation, home directories, updates, and MCP server.",
   "author": {
     "name": "Son Nguyen",

--- a/plugins/ccam-productivity/.claude-plugin/plugin.json
+++ b/plugins/ccam-productivity/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccam-productivity",
   "description": "Productivity workflows for Claude Code — daily standups, weekly reports, sprint summaries, and intelligent workflow optimization powered by Agent Monitor session data.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": { "name": "Son Nguyen", "url": "https://github.com/hoangsonww" },
   "homepage": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",
   "repository": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",

--- a/plugins/ccam-productivity/.codex-plugin/plugin.json
+++ b/plugins/ccam-productivity/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ccam-productivity",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Productivity workflows for Claude Code — daily standups, weekly reports, sprint summaries, and intelligent workflow optimization powered by Agent Monitor session data.",
   "author": {
     "name": "Son Nguyen",

--- a/plugins/ccam-quality/.claude-plugin/plugin.json
+++ b/plugins/ccam-quality/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccam-quality",
   "description": "Reliability and error monitoring for Claude Code sessions — surfaces APIError events, hook delivery failures, tool-failure ratios (PreToolUse/PostToolUse gaps), and SLO tracking with error-budget reporting, all derived from the Claude Code Agent Monitor event stream at http://localhost:4820.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": { "name": "Son Nguyen", "url": "https://github.com/hoangsonww" },
   "homepage": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",
   "repository": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",

--- a/plugins/ccam-quality/.codex-plugin/plugin.json
+++ b/plugins/ccam-quality/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ccam-quality",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Reliability and error monitoring for Claude Code sessions — surfaces APIError events, hook delivery failures, tool-failure ratios (PreToolUse/PostToolUse gaps), and SLO tracking with error-budget reporting, all derived from the Claude Code Agent Monitor event stream at http://localhost:4820.",
   "author": {
     "name": "Son Nguyen",

--- a/plugins/ccam-reports/.claude-plugin/plugin.json
+++ b/plugins/ccam-reports/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccam-reports",
   "description": "Generate stakeholder-ready CCAM reports from local session, cost, reliability, and workflow data with explicit scope, evidence, and export-friendly Markdown.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": { "name": "Son Nguyen", "url": "https://github.com/hoangsonww" },
   "homepage": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",
   "repository": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",

--- a/plugins/ccam-reports/.codex-plugin/plugin.json
+++ b/plugins/ccam-reports/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ccam-reports",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Generate stakeholder-ready CCAM reports from local session, cost, reliability, and workflow data with explicit scope, evidence, and export-friendly Markdown.",
   "author": {
     "name": "Son Nguyen",

--- a/plugins/ccam-runner/.claude-plugin/plugin.json
+++ b/plugins/ccam-runner/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccam-runner",
   "description": "Operate dashboard-launched Claude Code and Codex runs with safe launch, follow-up, stop, resume, model discovery, and persistent run-history workflows.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": { "name": "Son Nguyen", "url": "https://github.com/hoangsonww" },
   "homepage": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",
   "repository": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",

--- a/plugins/ccam-runner/.codex-plugin/plugin.json
+++ b/plugins/ccam-runner/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ccam-runner",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Operate dashboard-launched Claude Code and Codex runs with safe launch, follow-up, stop, resume, model discovery, and persistent run-history workflows.",
   "author": {
     "name": "Son Nguyen",

--- a/plugins/ccam-sessions/.claude-plugin/plugin.json
+++ b/plugins/ccam-sessions/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccam-sessions",
   "description": "Search, inspect, replay, and manage Claude Code sessions tracked by the Agent Monitor dashboard — find sessions by project, model, status, or date; reconstruct event timelines; walk transcripts turn-by-turn; roll up activity per working directory; and identify stale or empty sessions before cleanup.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": { "name": "Son Nguyen", "url": "https://github.com/hoangsonww" },
   "homepage": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",
   "repository": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",

--- a/plugins/ccam-sessions/.codex-plugin/plugin.json
+++ b/plugins/ccam-sessions/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ccam-sessions",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Search, inspect, replay, and manage Claude Code sessions tracked by the Agent Monitor dashboard — find sessions by project, model, status, or date; reconstruct event timelines; walk transcripts turn-by-turn; roll up activity per working directory; and identify stale or empty sessions before cleanup.",
   "author": {
     "name": "Son Nguyen",

--- a/plugins/ccam-workflows/.claude-plugin/plugin.json
+++ b/plugins/ccam-workflows/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccam-workflows",
   "description": "Analyze multi-agent orchestration and Workflow-tool fleet runs — DAGs, delegation, concurrency, error propagation, and effectiveness — via the Agent Monitor workflow intelligence API at http://localhost:4820. Maps parent→child subagent edges, scores model delegation and subagent success, surfaces concurrency lanes and serialization bottlenecks, and traces error cascades by agent depth.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": { "name": "Son Nguyen", "url": "https://github.com/hoangsonww" },
   "homepage": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",
   "repository": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",

--- a/plugins/ccam-workflows/.codex-plugin/plugin.json
+++ b/plugins/ccam-workflows/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ccam-workflows",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Analyze multi-agent orchestration and Workflow-tool fleet runs — DAGs, delegation, concurrency, error propagation, and effectiveness — via the Agent Monitor workflow intelligence API at http://localhost:4820. Maps parent→child subagent edges, scores model delegation and subagent success, surfaces concurrency lanes and serialization bottlenecks, and traces error cascades by agent depth.",
   "author": {
     "name": "Son Nguyen",

--- a/server/__tests__/deployment-audit-gate.test.js
+++ b/server/__tests__/deployment-audit-gate.test.js
@@ -15,10 +15,12 @@ const { spawnSync } = require("node:child_process");
 const ROOT = path.resolve(__dirname, "..", "..");
 const VALIDATOR = path.join(ROOT, "deployments", "scripts", "validate-deployment.sh");
 
-function runAuditScenario(fakeNpmBody) {
+function runAuditScenario(fakeNpmBody, retryBaseSeconds = "0") {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "ccam-audit-gate-"));
   const fakeNpm = path.join(tmp, "npm");
+  const fakeSleep = path.join(tmp, "sleep");
   const attempts = path.join(tmp, "attempts");
+  const delays = path.join(tmp, "delays");
   fs.writeFileSync(
     fakeNpm,
     `#!/usr/bin/env bash
@@ -32,6 +34,14 @@ ${fakeNpmBody}
 `
   );
   fs.chmodSync(fakeNpm, 0o755);
+  fs.writeFileSync(
+    fakeSleep,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$1" >>${JSON.stringify(delays)}
+`
+  );
+  fs.chmodSync(fakeSleep, 0o755);
 
   const command = `
     source ${JSON.stringify(VALIDATOR)}
@@ -42,14 +52,17 @@ ${fakeNpmBody}
     env: {
       ...process.env,
       PATH: `${tmp}:${process.env.PATH}`,
-      CCAM_AUDIT_RETRY_BASE_SECONDS: "0",
+      CCAM_AUDIT_RETRY_BASE_SECONDS: retryBaseSeconds,
     },
     encoding: "utf8",
     timeout: 15_000,
   });
   const attemptCount = Number(fs.readFileSync(attempts, "utf8"));
+  const retryDelays = fs.existsSync(delays)
+    ? fs.readFileSync(delays, "utf8").trim().split("\n").filter(Boolean)
+    : [];
   fs.rmSync(tmp, { recursive: true, force: true });
-  return { ...result, attemptCount };
+  return { ...result, attemptCount, retryDelays };
 }
 
 describe("deployment production dependency audit gate", () => {
@@ -92,6 +105,25 @@ exit 0
     assert.equal(result.status, 0, result.stderr);
     assert.equal(result.attemptCount, 3);
     assert.match(result.stdout, /transport failure .* retrying/);
+  });
+
+  it("treats a zero-padded retry base as decimal", () => {
+    const result = runAuditScenario(
+      `
+if [[ "$count" -eq 1 ]]; then
+  echo "registry connection reset" >&2
+  exit 1
+fi
+cat <<'JSON'
+{"metadata":{"vulnerabilities":{"total":0}}}
+JSON
+exit 0
+`,
+      "08"
+    );
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.attemptCount, 2);
+    assert.deepEqual(result.retryDelays, ["8"]);
   });
 
   it("fails immediately when the registry returns a real vulnerability report", () => {

--- a/server/__tests__/deployment-audit-gate.test.js
+++ b/server/__tests__/deployment-audit-gate.test.js
@@ -1,0 +1,119 @@
+/**
+ * @file Tests the deployment validator's production dependency audit gate.
+ * It verifies transient registry failures retry, vulnerability reports fail
+ * closed without retry, and successful audit reports pass deterministically.
+ * @author Son Nguyen <hoangson091104@gmail.com>
+ */
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const ROOT = path.resolve(__dirname, "..", "..");
+const VALIDATOR = path.join(ROOT, "deployments", "scripts", "validate-deployment.sh");
+
+function runAuditScenario(fakeNpmBody) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "ccam-audit-gate-"));
+  const fakeNpm = path.join(tmp, "npm");
+  const attempts = path.join(tmp, "attempts");
+  fs.writeFileSync(
+    fakeNpm,
+    `#!/usr/bin/env bash
+set -euo pipefail
+attempts_file=${JSON.stringify(attempts)}
+count=0
+[[ -f "$attempts_file" ]] && count="$(cat "$attempts_file")"
+count=$((count + 1))
+printf '%s' "$count" >"$attempts_file"
+${fakeNpmBody}
+`
+  );
+  fs.chmodSync(fakeNpm, 0o755);
+
+  const command = `
+    source ${JSON.stringify(VALIDATOR)}
+    audit_production_dependencies test npm
+  `;
+  const result = spawnSync("bash", ["-c", command], {
+    cwd: ROOT,
+    env: {
+      ...process.env,
+      PATH: `${tmp}:${process.env.PATH}`,
+      CCAM_AUDIT_RETRY_BASE_SECONDS: "0",
+    },
+    encoding: "utf8",
+    timeout: 15_000,
+  });
+  const attemptCount = Number(fs.readFileSync(attempts, "utf8"));
+  fs.rmSync(tmp, { recursive: true, force: true });
+  return { ...result, attemptCount };
+}
+
+describe("deployment production dependency audit gate", () => {
+  it("passes one valid zero-vulnerability report", () => {
+    const result = runAuditScenario(`
+cat <<'JSON'
+{"metadata":{"vulnerabilities":{"total":0}}}
+JSON
+exit 0
+`);
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.attemptCount, 1);
+    assert.match(result.stdout, /production dependency audit passed/);
+  });
+
+  it("accepts valid JSON when npm also prints a warning on stderr", () => {
+    const result = runAuditScenario(`
+echo "npm warn registry using cached advisory metadata" >&2
+cat <<'JSON'
+{"metadata":{"vulnerabilities":{"total":0}}}
+JSON
+exit 0
+`);
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.attemptCount, 1);
+    assert.match(result.stdout, /production dependency audit passed/);
+  });
+
+  it("retries malformed transport output and then accepts a valid report", () => {
+    const result = runAuditScenario(`
+if [[ "$count" -lt 3 ]]; then
+  echo "registry connection reset" >&2
+  exit 1
+fi
+cat <<'JSON'
+{"metadata":{"vulnerabilities":{"total":0}}}
+JSON
+exit 0
+`);
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.attemptCount, 3);
+    assert.match(result.stdout, /transport failure .* retrying/);
+  });
+
+  it("fails immediately when the registry returns a real vulnerability report", () => {
+    const result = runAuditScenario(`
+cat <<'JSON'
+{"vulnerabilities":{"js-yaml":{"severity":"high"}},"metadata":{"vulnerabilities":{"total":1}}}
+JSON
+exit 1
+`);
+    assert.notEqual(result.status, 0);
+    assert.equal(result.attemptCount, 1, "real vulnerabilities must not be retried");
+    assert.match(result.stderr, /found 1 vulnerability record/);
+    assert.match(result.stderr, /js-yaml/);
+  });
+
+  it("fails closed after repeated malformed reports", () => {
+    const result = runAuditScenario(`
+echo "not-json"
+exit 1
+`);
+    assert.notEqual(result.status, 0);
+    assert.equal(result.attemptCount, 3);
+    assert.match(result.stderr, /could not retrieve a valid registry report/);
+  });
+});

--- a/server/__tests__/deployment-audit-gate.test.js
+++ b/server/__tests__/deployment-audit-gate.test.js
@@ -105,6 +105,7 @@ exit 0
     assert.equal(result.status, 0, result.stderr);
     assert.equal(result.attemptCount, 3);
     assert.match(result.stdout, /transport failure .* retrying/);
+    assert.match(result.stdout, /audit retrying after 0s/);
   });
 
   it("treats a zero-padded retry base as decimal", () => {
@@ -124,6 +125,7 @@ exit 0
     assert.equal(result.status, 0, result.stderr);
     assert.equal(result.attemptCount, 2);
     assert.deepEqual(result.retryDelays, ["8"]);
+    assert.match(result.stdout, /audit retrying after 8s/);
   });
 
   it("fails immediately when the registry returns a real vulnerability report", () => {

--- a/server/__tests__/plugins-marketplace.test.js
+++ b/server/__tests__/plugins-marketplace.test.js
@@ -19,6 +19,50 @@ const PLUGINS_DIR = path.join(REPO_ROOT, "plugins");
 const MARKETPLACE = path.join(REPO_ROOT, ".claude-plugin", "marketplace.json");
 const CODEX_MARKETPLACE = path.join(REPO_ROOT, ".agents", "plugins", "marketplace.json");
 const PROJECT_VERSION = readJson(path.join(REPO_ROOT, "package.json")).version;
+const COUNTED_DOCS = [
+  {
+    file: path.join(REPO_ROOT, "README.md"),
+    plugin: /\b14 plugins\b/,
+    pluginSkills: /\b66 plugin skills\b/,
+    repositorySkills: /\b74 total repository skills\b/,
+  },
+  {
+    file: path.join(REPO_ROOT, "README-CN.md"),
+    plugin: /14 个共享插件/,
+    pluginSkills: /66 个插件技能/,
+    repositorySkills: /74 个仓库技能/,
+  },
+  {
+    file: path.join(REPO_ROOT, "README-ES.md"),
+    plugin: /14 plugins compartidos/,
+    pluginSkills: /66 habilidades empaquetadas/,
+    repositorySkills: /74 habilidades/,
+  },
+  {
+    file: path.join(REPO_ROOT, "README-KO.md"),
+    plugin: /14개 플러그인/,
+    pluginSkills: /66개 번들 스킬/,
+    repositorySkills: /74개 스킬/,
+  },
+  {
+    file: path.join(REPO_ROOT, "README-VN.md"),
+    plugin: /14 plugin/,
+    pluginSkills: /66 skill/,
+    repositorySkills: /74 skill/,
+  },
+  {
+    file: path.join(REPO_ROOT, "docs", "PLUGINS.md"),
+    plugin: /\b14 plugins\b/,
+    pluginSkills: /\b66 bundled plugin skills\b/,
+    repositorySkills: /\b74 total repository skills\b/,
+  },
+  {
+    file: path.join(REPO_ROOT, ".codex", "README.md"),
+    plugin: /\b14 shared plugins\b/,
+    pluginSkills: /\b66 bundled skills\b/,
+    repositorySkills: /\b74 repository skills\b/,
+  },
+];
 const WRITE_CAPABLE = new Set([
   "ccam-config",
   "ccam-cost-guard",
@@ -50,6 +94,16 @@ function listMd(dir) {
   }
 }
 
+function addSkillNamesFromDirectory(names, dir) {
+  for (const skillDir of listDirs(dir)) {
+    const file = path.join(dir, skillDir, "SKILL.md");
+    assert.ok(fs.existsSync(file), `${path.relative(REPO_ROOT, file)} must exist`);
+    const { frontmatter } = parseFrontmatter(fs.readFileSync(file, "utf8"));
+    assert.ok(frontmatter?.name, `${path.relative(REPO_ROOT, file)} must declare a skill name`);
+    names.add(frontmatter.name);
+  }
+}
+
 describe("plugin marketplace", () => {
   const marketplace = readJson(MARKETPLACE);
   const codexMarketplace = readJson(CODEX_MARKETPLACE);
@@ -68,6 +122,44 @@ describe("plugin marketplace", () => {
   it("ships the complete 14-plugin catalog", () => {
     assert.equal(marketplace.plugins.length, 14);
     assert.equal(pluginDirs.length, 14);
+  });
+
+  it("keeps documented marketplace totals in sync with the source tree", () => {
+    const pluginSkillCount = pluginDirs.reduce((total, dir) => {
+      const skillsDir = path.join(PLUGINS_DIR, dir, "skills");
+      return total + (fs.existsSync(skillsDir) ? listDirs(skillsDir).length : 0);
+    }, 0);
+    const uniqueSkillNames = new Set();
+    for (const dir of pluginDirs) {
+      addSkillNamesFromDirectory(uniqueSkillNames, path.join(PLUGINS_DIR, dir, "skills"));
+    }
+    for (const root of [".agents/skills", ".claude/skills", ".codex/skills"]) {
+      addSkillNamesFromDirectory(uniqueSkillNames, path.join(REPO_ROOT, root));
+    }
+    const repositorySkillCount = uniqueSkillNames.size;
+    const expected = {
+      pluginText: `${pluginDirs.length} plugins`,
+      pluginSkillText: `${pluginSkillCount} bundled`,
+      repositorySkillText: `${repositorySkillCount} repository skills`,
+    };
+
+    assert.equal(pluginSkillCount, 66);
+    assert.equal(repositorySkillCount, 74);
+    for (const { file, plugin, pluginSkills, repositorySkills } of COUNTED_DOCS) {
+      const text = fs.readFileSync(file, "utf8");
+      assert.ok(
+        plugin.test(text),
+        `${path.relative(REPO_ROOT, file)} must mention ${expected.pluginText}`
+      );
+      assert.ok(
+        pluginSkills.test(text),
+        `${path.relative(REPO_ROOT, file)} must mention ${expected.pluginSkillText}`
+      );
+      assert.ok(
+        repositorySkills.test(text),
+        `${path.relative(REPO_ROOT, file)} must mention ${expected.repositorySkillText}`
+      );
+    }
   });
 
   it("marketplace entries and plugin dirs are a bijection", () => {

--- a/server/openapi.js
+++ b/server/openapi.js
@@ -355,7 +355,7 @@ function createOpenApiSpec() {
             version: {
               type: "string",
               description: "Dashboard release version from package.json",
-              example: "2.0.1",
+              example: "2.0.2",
             },
             timestamp: { type: "string", format: "date-time" },
           },


### PR DESCRIPTION
## Summary

Restores every change from #271 after resetting `master` to the pre-#271 commit, then completes the skills.sh installation documentation for Claude Code and Codex.

## Changes

- restores the patched `js-yaml` production dependency resolution and fail-closed, transport-retry-aware deployment audit gate from #271
- preserves the full #271 deployment documentation and regression test coverage
- documents tested project and global skills.sh install, list, update, and removal workflows
- corrects stale Codex marketplace totals to 14 plugins, 66 bundled plugin skills, and 74 repository skills
- mirrors the skills.sh lifecycle across the English, Chinese, Vietnamese, Korean, and Spanish READMEs
- leaves all Mermaid diagrams unchanged

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (no functional changes)
- [x] Documentation update
- [x] Infrastructure / CI / DevOps
- [x] Dependency update

## How to Test

1. Run `npm run test:server` and confirm 898 tests pass.
2. Run `npm run test:client` and confirm 314 tests pass.
3. Run `npm run build`.
4. Start Docker and run `npm run deploy:validate`.
5. Run `npm run extensions:validate`.
6. Run `npx skills add hoangsonww/Claude-Code-Agent-Monitor --list` and confirm it finds 74 skills.
7. Run the isolated project and global lifecycle commands documented in `docs/PLUGINS.md`.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/hoangsonww/Claude-Code-Agent-Monitor/blob/master/.github/CONTRIBUTING.md)
- [x] I have signed the [CLA](https://github.com/hoangsonww/Claude-Code-Agent-Monitor/blob/master/CLA.md)
- [x] My code follows the project's coding standards
- [x] I have added/updated tests that prove my fix or feature works
- [x] All new and existing tests pass (`npm test`)
- [x] Code is formatted (`npm run format:check`)
- [x] I have updated documentation where necessary

## Verification Evidence

- `npm run test:server`: 898 passed, 0 failed
- `npm run test:client`: 314 passed, 0 failed
- `npm run build`: passed
- `npm run deploy:validate`: passed, including Docker, Compose, Nginx, Helm, Kustomize, Terraform, production audits, and headers
- `npm run extensions:validate`: 14 plugins and 66 bundled skills validated
- focused plugin and audit tests: 135 passed, 0 failed
- `npm audit --omit=dev --json`: 0 vulnerabilities
- public skills discovery: 74 skills
