### PR TITLE
fix(windows): suppress console popups from background child processes

### DIFF
--- a/server/lib/run-spawner.js
+++ b/server/lib/run-spawner.js
@@ -314,6 +314,7 @@ function spawnRun(args) {
     env: cleanSpawnEnv(),
     cwd: cwd || process.cwd(),
     stdio: ["pipe", "pipe", "pipe"],
+    windowsHide: true,
   });
 
   const handle = {

--- a/server/lib/update-check.js
+++ b/server/lib/update-check.js
@@ -23,7 +23,7 @@ function execGit(cwd, args, opts = {}) {
     execFile(
       "git",
       args,
-      { cwd, timeout, maxBuffer: 2_000_000, encoding: "utf8" },
+      { cwd, timeout, maxBuffer: 2_000_000, encoding: "utf8", windowsHide: true },
       (err, stdout) => {
         if (err) reject(err);
         else resolve(String(stdout).trim());


### PR DESCRIPTION
Add windowsHide:true to execFile/spawn calls in update-check.js and run-spawner.js. Without this option, periodic git fetch (every 5min) and Run Agent spawns flash a visible console window on Windows.

Closes #277

## Summary

<!-- What does this PR do? Keep it to 1-3 sentences. -->

## Changes

<!-- Bullet list of what changed and why. -->

-

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (no functional changes)
- [ ] Documentation update
- [ ] Infrastructure / CI / DevOps
- [ ] Dependency update

## How to Test

<!-- Steps a reviewer can follow to verify the change. -->

1.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/hoangsonww/Claude-Code-Agent-Monitor/blob/master/.github/CONTRIBUTING.md)
- [x] I have signed the [CLA](https://github.com/hoangsonww/Claude-Code-Agent-Monitor/blob/master/CLA.md) (the `🖋️ CLA Assistant` bot will prompt me on my first PR)
- [x] My code follows the project's coding standards
- [ ] I have added/updated tests that prove my fix or feature works
- [ ] All new and existing tests pass (`npm test`)
- [x] Code is formatted (`npm run format:check`)
- [ ] I have updated documentation where necessary

## Screenshots

<!-- If UI changes, include before/after screenshots. Delete this section otherwise. -->
