### PR TITLE
Add progress + todo list tracker

### DIFF
--- a/client/src/components/AgentCard.tsx
+++ b/client/src/components/AgentCard.tsx
@@ -61,6 +61,7 @@ import { useTranslation } from "react-i18next";
 import { Bot, GitBranch, Clock, Wrench, Cpu, Coins } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { AgentStatusBadge } from "./StatusBadge";
+import { ProgressBar } from "./ProgressBar";
 import { effectiveAgentStatus, isAgentAwaitingInput, agentAwaitingReason } from "../lib/types";
 import type { Agent, Session } from "../lib/types";
 import { formatDuration, timeAgo, formatModelName, pathBasename, fmtCost } from "../lib/format";
@@ -134,6 +135,16 @@ export function AgentCard({ agent, session, label, onClick }: AgentCardProps) {
       : 0
     : typeof agent.cost === "number"
       ? agent.cost
+      : 0;
+  // Progress bar shows only when the agent is actively working AND has a real
+  // denominator (TodoWrite items or workflow fleet). No denominator → no bar
+  // (we never fake a percent from time/tool-counts).
+  const progressTotal = typeof agent.todo_total === "number" ? agent.todo_total : 0;
+  const progressDone = typeof agent.todo_done === "number" ? agent.todo_done : 0;
+  const showProgress = isActive && progressTotal > 0;
+  const progressPct =
+    progressTotal > 0
+      ? Math.round((Math.min(progressDone, progressTotal) / progressTotal) * 100)
       : 0;
   // Real (user-given) session name - auto-generated Claude/Codex fallbacks
   // carry no extra info next to the ID, so they are suppressed.
@@ -263,6 +274,22 @@ export function AgentCard({ agent, session, label, onClick }: AgentCardProps) {
               {prompt}
             </p>
           ))}
+        </div>
+      )}
+
+      {showProgress && (
+        <div className="mb-3">
+          <ProgressBar
+            done={progressDone}
+            total={progressTotal}
+            title={t("progress.tooltip", {
+              pct: progressPct,
+              done: progressDone,
+              total: progressTotal,
+              context: agent.progress_source === "workflow" ? "workflow" : "todo",
+            })}
+            ariaLabel={t("progress.aria", { pct: progressPct })}
+          />
         </div>
       )}
 

--- a/client/src/components/ProgressBar.tsx
+++ b/client/src/components/ProgressBar.tsx
@@ -1,0 +1,47 @@
+/**
+ * @file ProgressBar.tsx
+ * @description A slim, accessible task-progress bar for Kanban agent cards.
+ * Given completed/total counts it renders a track+fill plus a compact
+ * "done/total" label; the exact percent + source live in the hover tooltip.
+ * Pure presentational — no data access — so it is unit-testable in isolation.
+ * Renders nothing when there is no real denominator (total <= 0).
+ * @author Son Nguyen <hoangson091104@gmail.com>
+ */
+
+interface ProgressBarProps {
+  /** Completed units (todo items done, or finished workflow agents). */
+  done: number;
+  /** Total units. When <= 0 the component renders nothing. */
+  total: number;
+  /** Tooltip text (exact percent + source), supplied by the caller for i18n. */
+  title?: string;
+  /** Accessible label, supplied by the caller for i18n. */
+  ariaLabel?: string;
+}
+
+export function ProgressBar({ done, total, title, ariaLabel }: ProgressBarProps) {
+  if (!Number.isFinite(total) || total <= 0) return null;
+  const safeDone = Math.max(0, Math.min(done, total));
+  const pct = Math.round((safeDone / total) * 100);
+  return (
+    <div
+      className="flex items-center gap-2"
+      title={title}
+      role="progressbar"
+      aria-valuemin={0}
+      aria-valuemax={total}
+      aria-valuenow={safeDone}
+      aria-label={ariaLabel}
+    >
+      <div className="h-1.5 flex-1 min-w-0 rounded-full bg-surface-3 overflow-hidden">
+        <div
+          className="h-full rounded-full bg-accent transition-[width] duration-300"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <span className="text-[11px] font-mono text-gray-500 flex-shrink-0 tabular-nums">
+        {safeDone}/{total}
+      </span>
+    </div>
+  );
+}

--- a/client/src/components/__tests__/ProgressBar.test.tsx
+++ b/client/src/components/__tests__/ProgressBar.test.tsx
@@ -1,0 +1,39 @@
+/**
+ * @file Unit tests for ProgressBar — width from done/total, label, a11y attrs,
+ * and the render-nothing contract when there is no denominator.
+ * @author Son Nguyen <hoangson091104@gmail.com>
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ProgressBar } from "../ProgressBar";
+
+describe("ProgressBar", () => {
+  it("renders a done/total label", () => {
+    render(<ProgressBar done={3} total={5} />);
+    expect(screen.getByText("3/5")).toBeInTheDocument();
+  });
+
+  it("sets progressbar aria attributes", () => {
+    render(<ProgressBar done={3} total={5} ariaLabel="Task 60% complete" />);
+    const bar = screen.getByRole("progressbar", { name: "Task 60% complete" });
+    expect(bar).toHaveAttribute("aria-valuenow", "3");
+    expect(bar).toHaveAttribute("aria-valuemax", "5");
+  });
+
+  it("computes 60% fill width for 3/5", () => {
+    const { container } = render(<ProgressBar done={3} total={5} />);
+    const fill = container.querySelector('[style*="width"]');
+    expect(fill).toHaveStyle({ width: "60%" });
+  });
+
+  it("clamps done to total", () => {
+    render(<ProgressBar done={9} total={5} />);
+    expect(screen.getByText("5/5")).toBeInTheDocument();
+  });
+
+  it("renders nothing when total is 0", () => {
+    const { container } = render(<ProgressBar done={0} total={0} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/client/src/i18n/locales/en/kanban.json
+++ b/client/src/i18n/locales/en/kanban.json
@@ -41,5 +41,10 @@
       "error": "Session ended with an error — an unrecoverable failure or an upstream API error terminated the run.",
       "abandoned": "Session went stale without a clean exit signal. Marked abandoned after 5+ minutes of no activity (for example after /resume, a network drop, or a killed CLI). Distinct from Completed: no real exit was observed."
     }
+  },
+  "progress": {
+    "tooltip_todo": "{{pct}}% · {{done}} of {{total}} todos done",
+    "tooltip_workflow": "{{pct}}% · {{done}} of {{total}} agents done",
+    "aria": "Task {{pct}}% complete"
   }
 }

--- a/client/src/i18n/locales/es/kanban.json
+++ b/client/src/i18n/locales/es/kanban.json
@@ -41,5 +41,10 @@
       "error": "La sesión terminó con un error: un fallo irrecuperable o un error de API upstream finalizó la ejecución.",
       "abandoned": "La sesión quedó inactiva sin una señal de salida limpia. Se marca como abandonada después de más de 5 minutos sin actividad (por ejemplo tras /resume, una caída de red o una CLI terminada). A diferencia de Completada, no se observó una salida real."
     }
+  },
+  "progress": {
+    "tooltip_todo": "{{pct}}% · {{done}} de {{total}} tareas completadas",
+    "tooltip_workflow": "{{pct}}% · {{done}} de {{total}} agentes completados",
+    "aria": "Tarea {{pct}}% completada"
   }
 }

--- a/client/src/i18n/locales/ko/kanban.json
+++ b/client/src/i18n/locales/ko/kanban.json
@@ -41,5 +41,10 @@
       "error": "복구 불가능한 실패 또는 상위 API 오류로 인해 세션이 오류와 함께 종료되었습니다.",
       "abandoned": "정상 종료 신호 없이 세션이 오래 방치되었습니다. 활동이 5분 이상 없으면 abandoned로 표시됩니다(예: /resume, 네트워크 끊김 또는 CLI 강제 종료 후). Completed와 달리 실제 종료가 관찰되지 않았습니다."
     }
+  },
+  "progress": {
+    "tooltip_todo": "{{pct}}% · 할 일 {{total}}개 중 {{done}}개 완료",
+    "tooltip_workflow": "{{pct}}% · Agent {{total}}개 중 {{done}}개 완료",
+    "aria": "작업 {{pct}}% 완료"
   }
 }

--- a/client/src/i18n/locales/vi/kanban.json
+++ b/client/src/i18n/locales/vi/kanban.json
@@ -41,5 +41,10 @@
       "error": "Phiên kết thúc với lỗi: lỗi không thể khôi phục hoặc lỗi API thượng nguồn đã chấm dứt lần chạy.",
       "abandoned": "Phiên trở nên cũ mà không có tín hiệu thoát sạch. Phiên bị đánh dấu bỏ dở sau hơn 5 phút không hoạt động (ví dụ sau /resume, mất mạng hoặc CLI bị tắt). Khác với Hoàn tất: không quan sát được tín hiệu thoát thật sự."
     }
+  },
+  "progress": {
+    "tooltip_todo": "{{pct}}% · Đã hoàn thành {{done}}/{{total}} việc cần làm",
+    "tooltip_workflow": "{{pct}}% · Đã hoàn thành {{done}}/{{total}} Agent",
+    "aria": "Tác vụ hoàn thành {{pct}}%"
   }
 }

--- a/client/src/i18n/locales/zh/kanban.json
+++ b/client/src/i18n/locales/zh/kanban.json
@@ -41,5 +41,10 @@
       "error": "会话以错误结束：不可恢复的故障或上游 API 错误终止了运行。",
       "abandoned": "会话在没有干净退出信号的情况下变得陈旧。超过 5 分钟没有活动后会被标记为已放弃（例如 /resume、网络中断或 CLI 被终止后）。与已完成不同：未观察到真实退出。"
     }
+  },
+  "progress": {
+    "tooltip_todo": "{{pct}}% · 已完成 {{total}} 项待办中的 {{done}} 项",
+    "tooltip_workflow": "{{pct}}% · 已完成 {{total}} 个 Agent 中的 {{done}} 个",
+    "aria": "任务完成 {{pct}}%"
   }
 }

--- a/client/src/lib/types.ts
+++ b/client/src/lib/types.ts
@@ -784,6 +784,17 @@ export interface Agent {
    * for main agents (whose cost is the session total) and compaction agents.
    */
   cost?: number;
+  /** Completed items of the agent's progress denominator — TodoWrite completed
+   *  items, or done/errored Workflow inner agents. Null when no progress is
+   *  known. Maps to `agents.todo_done`. */
+  todo_done?: number | null;
+  /** Total items of the progress denominator (todo items, or total Workflow
+   *  inner agents). Null when unknown. Maps to `agents.todo_total`. */
+  todo_total?: number | null;
+  /** What produced the counts above: 'todo' (agent's own TodoWrite list) or
+   *  'workflow' (fleet done/total); null when no progress. Maps to
+   *  `agents.progress_source`. */
+  progress_source?: "todo" | "workflow" | null;
 }
 
 // ───── "Awaiting input" overlay helpers ─────

--- a/docs/API.md
+++ b/docs/API.md
@@ -379,11 +379,16 @@ curl http://localhost:4820/api/sessions/sess_abc123/agents
       "parent_agent_id": null,
       "awaiting_input_since": "2024-03-18T12:05:00Z",
       "awaiting_reason": "stop",
+      "todo_done": null,
+      "todo_total": null,
+      "progress_source": null,
       "cost": 0
     }
   ]
 }
 ```
+
+> **Note on progress fields** — `todo_done`, `todo_total`, and `progress_source` are optional per-agent task-progress counts (all `null` when no progress is known). They are populated from the agent's own `TodoWrite` list (`progress_source: "todo"`, completed/total items) or from a Workflow-tool run (`progress_source: "workflow"`, done+error/total inner agents); a `"todo"` source is never overwritten by a `"workflow"` update. The dashboard renders them as a progress bar on `working` agent cards that carry a non-zero `todo_total`.
 
 > **Note on `cost`** — `/api/agents` and `/api/sessions/:id/agents` attach a `cost` (USD) to each agent: the agent's **own** cost, computed server-side from the per-agent token buckets stored in `agents.metadata.tokens` and priced at the current pricing rules (at the agent's start date, so promo/standard cutovers apply — see [Pricing](#pricing)). It is `0` for main agents (whose cost is the session total, reported by `/api/pricing/cost/:sessionId`), for compaction pseudo-agents, and for any subagent whose transcript is unavailable. This lets a subagent card show only what that subagent spent instead of the whole session's total.
 

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -267,6 +267,9 @@ CREATE TABLE agents (
     updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
     awaiting_input_since TEXT,                                        -- main-agent waiting flag
     awaiting_reason TEXT,                                             -- notification|stop|session_start|interrupted, or NULL
+    todo_done INTEGER,                                                -- completed task-progress count (nullable)
+    todo_total INTEGER,                                               -- total task-progress count (nullable)
+    progress_source TEXT,                                             -- 'todo' | 'workflow', or NULL when no progress known
     FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE,
     FOREIGN KEY (parent_agent_id) REFERENCES agents(id) ON DELETE SET NULL
 );
@@ -288,6 +291,9 @@ CREATE TABLE agents (
 | `metadata` | TEXT | YES | JSON blob for extras. For subagents it carries `model` (the subagent's own model, issue #185) and `tokens` — an array of per-agent token buckets parsed from the subagent's transcript. The agent-list endpoints price `tokens` at the current rates to attach a per-agent `cost` (so a subagent card shows its OWN cost, not the session total). Empty `[]` means the subagent did no billable work; absent means its transcript wasn't available to parse |
 | `awaiting_input_since` | TEXT | YES | Mirrors the parent session's flag for the main agent, including Codex `task_complete` / `turn_aborted` waiting state. NULL on subagents |
 | `awaiting_reason` | TEXT | YES | Why the row is waiting: `notification`, `stop`, `session_start`, or `interrupted`. Set/cleared in lock-step with `awaiting_input_since`; for Codex, `task_complete` uses `stop` and `turn_aborted` uses `interrupted`. NULL on subagents |
+| `todo_done` | INTEGER | YES | Completed task-progress count. Populated from the agent's own `TodoWrite` list (completed items, source `'todo'`) or, for Workflow-tool runs, done+error inner agents (source `'workflow'`). NULL means no progress is known |
+| `todo_total` | INTEGER | YES | Total task-progress count (all `TodoWrite` items, or all inner agents of a Workflow run). NULL means no progress is known |
+| `progress_source` | TEXT | YES | Which producer set the counts: `'todo'` (a `TodoWrite` PostToolUse, unweighted completed/total) or `'workflow'` (a Workflow-tool run). A `'todo'` source is never overwritten by a `'workflow'` update — TodoWrite wins. NULL when no progress is known |
 
 **Lifecycle:**
 

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -329,6 +329,7 @@ Triggered after a tool completes execution.
 - Update agent token counts via shared transcript cache
 - Calculate and update cost
 - Rollup cost to session
+- For the `TodoWrite` tool, parse `tool_input.todos` into per-agent task-progress counts on the acting agent: `todo_done` = completed items, `todo_total` = total items (unweighted), `progress_source = 'todo'`, then broadcast `agent_updated`. Previously the `TodoWrite` payload was only persisted as an opaque event blob
 
 **Cost Calculation Flow:**
 

--- a/docs/superpowers/plans/2026-08-05-kanban-task-progress.md
+++ b/docs/superpowers/plans/2026-08-05-kanban-task-progress.md
@@ -1,0 +1,534 @@
+# Implementation Plan — Kanban Task Progress (Percent-Complete on Agent Cards)
+
+**Date:** 2026-08-05
+**Spec:** `docs/superpowers/specs/2026-08-05-kanban-task-progress-design.md`
+**Branch:** `feat/task-percentage-done`
+**Status:** Ready for implementation (Stage 4)
+
+Locked decisions (from spec §12): columns `todo_done` / `todo_total` / `progress_source`; TodoWrite precedence over workflow; progress bar on its own line; shared `ProgressBar.tsx`; `completed/total` unweighted; bar shown only for `working` agents with `todo_total > 0`.
+
+Verified code anchors (read before writing this plan):
+- `server/routes/hooks.js`: `processEvent` transaction L332; `toolName = data.tool_name` L385; `agentId` inits to `mainAgentId` L387, reassigned to deepest working subagent in `PostToolUse` L506–511; `PostToolUse` branch L484–520. `tool_input` is **not** destructured → read `data.tool_input`.
+- `server/db.js`: additive-migration pattern L479–485; `stmts` object near L1441 (`getAgent`).
+- `server/lib/workflow-ingest.js`: journal `progress[]` parse L250–273; `ingestWorkflowJournal` upsert L291–309, agent loop L316; `mainAgentId = ${sessionId}-main` L282; live builder `progress` L453/489/531, upsert ~L565.
+- `client/src/lib/types.ts`: `Agent` interface L720–787 (last field `cost?` L786).
+- `client/src/components/AgentCard.tsx`: props L100, `useTranslation("kanban")` L112, task-preview block L255–267, meta row L269–313.
+- i18n: namespace `kanban`, languages `en es ko vi zh` under `client/src/i18n/locales/<lng>/kanban.json`.
+- Test harness (server): `node:test`; set `process.env.DASHBOARD_DB_PATH`; `const { createApp, startServer } = require("../index")`; POST helper `hook(hook_type, data) => POST /api/hooks/event { hook_type, data }` (see `awaiting-subagent-guard.test.js`). Component tests: vitest + RTL (see `StatCard.test.tsx`).
+- Every touched `.js/.ts/.tsx` must keep/add the `@author Son Nguyen <hoangson091104@gmail.com>` header.
+
+---
+
+## Task 1 — Schema migration + prepared statement (`server/db.js`)
+
+**1a. Migration.** Immediately AFTER the workflow-link migration block (after `CREATE INDEX ... idx_agents_workflow`, ~L485), insert:
+
+```js
+// Migrate: per-agent task-progress counts. `todo_done`/`todo_total` come from
+// the agent's own TodoWrite list (completed/total items) or, for Workflow-tool
+// runs, done/total inner agents. `progress_source` records which produced them
+// ('todo' | 'workflow'). NULL everywhere = no progress known. Additive, safe on
+// existing DBs.
+try {
+  db.prepare("SELECT todo_done FROM agents LIMIT 1").get();
+} catch {
+  db.prepare("ALTER TABLE agents ADD COLUMN todo_done INTEGER").run();
+  db.prepare("ALTER TABLE agents ADD COLUMN todo_total INTEGER").run();
+  db.prepare("ALTER TABLE agents ADD COLUMN progress_source TEXT").run();
+}
+```
+
+**1b. Prepared statement.** In the `stmts` object, right after `getAgent` (L1441), add:
+
+```js
+  updateAgentProgress: db.prepare(
+    "UPDATE agents SET todo_done = ?, todo_total = ?, progress_source = ? WHERE id = ?"
+  ),
+```
+
+**No test of its own** (exercised by Tasks 2 & 3). File header already present — leave as is.
+
+**Command:** `npm run test:server` (must stay green — migration must not break existing suites).
+
+---
+
+## Task 2 — Fase 1: TodoWrite ingestion (`server/routes/hooks.js`)
+
+In the `PostToolUse` branch, AFTER the `agentId` reassignment block that ends at L511 (`}` closing `if (mainAgent && mainAgent.status === "waiting" ...)`), and BEFORE the `current_tool` clear at L513, insert:
+
+```js
+      // TodoWrite carries the agent's own plan — completed/total items is the
+      // one real, self-declared progress denominator we get. Parse it into
+      // per-agent counts and attribute to whoever ran it (agentId, already
+      // resolved above to the deepest working subagent when main is waiting).
+      // Fail-safe: a malformed payload must never throw inside this ingest
+      // transaction (backend rule: hooks stay non-blocking).
+      if (toolName === "TodoWrite") {
+        try {
+          const todos = Array.isArray(data.tool_input?.todos) ? data.tool_input.todos : [];
+          if (todos.length > 0) {
+            const total = todos.length;
+            const done = todos.filter((item) => item && item.status === "completed").length;
+            stmts.updateAgentProgress.run(done, total, "todo", agentId);
+            broadcast("agent_updated", stmts.getAgent.get(agentId));
+          }
+        } catch {
+          /* fail-safe: ignore malformed TodoWrite payloads */
+        }
+      }
+```
+
+Notes:
+- Explicit `broadcast` here (not the conditional one at L517) so the card updates live even when `agentId` is a subagent or the main agent isn't `working`.
+- Header already present.
+
+### Task 2 test — `server/__tests__/task-progress-todo.test.js` (NEW)
+
+```js
+/**
+ * @file Regression: TodoWrite hook payloads must be parsed into per-agent
+ * progress counts (agents.todo_done / todo_total / progress_source='todo').
+ * A completed/total denominator is the primary signal behind the Kanban
+ * progress bar; malformed or empty payloads must never write or throw.
+ * @author Son Nguyen <hoangson091104@gmail.com>
+ */
+
+const { describe, it, before, after } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("path");
+const os = require("os");
+const fs = require("fs");
+const http = require("http");
+
+const TEST_DB = path.join(os.tmpdir(), `task-progress-todo-${Date.now()}-${process.pid}.db`);
+process.env.DASHBOARD_DB_PATH = TEST_DB;
+process.env.DASHBOARD_LIVENESS_PROBE = "0";
+
+const { createApp, startServer } = require("../index");
+const { db, stmts } = require("../db");
+
+let server;
+let BASE;
+
+function fetchJson(urlPath, options = {}) {
+  return new Promise((resolve, reject) => {
+    const url = new URL(urlPath, BASE);
+    const req = http.request(
+      {
+        hostname: url.hostname,
+        port: url.port,
+        path: url.pathname + url.search,
+        method: options.method || "GET",
+        headers: { "Content-Type": "application/json", ...options.headers },
+      },
+      (res) => {
+        let body = "";
+        res.on("data", (c) => (body += c));
+        res.on("end", () => {
+          let parsed;
+          try {
+            parsed = JSON.parse(body);
+          } catch {
+            parsed = body;
+          }
+          resolve({ status: res.statusCode, body: parsed });
+        });
+      }
+    );
+    req.on("error", reject);
+    if (options.body) req.write(JSON.stringify(options.body));
+    req.end();
+  });
+}
+const hook = (hook_type, data) =>
+  fetchJson("/api/hooks/event", { method: "POST", body: { hook_type, data } });
+
+before(async () => {
+  const app = createApp();
+  server = await startServer(app, 0);
+  const addr = server.address();
+  BASE = `http://127.0.0.1:${addr.port}`;
+});
+
+after(() => {
+  if (server) server.close();
+  if (db) db.close();
+  for (const suffix of ["", "-wal", "-shm"]) {
+    try {
+      fs.unlinkSync(TEST_DB + suffix);
+    } catch {
+      /* ignore */
+    }
+  }
+});
+
+async function driveWorkingMain(sid) {
+  await hook("SessionStart", { session_id: sid });
+  await hook("UserPromptSubmit", { session_id: sid, prompt: "go" });
+}
+
+describe("TodoWrite → agent progress", () => {
+  it("writes completed/total and progress_source='todo' from a TodoWrite payload", async () => {
+    const sid = "todo-basic";
+    await driveWorkingMain(sid);
+    await hook("PostToolUse", {
+      session_id: sid,
+      tool_name: "TodoWrite",
+      tool_input: {
+        todos: [
+          { content: "a", status: "completed" },
+          { content: "b", status: "completed" },
+          { content: "c", status: "in_progress" },
+          { content: "d", status: "pending" },
+          { content: "e", status: "pending" },
+        ],
+      },
+    });
+    const agent = stmts.getAgent.get(`${sid}-main`);
+    assert.equal(agent.todo_total, 5);
+    assert.equal(agent.todo_done, 2); // in_progress counts as NOT done (unweighted)
+    assert.equal(agent.progress_source, "todo");
+  });
+
+  it("updates counts when a later TodoWrite replaces the list", async () => {
+    const sid = "todo-replace";
+    await driveWorkingMain(sid);
+    await hook("PostToolUse", {
+      session_id: sid,
+      tool_name: "TodoWrite",
+      tool_input: { todos: [{ content: "x", status: "completed" }] },
+    });
+    await hook("PostToolUse", {
+      session_id: sid,
+      tool_name: "TodoWrite",
+      tool_input: {
+        todos: [
+          { content: "x", status: "completed" },
+          { content: "y", status: "completed" },
+          { content: "z", status: "pending" },
+        ],
+      },
+    });
+    const agent = stmts.getAgent.get(`${sid}-main`);
+    assert.equal(agent.todo_total, 3);
+    assert.equal(agent.todo_done, 2);
+  });
+
+  it("ignores an empty todos array (no write, no throw)", async () => {
+    const sid = "todo-empty";
+    await driveWorkingMain(sid);
+    await hook("PostToolUse", {
+      session_id: sid,
+      tool_name: "TodoWrite",
+      tool_input: { todos: [] },
+    });
+    const agent = stmts.getAgent.get(`${sid}-main`);
+    assert.equal(agent.todo_total, null);
+    assert.equal(agent.progress_source, null);
+  });
+
+  it("ignores a malformed TodoWrite payload without throwing", async () => {
+    const sid = "todo-malformed";
+    await driveWorkingMain(sid);
+    const res = await hook("PostToolUse", {
+      session_id: sid,
+      tool_name: "TodoWrite",
+      tool_input: { todos: "not-an-array" },
+    });
+    assert.equal(res.status, 200);
+    const agent = stmts.getAgent.get(`${sid}-main`);
+    assert.equal(agent.todo_total, null);
+  });
+
+  it("leaves non-TodoWrite tools untouched", async () => {
+    const sid = "todo-other-tool";
+    await driveWorkingMain(sid);
+    await hook("PreToolUse", { session_id: sid, tool_name: "Read", tool_input: {} });
+    await hook("PostToolUse", { session_id: sid, tool_name: "Read", tool_input: {} });
+    const agent = stmts.getAgent.get(`${sid}-main`);
+    assert.equal(agent.todo_total, null);
+    assert.equal(agent.progress_source, null);
+  });
+});
+```
+
+> Implementer note: confirm `startServer(app, 0)` returns/`resolve`s the `http.Server` and that `server.address().port` is available (match whatever `awaiting-subagent-guard.test.js` / `session-liveness.test.js` do in this repo — mirror that exact bootstrap if the signature differs). Adjust only the bootstrap, not the assertions.
+
+**Command:** `npm run test:server` → the new suite passes; all pre-existing suites stay green.
+
+---
+
+## Task 3 — Fase 2: Workflow fleet progress (`server/lib/workflow-ingest.js`)
+
+Goal: after a workflow's agents are known, write `done/total` to the run's **main agent** (`${sessionId}-main`) with `progress_source='workflow'`, **without** clobbering a `'todo'` source (precedence).
+
+**3a. Add a precedence-aware helper** (module-scope, near `mapState`):
+
+```js
+/**
+ * Write fleet progress (done/total inner agents) onto the run's main agent,
+ * but never overwrite a finer-grained 'todo' progress the orchestrator set for
+ * itself. Counts a `done` OR `error` inner agent as finished (an errored agent
+ * won't progress further). No-op when there are no inner agents.
+ */
+function writeWorkflowProgress(dbModule, mainAgentId, progress) {
+  const { stmts } = dbModule;
+  const entries = Array.isArray(progress)
+    ? progress.filter((e) => e && e.type === "workflow_agent")
+    : [];
+  const total = entries.length;
+  if (total === 0) return;
+  const done = entries.filter((e) => e.state === "done" || e.state === "error").length;
+  const main = stmts.getAgent.get(mainAgentId);
+  if (!main) return;
+  if (main.progress_source === "todo") return; // TodoWrite wins (spec §6.1)
+  stmts.updateAgentProgress.run(done, total, "workflow", mainAgentId);
+}
+```
+
+**3b. Call it in the journal path.** In `ingestWorkflowJournal`, after the agent loop completes (after the `for (const entry of agentEntries)` block, before the function returns the upserted workflow row), add:
+
+```js
+  try {
+    writeWorkflowProgress(dbModule, mainAgentId, journal.progress);
+  } catch {
+    /* progress is best-effort; never fail the ingest over it */
+  }
+```
+
+**3c. Call it in the live path.** In the live-run builder (the block ~L407–575 that upserts the workflow from the reconstructed `progress[]`), after `progress` is fully built and before/after the workflow upsert, add the same guarded call using that scope's `progress` array and `${sessionId}-main` (bind `mainAgentId` if not already in scope):
+
+```js
+  try {
+    writeWorkflowProgress(dbModule, `${sessionId}-main`, progress);
+  } catch {
+    /* best-effort */
+  }
+```
+
+> Implementer note: verify the exact variable names in the live builder (`sessionId`, `progress`, and whether a `dbModule`/`stmts` handle is in scope) and wire the call to match. Do not change the workflow upsert itself.
+
+### Task 3 test — `server/__tests__/task-progress-workflow.test.js` (NEW)
+
+Mirror the harness of the existing `import-workflow-link.test.js` / `workflow-ingest.test.js` (same suite already builds a journal fixture and calls the ingest). The implementer MUST open one of those two files and copy its exact fixture-building + ingest-invocation approach, then assert:
+
+```js
+// after ingesting a journal whose progress[] has 3 workflow_agent entries
+// (2 state:"done", 1 state:"running") for session `sid`:
+const main = stmts.getAgent.get(`${sid}-main`);
+assert.equal(main.todo_total, 3);
+assert.equal(main.todo_done, 2);
+assert.equal(main.progress_source, "workflow");
+
+// precedence: if the main agent already has progress_source='todo' with counts,
+// a subsequent workflow ingest must NOT overwrite them.
+stmts.updateAgentProgress.run(1, 4, "todo", `${sid}-main`);
+// ...re-run the same ingest...
+const main2 = stmts.getAgent.get(`${sid}-main`);
+assert.equal(main2.progress_source, "todo");
+assert.equal(main2.todo_total, 4);
+assert.equal(main2.todo_done, 1);
+```
+
+Header on the new test file required.
+
+**Command:** `npm run test:server`.
+
+---
+
+## Task 4 — Client: `Agent` type, `ProgressBar` component, `AgentCard` integration
+
+**4a. Type** — `client/src/lib/types.ts`, in `interface Agent`, after `cost?` (L786):
+
+```ts
+  /** Completed items of the agent's progress denominator — TodoWrite completed
+   *  items, or done/errored Workflow inner agents. Null when no progress is
+   *  known. Maps to `agents.todo_done`. */
+  todo_done?: number | null;
+  /** Total items of the progress denominator (todo items, or total Workflow
+   *  inner agents). Null when unknown. Maps to `agents.todo_total`. */
+  todo_total?: number | null;
+  /** What produced the counts above: 'todo' (agent's own TodoWrite list) or
+   *  'workflow' (fleet done/total); null when no progress. Maps to
+   *  `agents.progress_source`. */
+  progress_source?: "todo" | "workflow" | null;
+```
+
+**4b. Component** — `client/src/components/ProgressBar.tsx` (NEW):
+
+```tsx
+/**
+ * @file ProgressBar.tsx
+ * @description A slim, accessible task-progress bar for Kanban agent cards.
+ * Given completed/total counts it renders a track+fill plus a compact
+ * "done/total" label; the exact percent + source live in the hover tooltip.
+ * Pure presentational — no data access — so it is unit-testable in isolation.
+ * Renders nothing when there is no real denominator (total <= 0).
+ * @author Son Nguyen <hoangson091104@gmail.com>
+ */
+
+interface ProgressBarProps {
+  /** Completed units (todo items done, or finished workflow agents). */
+  done: number;
+  /** Total units. When <= 0 the component renders nothing. */
+  total: number;
+  /** Tooltip text (exact percent + source), supplied by the caller for i18n. */
+  title?: string;
+  /** Accessible label, supplied by the caller for i18n. */
+  ariaLabel?: string;
+}
+
+export function ProgressBar({ done, total, title, ariaLabel }: ProgressBarProps) {
+  if (!Number.isFinite(total) || total <= 0) return null;
+  const safeDone = Math.max(0, Math.min(done, total));
+  const pct = Math.round((safeDone / total) * 100);
+  return (
+    <div
+      className="flex items-center gap-2"
+      title={title}
+      role="progressbar"
+      aria-valuemin={0}
+      aria-valuemax={total}
+      aria-valuenow={safeDone}
+      aria-label={ariaLabel}
+    >
+      <div className="h-1.5 flex-1 min-w-0 rounded-full bg-surface-3 overflow-hidden">
+        <div
+          className="h-full rounded-full bg-accent transition-[width] duration-300"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <span className="text-[11px] font-mono text-gray-500 flex-shrink-0 tabular-nums">
+        {safeDone}/{total}
+      </span>
+    </div>
+  );
+}
+```
+
+> Implementer note: confirm the theme token for the track (`bg-surface-3`) exists in this Tailwind config; if the scale differs, use the nearest existing surface token used elsewhere in cards. Fill uses `bg-accent` (already used across cards).
+
+**4c. AgentCard integration** — `client/src/components/AgentCard.tsx`:
+
+1. Import: `import { ProgressBar } from "./ProgressBar";`
+2. Derive, near the other `const` derivations (after `cost`, ~L137):
+
+```tsx
+  // Progress bar shows only when the agent is actively working AND has a real
+  // denominator (TodoWrite items or workflow fleet). No denominator → no bar
+  // (we never fake a percent from time/tool-counts).
+  const progressTotal = typeof agent.todo_total === "number" ? agent.todo_total : 0;
+  const progressDone = typeof agent.todo_done === "number" ? agent.todo_done : 0;
+  const showProgress = isActive && progressTotal > 0;
+  const progressPct = progressTotal > 0 ? Math.round((Math.min(progressDone, progressTotal) / progressTotal) * 100) : 0;
+```
+
+3. Render on its own line, BETWEEN the task-preview block (closes L267) and the meta row (opens L269):
+
+```tsx
+      {showProgress && (
+        <div className="mb-3">
+          <ProgressBar
+            done={progressDone}
+            total={progressTotal}
+            title={t("progress.tooltip", {
+              pct: progressPct,
+              done: progressDone,
+              total: progressTotal,
+              context: agent.progress_source === "workflow" ? "workflow" : "todo",
+            })}
+            ariaLabel={t("progress.aria", { pct: progressPct })}
+          />
+        </div>
+      )}
+```
+
+**4d. i18n** — add a `progress` block to `kanban.json` for **all five** languages (`en es ko vi zh`). English:
+
+```json
+  "progress": {
+    "tooltip_todo": "{{pct}}% · {{done}} of {{total}} todos done",
+    "tooltip_workflow": "{{pct}}% · {{done}} of {{total}} agents done",
+    "aria": "Task {{pct}}% complete"
+  },
+```
+
+> i18next `context` maps `progress.tooltip` + `context:"todo"|"workflow"` → keys `tooltip_todo` / `tooltip_workflow`. Provide translated strings for `es`, `ko`, `vi`, `zh` (do not leave English placeholders — match how the rest of each file is localized). Keep placeholder names identical across languages.
+
+### Task 4 test — `client/src/components/__tests__/ProgressBar.test.tsx` (NEW)
+
+```tsx
+/**
+ * @file Unit tests for ProgressBar — width from done/total, label, a11y attrs,
+ * and the render-nothing contract when there is no denominator.
+ * @author Son Nguyen <hoangson091104@gmail.com>
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ProgressBar } from "../ProgressBar";
+
+describe("ProgressBar", () => {
+  it("renders a done/total label", () => {
+    render(<ProgressBar done={3} total={5} />);
+    expect(screen.getByText("3/5")).toBeInTheDocument();
+  });
+
+  it("sets progressbar aria attributes", () => {
+    render(<ProgressBar done={3} total={5} ariaLabel="Task 60% complete" />);
+    const bar = screen.getByRole("progressbar", { name: "Task 60% complete" });
+    expect(bar).toHaveAttribute("aria-valuenow", "3");
+    expect(bar).toHaveAttribute("aria-valuemax", "5");
+  });
+
+  it("computes 60% fill width for 3/5", () => {
+    const { container } = render(<ProgressBar done={3} total={5} />);
+    const fill = container.querySelector('[style*="width"]');
+    expect(fill).toHaveStyle({ width: "60%" });
+  });
+
+  it("clamps done to total", () => {
+    render(<ProgressBar done={9} total={5} />);
+    expect(screen.getByText("5/5")).toBeInTheDocument();
+  });
+
+  it("renders nothing when total is 0", () => {
+    const { container } = render(<ProgressBar done={0} total={0} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+```
+
+**Command:** `cd client && npm test` (or `npm run test:client`).
+
+---
+
+## Task 5 — Snapshot baseline, docs, headers, full verification
+
+1. **Snapshot review:** `cd client && npx vitest run` — inspect the `screens.snapshot.test.tsx` diff; the progress bar should appear only on `working` agent cards that carry `todo_total`. If the snapshot fixtures have no such agent, the diff may be empty (acceptable). Regenerate intentionally: `cd client && npx vitest run -u`. Review the diff before committing — never blind-update.
+2. **Docs (`update-project-docs` skill):**
+   - `docs/DATABASE.md` — document the three new `agents` columns.
+   - `docs/HOOKS.md` — note that `TodoWrite` `PostToolUse` payloads are now consumed into per-agent progress.
+   - Any card/UI reference doc that lists card fields.
+3. **Headers:** `bash .claude/skills/file-headers/scripts/check-headers.sh` → exit 0 (new `.tsx`/`.test.tsx`/`.js` files carry `@author`).
+4. **Full gates:**
+   - `npm run test:server`
+   - `npm run test:client`
+   - (No MCP surface touched — `mcp:typecheck` not required; state so if skipped.)
+
+---
+
+## Review gates (Stage 4, per task)
+
+For each task: **spec-compliance review** (built exactly what spec §4–§8 says?) → **code-quality review** (fail-safe, backward-compatible, matches repo idioms, headers present) → fix loop → mark complete → next task.
+
+## Final holistic review
+
+Across all changed files: precedence correctness (todo never clobbered by workflow), no broadcast/WS shape regressions (`SELECT *` carries new columns; existing consumers unaffected by extra fields), bar hidden for non-working agents, i18n complete in all 5 languages, all four verification commands green.
+
+## Ordered task list
+1. Task 1 — schema migration + `updateAgentProgress` stmt.
+2. Task 2 — TodoWrite ingestion + `task-progress-todo.test.js`.
+3. Task 3 — workflow fleet progress + `task-progress-workflow.test.js`.
+4. Task 4 — `Agent` type + `ProgressBar.tsx` + `AgentCard` wiring + i18n (×5) + `ProgressBar.test.tsx`.
+5. Task 5 — snapshot/docs/headers/full verification.

--- a/docs/superpowers/specs/2026-08-05-kanban-task-progress-design.md
+++ b/docs/superpowers/specs/2026-08-05-kanban-task-progress-design.md
@@ -1,0 +1,220 @@
+# Kanban Task Progress — Percent-Complete on Agent Cards (Design Spec)
+
+**Date:** 2026-08-05
+**Status:** Approved (design) — decisions locked, ready for planning
+**Owner:** Son Nguyen (David)
+**Branch:** `feat/task-percentage-done`
+**Topic:** Show an estimated completion indicator (progress bar + `done/total` count) on the Kanban `AgentCard`s, derived from the agent's own TodoWrite list (per-agent) and from Workflow-tool run state (fleets). Honest, source-labelled, and hidden when there is no real denominator.
+
+---
+
+## 1. Summary
+
+Agent cards on the Kanban board (`working | waiting | completed | error`) currently show status, tool, model, cost, and elapsed time — but **nothing about how far along the task is**. This feature adds a slim progress bar plus a `3/5` count to a card **only when a real denominator exists**.
+
+There is no ground-truth "percent done" for an AI task, so we do **not** invent one. We surface the two signals that carry a genuine denominator:
+
+1. **TodoWrite (Fase 1)** — when an agent maintains a todo list, `completed / total` items is a real, self-declared measure of its own plan. This is the primary signal.
+2. **Workflow runs (Fase 2)** — for a Workflow-tool fleet, `agents done / total agents` is a real measure of the run. This reuses data already ingested into the `workflows` table.
+
+When neither signal is present, the card shows **no** progress element — no time-based or tool-count guessing (that noise would destroy the indicator's credibility). Each progress value is tagged with its `source` so the UI and tooltip stay honest.
+
+The transport layer needs **zero** new plumbing: agent rows are returned via `SELECT * FROM agents` and broadcast whole (`broadcast("agent_updated", stmts.getAgent.get(id))`), so new columns flow to REST + WebSocket automatically, and the board already re-fetches columns on every relevant WS message.
+
+---
+
+## 2. Goals / Non-Goals
+
+### Goals
+- A truthful, at-a-glance progress indicator on `AgentCard` for tasks that expose a real denominator.
+- Bar + `done/total` label on the card; exact `%` in the hover tooltip (per approved design decision).
+- Progress computed from `completed / total` **unweighted** — bar and count always agree (`3/5` ⇒ bar at 60%; `in_progress` counts as not-done).
+- Reuse existing signals: TodoWrite hook payloads (currently discarded) and `workflows.progress` (already ingested).
+- Fail-safe ingestion — TodoWrite parsing never blocks or breaks the hook transaction.
+- Additive, migration-safe schema; backward-compatible REST + WebSocket payloads.
+- Source-labelled (`todo` vs `workflow`) so the number is never misread.
+
+### Non-Goals (YAGNI)
+- **No** time-based or tool-count percentage (Fase 3 fallback explicitly rejected).
+- **No** weighting of `in_progress` items.
+- No progress on `SessionCard` (sessions aggregate many agents; out of scope for v1).
+- No historical progress timeline / sparkline — just the current value.
+- No new WebSocket message type, no new REST endpoint.
+- No changes to the status state machines (`working/waiting/completed/error`).
+- No persistence of todo item *contents* as structured rows — only the two counts.
+
+---
+
+## 3. Signals & rationale (feasibility recap)
+
+| Signal | Denominator? | Quality | Where it lives today |
+|---|---|---|---|
+| **TodoWrite** items | ✅ `completed/total` | **High** — the agent's declared plan | Discarded into `events.data` (`hooks.js` ~L1036), `tool_name='TodoWrite'` |
+| **Workflow** agents/phases | ✅ `done/total` agents | High (fleets only) | `workflows.progress` JSON (`workflow-ingest.js`) |
+| Tool-call count | ❌ no target | Low | `events` rows |
+| Elapsed time | ❌ no expected duration | Very low (misleading) | `started_at`/`ended_at` |
+
+TodoWrite is the gold signal and is currently thrown away — the hook arrives but is only stored as an opaque blob. Parsing it is the core of the feature.
+
+---
+
+## 4. Data model changes (schema)
+
+Two additive columns on `agents` (pattern matches existing `ALTER TABLE ... ADD COLUMN` migrations in `server/db.js`, e.g. `workflow_run_id`/`workflow_phase` at ~L482):
+
+| Column | Type | Meaning |
+|---|---|---|
+| `todo_done` | `INTEGER` | completed todo items (or done workflow agents) — nullable |
+| `todo_total` | `INTEGER` | total todo items (or total workflow agents) — nullable |
+| `progress_source` | `TEXT` | `'todo'` \| `'workflow'` \| `NULL` — what produced the counts |
+
+- **NULL means "no progress known"** — the UI renders nothing. This is the default for every existing row after migration.
+- Store **raw counts**, not a pre-computed percent — keeps the source data and lets the client format the bar and label consistently.
+- Naming: `todo_*` is kept generic because Fase 2 reuses the same columns with `progress_source='workflow'`; the alternative (`progress_done`/`progress_total`) is cleaner but a larger rename. **Open item #1** — decide the column names at planning.
+
+No changes to `sessions`, `events`, or `workflows` tables. New columns are covered by `SELECT *`, so REST (`server/routes/agents.js`) and WS broadcasts carry them with no mapper edit.
+
+---
+
+## 5. Fase 1 — TodoWrite ingestion (server)
+
+**Where:** `server/routes/hooks.js`, inside `processEvent`, on the `PostToolUse` branch (~L484). We use `PostToolUse` (not `PreToolUse`) so the todo list reflects the state *after* the write.
+
+**Logic (fail-safe, wrapped in try/catch):**
+```
+if (toolName === 'TodoWrite') {
+  const todos = Array.isArray(toolInput?.todos) ? toolInput.todos : [];
+  if (todos.length > 0) {
+    const total = todos.length;
+    const done  = todos.filter(t => t && t.status === 'completed').length;
+    stmts.updateAgentProgress.run(done, total, 'todo', agentId);
+  }
+}
+```
+- Attaches to the **agent that emitted the call** (the resolved `agentId` in that branch — typically the session's main agent, but a subagent that runs TodoWrite gets its own counts).
+- A new prepared statement `updateAgentProgress` (`UPDATE agents SET todo_done=?, todo_total=?, progress_source=? WHERE id=?`).
+- The existing branch already re-broadcasts the updated agent (`broadcast("agent_updated", stmts.getAgent.get(mainAgentId))`), so the new counts ship on the same frame — **no extra broadcast**.
+- Parse errors or unexpected shapes → caught, logged, ignored. Never throws inside the transaction (backend rule: non-blocking hooks).
+
+**Codex path:** the Codex ingest (`lib/codex-ingest.js`) has no TodoWrite equivalent; Codex agents simply keep `NULL` progress. Documented, not a regression.
+
+### 5.1 Terminal / reset behavior
+- **Agent completes** (`status → completed`): leave the last counts as-is (a completed agent showing its final `5/5` or `3/5` is truthful). The **card only renders the bar for `working` agents** (see §7), so a completed card shows no bar regardless — this keeps completed columns clean while preserving the data.
+- **New todo list replaces old** (agent starts a fresh plan): TodoWrite always sends the *full* current list, so `total`/`done` naturally reset to the new list on the next call. No stale accumulation.
+
+---
+
+## 6. Fase 2 — Workflow fleet progress (server)
+
+Workflow runs already store a `progress[]` JSON with one `workflow_agent` entry per inner agent, each carrying a `state` (`done | error | running | queued`). The run's main agent (`${sessionId}-main`) is the board card that represents the fleet.
+
+**Derivation (in `server/lib/workflow-ingest.js`, at the end of both `ingestWorkflowJournal` and the live-run builder):**
+```
+const agentEntries = progress.filter(e => e?.type === 'workflow_agent');
+const total = agentEntries.length;             // == journal.agentCount
+const done  = agentEntries.filter(e => ['done','error'].includes(e.state)).length;
+if (total > 0) stmts.updateAgentProgress.run(done, total, 'workflow', mainAgentId);
+```
+- Counts **`done` and `error`** as finished (an errored agent won't progress further — it's "resolved", not "in flight"). Bar reflects fleet completion.
+- Uses the same `updateAgentProgress` statement and the same three columns, with `progress_source='workflow'`.
+- **Live runs:** the real-time builder (`buildLiveWorkflow`, ~L407) already reconstructs `progress[]` from streaming transcripts; total grows as agents appear. The denominator is provisional until the terminal journal lands (flagged in tooltip via the `workflow` source — see §7). This matches the known limitation that phase/agent totals are only final at completion.
+
+### 6.1 Precedence (todo vs workflow on the same agent)
+A workflow orchestrator's main agent can have *both* its own TodoWrite list and a workflow run. Rule: **`todo` wins when present.** Concretely, the workflow update only writes progress if the agent's `progress_source` is not already `'todo'`, OR the todo update always overwrites workflow (todo is finer-grained and agent-authored). Chosen rule: **TodoWrite writes unconditionally; workflow writes only when `progress_source` is `NULL` or `'workflow'`.** This gives a single bar per card with a deterministic source. **Open item #2** — confirm this precedence.
+
+---
+
+## 7. UI — AgentCard rendering (client)
+
+**Types** (`client/src/lib/types.ts`, `Agent` interface ~L720): add
+```ts
+todo_done?: number | null;
+todo_total?: number | null;
+progress_source?: 'todo' | 'workflow' | null;
+```
+
+**Component** (`client/src/components/AgentCard.tsx`, meta row ~L269): a new presentational `<ProgressBar>` piece rendered **only when**:
+- `agent.status === 'working'` **and**
+- `todo_total` is a number `> 0`.
+
+Render:
+- A slim bar (track + fill) using existing theme tokens (`surface-*`, `accent`) — width = `done/total * 100%`.
+- A compact label `done/total` (e.g. `3/5`) beside/under the bar.
+- `title` (tooltip) = exact percent + source, e.g. `"60% · 3 of 5 todos done"` or `"60% · 3 of 5 agents done (workflow)"`. i18n keys under a `progress:*` namespace.
+- Accessible: `role="progressbar"` with `aria-valuenow/min/max` and an `aria-label`.
+
+**Where in the layout:** its own line in the card body (below the task preview, above or within the meta row) so it doesn't crowd the existing tool/model/cost/time chips. Exact placement finalized against the render snapshot.
+
+**No SessionCard change** (§2 non-goal).
+
+The board (`KanbanBoard.tsx`) needs **no** change — it re-fetches columns on `agent_updated` (debounced 300ms) and the new fields ride along.
+
+---
+
+## 8. Edge cases
+
+| Case | Behavior |
+|---|---|
+| Agent never calls TodoWrite, not a workflow | `NULL` progress → no bar. |
+| `todo_total === 0` (empty list write) | Ignored (guarded) → no bar, no divide-by-zero. |
+| Agent `waiting`/`completed`/`error` | Data retained; bar hidden (only `working` renders). |
+| Todo list shrinks/replaced | Full-list semantics → counts reset cleanly. |
+| Subagent runs its own TodoWrite | Gets its own per-agent counts (correct). |
+| Live workflow, growing total | Bar reflects current known total; tooltip source = `workflow`. |
+| Old clients / old rows | Fields absent/NULL → render nothing (backward-compatible). |
+
+---
+
+## 9. Phasing
+
+- **Fase 1 — TodoWrite (core, ~½ day):** migration + `updateAgentProgress` stmt + `PostToolUse` parse + `Agent` type + `ProgressBar` + tooltip/i18n + tests. Ship and validate here first.
+- **Fase 2 — Workflow fleets (+2–3h):** derive `done/total` in `workflow-ingest.js` (journal + live), reuse the same columns/UI. Precedence rule applied.
+
+Fase 3 (time/tool fallback): **rejected**, not built.
+
+---
+
+## 10. Verification (per CLAUDE.md)
+
+- **Backend:** `npm run test:server`
+  - `PostToolUse` with a `TodoWrite` payload → agent row has expected `todo_done/todo_total/progress_source='todo'`.
+  - Empty todos / malformed payload → no write, no throw (fail-safe).
+  - Workflow ingest (journal fixture) → main agent gets `done/total`, `progress_source='workflow'`.
+  - Precedence: agent with todo progress is not overwritten by a later workflow update.
+  - Migration idempotent on an existing DB (columns added once, NULL default).
+- **Frontend:** `npm run test:client`
+  - `ProgressBar` unit: `3/5` → 60% width, correct `aria` + tooltip; `0`/NULL → renders nothing.
+  - `AgentCard`: bar shown only for `working` + `todo_total>0`.
+  - Review + regenerate `screens.snapshot.test.tsx` baselines intentionally (`cd client && npx vitest run -u`).
+- **Docs:** run `update-project-docs` — `docs/DATABASE.md` (new columns), `docs/HOOKS.md` (TodoWrite now consumed), any card/UI reference.
+- **Headers:** every touched `.js/.ts/.tsx` keeps the `@author` header; `bash .claude/skills/file-headers/scripts/check-headers.sh` exits 0.
+
+---
+
+## 11. File change summary
+
+**Server**
+- `server/db.js` — migration (3 `ADD COLUMN`), `updateAgentProgress` prepared statement.
+- `server/routes/hooks.js` — TodoWrite parse in `PostToolUse` (Fase 1).
+- `server/lib/workflow-ingest.js` — derive fleet `done/total` in journal + live builders (Fase 2).
+
+**Client**
+- `client/src/lib/types.ts` — 3 fields on `Agent`.
+- `client/src/components/AgentCard.tsx` — `ProgressBar` render (+ small `ProgressBar` subcomponent, inline or `client/src/components/ProgressBar.tsx`).
+- i18n locale files — `progress:*` keys.
+
+**Tests**
+- `server/**/__tests__` — ingestion + migration + precedence.
+- `client/src/components/__tests__` — `ProgressBar` / `AgentCard`.
+- `client/src/pages/__tests__/screens.snapshot.test.tsx` — regenerated baseline.
+
+**Docs**
+- `docs/DATABASE.md`, `docs/HOOKS.md` (+ any others flagged by `update-project-docs`).
+
+---
+
+## 12. Decisions (locked 2026-08-05)
+1. **Column names:** `todo_done` / `todo_total` (+ `progress_source`) — generic, reused by workflow.
+2. **Precedence:** TodoWrite writes unconditionally; workflow writes only when `progress_source` is `NULL` or `'workflow'`. TodoWrite wins.
+3. **ProgressBar placement:** its own line in the card body (below the task preview), not an inline meta-row chip.
+4. **`ProgressBar` location:** shared, pure presentational `client/src/components/ProgressBar.tsx` — unit-testable in isolation.

--- a/server/__tests__/task-progress-todo.test.js
+++ b/server/__tests__/task-progress-todo.test.js
@@ -1,0 +1,123 @@
+/**
+ * @file Regression: TodoWrite hook payloads must be parsed into per-agent
+ * progress counts (agents.todo_done / todo_total / progress_source='todo').
+ * Driven via processEvent directly (no HTTP socket) so it runs under the
+ * sandbox's localhost-bind restriction. Malformed/empty payloads must never
+ * write or throw.
+ * @author Son Nguyen <hoangson091104@gmail.com>
+ */
+
+const { describe, it, before, after } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("path");
+const os = require("os");
+const fs = require("fs");
+
+const TEST_DB = path.join(os.tmpdir(), `task-progress-todo-${Date.now()}-${process.pid}.db`);
+process.env.DASHBOARD_DB_PATH = TEST_DB;
+process.env.DASHBOARD_LIVENESS_PROBE = "0";
+
+const { db, stmts } = require("../db");
+const hooks = require("../routes/hooks");
+const processEvent = hooks.processEvent;
+
+after(() => {
+  if (db) db.close();
+  for (const suffix of ["", "-wal", "-shm"]) {
+    try {
+      fs.unlinkSync(TEST_DB + suffix);
+    } catch {
+      /* ignore */
+    }
+  }
+});
+
+function driveWorkingMain(sid) {
+  processEvent("SessionStart", { session_id: sid });
+  processEvent("UserPromptSubmit", { session_id: sid, prompt: "go" });
+}
+
+describe("TodoWrite -> agent progress", () => {
+  it("writes completed/total and progress_source='todo'", () => {
+    const sid = "todo-basic";
+    driveWorkingMain(sid);
+    processEvent("PostToolUse", {
+      session_id: sid,
+      tool_name: "TodoWrite",
+      tool_input: {
+        todos: [
+          { content: "a", status: "completed" },
+          { content: "b", status: "completed" },
+          { content: "c", status: "in_progress" },
+          { content: "d", status: "pending" },
+          { content: "e", status: "pending" },
+        ],
+      },
+    });
+    const agent = stmts.getAgent.get(`${sid}-main`);
+    assert.equal(agent.todo_total, 5);
+    assert.equal(agent.todo_done, 2); // in_progress counts as NOT done (unweighted)
+    assert.equal(agent.progress_source, "todo");
+  });
+
+  it("updates counts when a later TodoWrite replaces the list", () => {
+    const sid = "todo-replace";
+    driveWorkingMain(sid);
+    processEvent("PostToolUse", {
+      session_id: sid,
+      tool_name: "TodoWrite",
+      tool_input: { todos: [{ content: "x", status: "completed" }] },
+    });
+    processEvent("PostToolUse", {
+      session_id: sid,
+      tool_name: "TodoWrite",
+      tool_input: {
+        todos: [
+          { content: "x", status: "completed" },
+          { content: "y", status: "completed" },
+          { content: "z", status: "pending" },
+        ],
+      },
+    });
+    const agent = stmts.getAgent.get(`${sid}-main`);
+    assert.equal(agent.todo_total, 3);
+    assert.equal(agent.todo_done, 2);
+  });
+
+  it("ignores an empty todos array (no write, no throw)", () => {
+    const sid = "todo-empty";
+    driveWorkingMain(sid);
+    processEvent("PostToolUse", {
+      session_id: sid,
+      tool_name: "TodoWrite",
+      tool_input: { todos: [] },
+    });
+    const agent = stmts.getAgent.get(`${sid}-main`);
+    assert.equal(agent.todo_total, null);
+    assert.equal(agent.progress_source, null);
+  });
+
+  it("ignores a malformed TodoWrite payload without throwing", () => {
+    const sid = "todo-malformed";
+    driveWorkingMain(sid);
+    assert.doesNotThrow(() =>
+      processEvent("PostToolUse", {
+        session_id: sid,
+        tool_name: "TodoWrite",
+        tool_input: { todos: "not-an-array" },
+      })
+    );
+    const agent = stmts.getAgent.get(`${sid}-main`);
+    assert.equal(agent.todo_total, null);
+  });
+
+  it("leaves non-TodoWrite tools untouched", () => {
+    const sid = "todo-other";
+    driveWorkingMain(sid);
+    processEvent("PreToolUse", { session_id: sid, tool_name: "Read", tool_input: {} });
+    processEvent("PostToolUse", { session_id: sid, tool_name: "Read", tool_input: {} });
+    const agent = stmts.getAgent.get(`${sid}-main`);
+    assert.equal(agent.todo_total, null);
+    assert.equal(agent.progress_source, null);
+  });
+});

--- a/server/__tests__/task-progress-workflow.test.js
+++ b/server/__tests__/task-progress-workflow.test.js
@@ -1,0 +1,137 @@
+/**
+ * @file Tests for Workflow-tool fleet progress written onto the run's MAIN
+ * agent (`${sessionId}-main`) with `progress_source='workflow'`. A completed
+ * journal's `progress[]` (done/total inner `workflow_agent` entries) is folded
+ * onto the main row — counting a `done` OR `error` inner agent as finished —
+ * but a finer-grained `'todo'` progress the orchestrator set for itself via
+ * TodoWrite is never overwritten (TodoWrite wins the precedence).
+ * @author Son Nguyen <hoangson091104@gmail.com>
+ */
+
+const { describe, it, before, after } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+// Isolated test DB before requiring any server module.
+const TEST_DB = path.join(os.tmpdir(), `dashboard-wfprog-test-${Date.now()}-${process.pid}.db`);
+process.env.DASHBOARD_DB_PATH = TEST_DB;
+
+const dbModule = require("../db");
+const { stmts } = dbModule;
+const { ingestWorkflowsForSession } = require("../lib/workflow-ingest");
+
+let ROOT; // temp transcript root
+
+function writeJson(p, obj) {
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, JSON.stringify(obj));
+}
+
+/** Path to a session's transcript JSONL under the temp root. */
+function transcriptPathFor(sid) {
+  return path.join(ROOT, `${sid}.jsonl`);
+}
+
+/** Seed a session row + its `${sid}-main` agent (FK targets), write transcript. */
+function seedSession(sid) {
+  const tp = transcriptPathFor(sid);
+  fs.writeFileSync(tp, ""); // only dirname + basename are used
+  stmts.insertSession.run(sid, `session ${sid}`, "active", "/tmp/proj", "claude-opus-4-8", null);
+  stmts.insertAgent.run(`${sid}-main`, sid, "Main", "main", null, "completed", null, null, null);
+  return tp;
+}
+
+/** Write a completed run journal whose progress[] carries workflow_agent entries. */
+function writeJournal(sid, runId, agents) {
+  const workflowProgress = agents.map((a, i) => ({
+    type: "workflow_agent",
+    index: i + 1,
+    agentId: a.agentId || `${runId}-a${i + 1}`,
+    model: "claude-opus-4-8",
+    state: a.state,
+    label: `agent:${i + 1}`,
+    phaseTitle: "Work",
+  }));
+  writeJson(path.join(ROOT, sid, "workflows", `${runId}.json`), {
+    runId,
+    workflowName: "fleet-run",
+    status: "completed",
+    startTime: 1700000000000,
+    durationMs: 1000,
+    agentCount: agents.length,
+    totalTokens: 0,
+    totalToolCalls: 0,
+    phases: [],
+    workflowProgress,
+  });
+}
+
+before(() => {
+  ROOT = fs.mkdtempSync(path.join(os.tmpdir(), "wfprog-fixture-"));
+});
+
+after(() => {
+  try {
+    fs.rmSync(ROOT, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+  try {
+    dbModule.db.close();
+  } catch {
+    /* ignore */
+  }
+  try {
+    fs.rmSync(TEST_DB, { force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+describe("workflow fleet progress on the main agent", () => {
+  it("writes done/total from workflow_agent entries with progress_source='workflow'", async () => {
+    const sid = "sess-prog-1";
+    const tp = seedSession(sid);
+    // 3 inner agents: 2 done, 1 running.
+    writeJournal(sid, "wf_prog1", [{ state: "done" }, { state: "done" }, { state: "running" }]);
+
+    await ingestWorkflowsForSession(dbModule, { id: sid, transcript_path: tp });
+
+    const main = stmts.getAgent.get(`${sid}-main`);
+    assert.equal(main.todo_total, 3);
+    assert.equal(main.todo_done, 2);
+    assert.equal(main.progress_source, "workflow");
+  });
+
+  it("counts an 'error' inner agent as finished", async () => {
+    const sid = "sess-prog-2";
+    const tp = seedSession(sid);
+    // done, error, running → 2 finished of 3.
+    writeJournal(sid, "wf_prog2", [{ state: "done" }, { state: "error" }, { state: "running" }]);
+
+    await ingestWorkflowsForSession(dbModule, { id: sid, transcript_path: tp });
+
+    const main = stmts.getAgent.get(`${sid}-main`);
+    assert.equal(main.todo_total, 3);
+    assert.equal(main.todo_done, 2);
+    assert.equal(main.progress_source, "workflow");
+  });
+
+  it("never overwrites a finer-grained 'todo' progress (TodoWrite wins)", async () => {
+    const sid = "sess-prog-3";
+    const tp = seedSession(sid);
+    // Orchestrator set its own todo progress first.
+    stmts.updateAgentProgress.run(1, 4, "todo", `${sid}-main`);
+
+    writeJournal(sid, "wf_prog3", [{ state: "done" }, { state: "done" }, { state: "running" }]);
+
+    await ingestWorkflowsForSession(dbModule, { id: sid, transcript_path: tp });
+
+    const main2 = stmts.getAgent.get(`${sid}-main`);
+    assert.equal(main2.progress_source, "todo");
+    assert.equal(main2.todo_total, 4);
+    assert.equal(main2.todo_done, 1);
+  });
+});

--- a/server/db.js
+++ b/server/db.js
@@ -484,6 +484,19 @@ try {
 }
 db.prepare("CREATE INDEX IF NOT EXISTS idx_agents_workflow ON agents(workflow_run_id)").run();
 
+// Migrate: per-agent task-progress counts. `todo_done`/`todo_total` come from
+// the agent's own TodoWrite list (completed/total items) or, for Workflow-tool
+// runs, done/total inner agents. `progress_source` records which produced them
+// ('todo' | 'workflow'). NULL everywhere = no progress known. Additive, safe on
+// existing DBs.
+try {
+  db.prepare("SELECT todo_done FROM agents LIMIT 1").get();
+} catch {
+  db.prepare("ALTER TABLE agents ADD COLUMN todo_done INTEGER").run();
+  db.prepare("ALTER TABLE agents ADD COLUMN todo_total INTEGER").run();
+  db.prepare("ALTER TABLE agents ADD COLUMN progress_source TEXT").run();
+}
+
 // Migrate: add the 1h-ephemeral cache-write rate column to model_pricing.
 // Older DBs predate the 5m/1h cache-write split. ADD COLUMN defaults every
 // existing row to 0, which is not a realistic rate — so immediately backfill a
@@ -1015,6 +1028,9 @@ try {
         awaiting_reason TEXT,
         workflow_run_id TEXT,
         workflow_phase TEXT,
+        todo_done INTEGER,
+        todo_total INTEGER,
+        progress_source TEXT,
         FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE,
         FOREIGN KEY (parent_agent_id) REFERENCES agents(id) ON DELETE SET NULL
       );
@@ -1026,7 +1042,8 @@ try {
           ELSE status
         END,
         task, current_tool, started_at, ended_at, parent_agent_id, metadata,
-        updated_at, awaiting_input_since, awaiting_reason, workflow_run_id, workflow_phase
+        updated_at, awaiting_input_since, awaiting_reason, workflow_run_id, workflow_phase,
+        todo_done, todo_total, progress_source
       FROM agents;
       DROP TABLE agents;
       ALTER TABLE agents_new RENAME TO agents;
@@ -1439,6 +1456,9 @@ const stmts = {
   ),
 
   getAgent: db.prepare("SELECT * FROM agents WHERE id = ?"),
+  updateAgentProgress: db.prepare(
+    "UPDATE agents SET todo_done = ?, todo_total = ?, progress_source = ? WHERE id = ?"
+  ),
   listAgents: db.prepare(
     `SELECT a.*, ${AGENT_LAST_ACTIVITY_SQL} AS last_activity
      FROM agents a ORDER BY last_activity DESC LIMIT ? OFFSET ?`

--- a/server/lib/workflow-ingest.js
+++ b/server/lib/workflow-ingest.js
@@ -100,6 +100,26 @@ function mapState(state) {
   }
 }
 
+/**
+ * Write fleet progress (done/total inner agents) onto the run's main agent,
+ * but never overwrite a finer-grained 'todo' progress the orchestrator set for
+ * itself. Counts a `done` OR `error` inner agent as finished (an errored agent
+ * won't progress further). No-op when there are no inner agents or no main row.
+ */
+function writeWorkflowProgress(dbModule, mainAgentId, progress) {
+  const { stmts } = dbModule;
+  const entries = Array.isArray(progress)
+    ? progress.filter((e) => e && e.type === "workflow_agent")
+    : [];
+  const total = entries.length;
+  if (total === 0) return;
+  const done = entries.filter((e) => e.state === "done" || e.state === "error").length;
+  const main = stmts.getAgent.get(mainAgentId);
+  if (!main) return;
+  if (main.progress_source === "todo") return; // TodoWrite wins (spec precedence)
+  stmts.updateAgentProgress.run(done, total, "workflow", mainAgentId);
+}
+
 // Token fields carried on a parsed-subagent bucket (camelCase, matching
 // writeSessionTokens). Used to fold inner-agent usage into the session's cost.
 const TOKEN_FIELDS = [
@@ -370,6 +390,12 @@ async function ingestWorkflowJournal(dbModule, sessionId, journal, opts = {}) {
     }
   }
 
+  try {
+    writeWorkflowProgress(dbModule, mainAgentId, journal.progress);
+  } catch {
+    /* progress is best-effort; never fail the ingest over it */
+  }
+
   return { row: stmts.getWorkflow.get(journal.runId), tokens: runTokens };
 }
 
@@ -571,6 +597,13 @@ async function ingestLiveWorkflow(dbModule, sessionId, sessionDir, runId, script
     null,
     "live"
   );
+
+  try {
+    writeWorkflowProgress(dbModule, mainAgentId, progress);
+  } catch {
+    /* best-effort */
+  }
+
   return { row: stmts.getWorkflow.get(runId), tokens: runTokens };
 }
 

--- a/server/routes/hooks.js
+++ b/server/routes/hooks.js
@@ -510,6 +510,26 @@ const processEvent = db.transaction((hookType, data) => {
         }
       }
 
+      // TodoWrite carries the agent's own plan — completed/total items is the
+      // one real, self-declared progress denominator we get. Parse it into
+      // per-agent counts and attribute to whoever ran it (agentId, already
+      // resolved above to the deepest working subagent when main is waiting).
+      // Fail-safe: a malformed payload must never throw inside this ingest
+      // transaction (backend rule: hooks stay non-blocking).
+      if (toolName === "TodoWrite") {
+        try {
+          const todos = Array.isArray(data.tool_input?.todos) ? data.tool_input.todos : [];
+          if (todos.length > 0) {
+            const total = todos.length;
+            const done = todos.filter((item) => item && item.status === "completed").length;
+            stmts.updateAgentProgress.run(done, total, "todo", agentId);
+            broadcast("agent_updated", stmts.getAgent.get(agentId));
+          }
+        } catch {
+          /* fail-safe: ignore malformed TodoWrite payloads */
+        }
+      }
+
       // Only clear current_tool on the main agent if it's actively working.
       // Skip if waiting (waiting for subagents) or already completed.
       if (mainAgent && mainAgent.status === "working") {
@@ -1637,3 +1657,7 @@ router.livenessReap = livenessReap;
 // Exposed as a narrow test seam for version-variant Codex hook payloads.
 router.codexTranscriptPath = codexTranscriptPath;
 module.exports = router;
+
+// Exposed for tests: lets suites drive ingestion directly without binding an
+// HTTP socket (the route handler just calls processEvent(hook_type, data)).
+module.exports.processEvent = processEvent;


### PR DESCRIPTION
## O que muda
Barra de progresso (barra + `3/5`, `%` no tooltip) nos cards de agente do Kanban, a partir de sinais reais — nunca estimativa fabricada:
- **TodoWrite (Fase 1):** `PostToolUse` de `TodoWrite` → `completed/total` (sem peso) por agente, `progress_source='todo'`.
- **Workflow (Fase 2):** runs do Workflow-tool escrevem `done+error / total` no main agent do run, `progress_source='workflow'`, sem sobrescrever `'todo'`.

A barra só aparece para agentes `working` com `todo_total > 0`; sem denominador real, nada é mostrado.

## Detalhes
- Migração aditiva em `agents` (`todo_done`/`todo_total`/`progress_source`), carregada também no legacy-rebuild. Retrocompatível (NULL = sem progresso).
- Ingestão fail-safe (nunca bloqueia o hook); campos fluem via `SELECT *` + broadcast `agent_updated`.
- `ProgressBar` acessível, i18n em 5 idiomas.

## Verificação
- Cliente 308/308; servidor DB-only 27/27; header audit OK; sem diff de snapshot.
- Suítes HTTP validadas localmente (as 6 falhas em `ccam-cli` são pré-existentes, sem relação com este change-set).
- Verificado ao vivo: card `working` mostra a barra 3/5 via ingestão real de `TodoWrite`.

## Artefatos
- Spec: docs/superpowers/specs/2026-08-05-kanban-task-progress-design.md
- Plano: docs/superpowers/plans/2026-08-05-kanban-task-progress.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)