### PR TITLE
chore(release): bump version to v2.0.8

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -193,7 +193,7 @@ Render and replace the local image name with an immutable registry reference:
 REGISTRY="ghcr.io/$(gh repo view --json owner -q .owner.login)"
 IMAGE_TAG="$(git rev-parse --short HEAD)"
 kubectl kustomize deployments/kubernetes/overlays/production \
-  | sed "s|ccam-dashboard:2.0.6|${REGISTRY}/claude-code-agent-monitor:${IMAGE_TAG}|g" \
+  | sed "s|ccam-dashboard:2.0.8|${REGISTRY}/claude-code-agent-monitor:${IMAGE_TAG}|g" \
   | kubectl apply --server-side --field-manager=ccam-deployer -f -
 ```
 

--- a/README-CN.md
+++ b/README-CN.md
@@ -73,6 +73,9 @@
 
 切换文档：[`README.md`](./README.md) · [`README-CN.md`](./README-CN.md) · [`README-VN.md`](./README-VN.md) · [`README-KO.md`](./README-KO.md) · [`README-ES.md`](./README-ES.md)
 
+> [!NOTE]
+> 需要按任务查阅的帮助？[GitHub Wiki](https://github.com/hoangsonww/Claude-Code-Agent-Monitor/wiki) 是面向日常使用、团队运维、故障排查、CLI/MCP 自动化和部署操作的实用手册。[本地化静态 Wiki](https://hoangsonww.github.io/Claude-Code-Agent-Monitor/wiki/) 继续提供英语、越南语、中文、韩语和西班牙语的产品与架构导览；精确的技术契约仍以 [`docs/`](./docs/README.md) 为准。
+
 ---
 
 ## 目录

--- a/README-ES.md
+++ b/README-ES.md
@@ -72,6 +72,9 @@ Un panel profesional para rastrear y visualizar sus sesiones de agente Claude Co
 > [!TIP]
 > Consulta también [README.md](./README.md) (English), [README-CN.md](./README-CN.md) (中文), [README-VN.md](./README-VN.md) (Tiếng Việt) y [README-KO.md](./README-KO.md) (한국어). Este es el README en español.
 
+> [!NOTE]
+> ¿Necesitas ayuda orientada a tareas? La [Wiki de GitHub](https://github.com/hoangsonww/Claude-Code-Agent-Monitor/wiki) es el manual práctico para el uso diario, las operaciones de equipo, la solución de problemas, la automatización con CLI/MCP y las recetas de despliegue. La [Wiki estática localizada](https://hoangsonww.github.io/Claude-Code-Agent-Monitor/wiki/) sigue siendo el recorrido del producto y la arquitectura en inglés, vietnamita, chino, coreano y español; los contratos técnicos exactos permanecen en [`docs/`](./docs/README.md).
+
 ---
 
 ## Índice de contenidos

--- a/README-KO.md
+++ b/README-KO.md
@@ -72,6 +72,9 @@ Claude Code & Codex 에이전트 세션, 도구 사용, 서브에이전트 오�
 > [!TIP]
 > 참고: 영어 원문은 [README.md](./README.md), 중국어 버전은 [README-CN.md](./README-CN.md) (中文版本), 베트남어 버전은 [README-VN.md](./README-VN.md) (Phiên bản tiếng Việt), 스페인어 버전은 [README-ES.md](./README-ES.md) (Español)를 확인하세요. 이 문서는 한국어 버전입니다.
 
+> [!NOTE]
+> 작업 중심의 도움이 필요하신가요? [GitHub Wiki](https://github.com/hoangsonww/Claude-Code-Agent-Monitor/wiki)는 일상적인 사용, 팀 운영, 문제 해결, CLI/MCP 자동화 및 배포 절차를 위한 실용 핸드북입니다. [현지화된 정적 Wiki](https://hoangsonww.github.io/Claude-Code-Agent-Monitor/wiki/)는 영어, 베트남어, 중국어, 한국어 및 스페인어 제품·아키텍처 둘러보기를 계속 제공하며, 정확한 기술 계약은 [`docs/`](./docs/README.md)에 유지됩니다.
+
 ---
 
 ## 목차

--- a/README-VN.md
+++ b/README-VN.md
@@ -73,6 +73,9 @@ Bảng điều khiển chuyên nghiệp để theo dõi và trực quan hóa cá
 
 Tài liệu đã bản địa hóa: [`README.md`](./README.md) · [`README-CN.md`](./README-CN.md) · [`README-VN.md`](./README-VN.md) · [`README-KO.md`](./README-KO.md) · [`README-ES.md`](./README-ES.md)
 
+> [!NOTE]
+> Bạn cần hướng dẫn theo tác vụ? [GitHub Wiki](https://github.com/hoangsonww/Claude-Code-Agent-Monitor/wiki) là sổ tay thực hành về sử dụng hằng ngày, vận hành theo nhóm, khắc phục sự cố, tự động hóa CLI/MCP và các quy trình triển khai. [Wiki tĩnh đã bản địa hóa](https://hoangsonww.github.io/Claude-Code-Agent-Monitor/wiki/) vẫn là phần giới thiệu sản phẩm và kiến trúc bằng tiếng Anh, Việt, Trung, Hàn và Tây Ban Nha; các hợp đồng kỹ thuật chính xác vẫn nằm trong [`docs/`](./docs/README.md).
+
 ---
 
 ## Mục lục

--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ A professional dashboard to track and visualize your Claude Code and Codex agent
 > [!TIP]
 > See also: [README-CN.md](./README-CN.md) (中文版本), [README-VN.md](./README-VN.md) (Phiên bản tiếng Việt), [README-KO.md](./README-KO.md) (한국어 버전), and [README-ES.md](./README-ES.md) (versión en español) for localized documentation with region-specific tips and best practices.
 
+> [!NOTE]
+> Need task-first help? The [GitHub Wiki](https://github.com/hoangsonww/Claude-Code-Agent-Monitor/wiki) is the practical handbook for everyday use, team operations, troubleshooting, CLI/MCP automation, and deployment recipes. The [localized static Wiki](https://hoangsonww.github.io/Claude-Code-Agent-Monitor/wiki/) remains the English, Vietnamese, Chinese, Korean, and Spanish product and architecture tour; exact technical contracts stay in [`docs/`](./docs/README.md).
+
 ---
 
 ## Table of Contents

--- a/client/src/pages/__tests__/__snapshots__/screens.snapshot.test.tsx.snap
+++ b/client/src/pages/__tests__/__snapshots__/screens.snapshot.test.tsx.snap
@@ -10553,7 +10553,7 @@ exports[`screen snapshots > Settings 1`] = `
             <p
               class="text-[10px] text-amber-400/90 mt-1"
             >
-              UI build v2.0.6 (rebuild client to match)
+              UI build v2.0.8 (rebuild client to match)
             </p>
           </div>
           <div

--- a/deployments/helm/agent-monitor/Chart.yaml
+++ b/deployments/helm/agent-monitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agent-monitor
 description: Production-safe single-writer CCAM deployment for Claude Code and Codex monitoring
 type: application
-version: 2.0.6
-appVersion: "2.0.6"
+version: 2.0.8
+appVersion: "2.0.8"
 
 home: https://github.com/hoangsonww/Claude-Code-Agent-Monitor
 sources:

--- a/deployments/kubernetes/base/configmap.yaml
+++ b/deployments/kubernetes/base/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: agent-monitor
     app.kubernetes.io/instance: agent-monitor
-    app.kubernetes.io/version: "2.0.6"
+    app.kubernetes.io/version: "2.0.8"
     app.kubernetes.io/component: config
     app.kubernetes.io/managed-by: kustomize
 data:

--- a/deployments/kubernetes/base/deployment.yaml
+++ b/deployments/kubernetes/base/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: agent-monitor
     app.kubernetes.io/instance: agent-monitor
-    app.kubernetes.io/version: "2.0.6"
+    app.kubernetes.io/version: "2.0.8"
     app.kubernetes.io/component: server
     app.kubernetes.io/managed-by: kustomize
 spec:
@@ -25,7 +25,7 @@ spec:
       labels:
         app.kubernetes.io/name: agent-monitor
         app.kubernetes.io/instance: agent-monitor
-        app.kubernetes.io/version: "2.0.6"
+        app.kubernetes.io/version: "2.0.8"
         app.kubernetes.io/component: server
         app.kubernetes.io/managed-by: kustomize
     spec:
@@ -44,7 +44,7 @@ spec:
 
       containers:
         - name: agent-monitor
-          image: ccam-dashboard:2.0.6
+          image: ccam-dashboard:2.0.8
           imagePullPolicy: IfNotPresent
 
           ports:

--- a/deployments/kubernetes/base/ingress.yaml
+++ b/deployments/kubernetes/base/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: agent-monitor
     app.kubernetes.io/instance: agent-monitor
-    app.kubernetes.io/version: "2.0.6"
+    app.kubernetes.io/version: "2.0.8"
     app.kubernetes.io/component: ingress
     app.kubernetes.io/managed-by: kustomize
   annotations:

--- a/deployments/kubernetes/base/kustomization.yaml
+++ b/deployments/kubernetes/base/kustomization.yaml
@@ -8,7 +8,7 @@ labels:
   - pairs:
       app.kubernetes.io/name: agent-monitor
       app.kubernetes.io/instance: agent-monitor
-      app.kubernetes.io/version: "2.0.6"
+      app.kubernetes.io/version: "2.0.8"
       app.kubernetes.io/managed-by: kustomize
 
 resources:
@@ -23,4 +23,4 @@ resources:
 
 images:
   - name: ccam-dashboard
-    newTag: 2.0.6
+    newTag: 2.0.8

--- a/deployments/kubernetes/base/namespace.yaml
+++ b/deployments/kubernetes/base/namespace.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: agent-monitor
     app.kubernetes.io/instance: agent-monitor
-    app.kubernetes.io/version: "2.0.6"
+    app.kubernetes.io/version: "2.0.8"
     app.kubernetes.io/component: namespace
     app.kubernetes.io/managed-by: kustomize
     # Enable Pod Security Standards (restricted)

--- a/deployments/kubernetes/base/networkpolicy.yaml
+++ b/deployments/kubernetes/base/networkpolicy.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: agent-monitor
     app.kubernetes.io/instance: agent-monitor
-    app.kubernetes.io/version: "2.0.6"
+    app.kubernetes.io/version: "2.0.8"
     app.kubernetes.io/component: network
     app.kubernetes.io/managed-by: kustomize
 spec:

--- a/deployments/kubernetes/base/pvc.yaml
+++ b/deployments/kubernetes/base/pvc.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: agent-monitor
     app.kubernetes.io/instance: agent-monitor
-    app.kubernetes.io/version: "2.0.6"
+    app.kubernetes.io/version: "2.0.8"
     app.kubernetes.io/component: storage
     app.kubernetes.io/managed-by: kustomize
 spec:

--- a/deployments/kubernetes/base/service.yaml
+++ b/deployments/kubernetes/base/service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: agent-monitor
     app.kubernetes.io/instance: agent-monitor
-    app.kubernetes.io/version: "2.0.6"
+    app.kubernetes.io/version: "2.0.8"
     app.kubernetes.io/component: server
     app.kubernetes.io/managed-by: kustomize
 spec:

--- a/deployments/kubernetes/base/serviceaccount.yaml
+++ b/deployments/kubernetes/base/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: agent-monitor
     app.kubernetes.io/instance: agent-monitor
-    app.kubernetes.io/version: "2.0.6"
+    app.kubernetes.io/version: "2.0.8"
     app.kubernetes.io/component: serviceaccount
     app.kubernetes.io/managed-by: kustomize
 automountServiceAccountToken: false

--- a/deployments/kubernetes/components/mcp-sidecar/deployment-patch.yaml
+++ b/deployments/kubernetes/components/mcp-sidecar/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: mcp-sidecar
-          image: ccam-mcp:2.0.6
+          image: ccam-mcp:2.0.8
           imagePullPolicy: IfNotPresent
 
           ports:

--- a/deployments/kubernetes/components/mcp-sidecar/kustomization.yaml
+++ b/deployments/kubernetes/components/mcp-sidecar/kustomization.yaml
@@ -16,4 +16,4 @@ patches:
 
 images:
   - name: ccam-mcp
-    newTag: 2.0.6
+    newTag: 2.0.8

--- a/deployments/kubernetes/components/monitoring/servicemonitor.yaml
+++ b/deployments/kubernetes/components/monitoring/servicemonitor.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: agent-monitor
     app.kubernetes.io/instance: agent-monitor
-    app.kubernetes.io/version: "2.0.6"
+    app.kubernetes.io/version: "2.0.8"
     app.kubernetes.io/component: monitoring
     app.kubernetes.io/managed-by: kustomize
     # Common label for Prometheus Operator discovery

--- a/deployments/kubernetes/overlays/dev/kustomization.yaml
+++ b/deployments/kubernetes/overlays/dev/kustomization.yaml
@@ -11,7 +11,7 @@ resources:
 
 images:
   - name: ccam-dashboard
-    newTag: 2.0.6
+    newTag: 2.0.8
 
 patches:
   - path: patches/deployment-patch.yaml

--- a/deployments/kubernetes/overlays/production/kustomization.yaml
+++ b/deployments/kubernetes/overlays/production/kustomization.yaml
@@ -31,4 +31,4 @@ patches:
 
 images:
   - name: ccam-dashboard
-    newTag: 2.0.6
+    newTag: 2.0.8

--- a/deployments/kubernetes/overlays/staging/kustomization.yaml
+++ b/deployments/kubernetes/overlays/staging/kustomization.yaml
@@ -31,4 +31,4 @@ patches:
 
 images:
   - name: ccam-dashboard
-    newTag: 2.0.6
+    newTag: 2.0.8

--- a/deployments/scripts/deploy.sh
+++ b/deployments/scripts/deploy.sh
@@ -85,7 +85,7 @@ ${BOLD}Options:${NC}
 
 ${BOLD}Examples:${NC}
   $(basename "$0") --env dev --method helm
-  $(basename "$0") --env production --method helm --tag 2.0.6
+  $(basename "$0") --env production --method helm --tag 2.0.8
   $(basename "$0") --env staging --method kustomize --dry-run
 
 EOF
@@ -299,7 +299,7 @@ deploy_kustomize() {
 
   local rendered
   rendered="$(mktemp)"
-  kubectl kustomize "${overlay_dir}" | sed "s|ccam-dashboard:2.0.6|${FULL_IMAGE}|g" > "${rendered}"
+  kubectl kustomize "${overlay_dir}" | sed "s|ccam-dashboard:2.0.8|${FULL_IMAGE}|g" > "${rendered}"
   if ! kubectl apply -f "${rendered}" --server-side --field-manager=ccam-deployer; then
     rm -f "${rendered}"
     err "Kustomize deployment failed!"

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-dashboard-desktop",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-dashboard-desktop",
-      "version": "2.0.6",
+      "version": "2.0.8",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-dashboard-desktop",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "private": true,
   "description": "Native macOS and Windows desktop shell for Claude Code Agent Monitor.",
   "author": "Son Nguyen <hoangson091104@gmail.com>",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ name: ccam
 # or run two active containers against the same data volume.
 services:
   agent-monitor:
-    image: ${CCAM_IMAGE:-ccam-dashboard:2.0.6}
+    image: ${CCAM_IMAGE:-ccam-dashboard:2.0.8}
     build:
       context: .
       dockerfile: Dockerfile
@@ -62,7 +62,7 @@ services:
   # Compose network and publishes MCP on host loopback only.
   mcp:
     profiles: ["mcp"]
-    image: ${CCAM_MCP_IMAGE:-ccam-mcp:2.0.6}
+    image: ${CCAM_MCP_IMAGE:-ccam-mcp:2.0.8}
     build:
       context: .
       dockerfile: mcp/Dockerfile

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -193,7 +193,7 @@ Render and replace the local image name with an immutable registry reference:
 REGISTRY="ghcr.io/$(gh repo view --json owner -q .owner.login)"
 IMAGE_TAG="$(git rev-parse --short HEAD)"
 kubectl kustomize deployments/kubernetes/overlays/production \
-  | sed "s|ccam-dashboard:2.0.6|${REGISTRY}/claude-code-agent-monitor:${IMAGE_TAG}|g" \
+  | sed "s|ccam-dashboard:2.0.8|${REGISTRY}/claude-code-agent-monitor:${IMAGE_TAG}|g" \
   | kubectl apply --server-side --field-manager=ccam-deployer -f -
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,8 @@ Comprehensive documentation for the Agent Dashboard project.
 
 ## Quick Links
 
+- [Operator Handbook](https://github.com/hoangsonww/Claude-Code-Agent-Monitor/wiki) - Task-oriented usage, operations, automation, and troubleshooting
+- [Localized Product Wiki](https://hoangsonww.github.io/Claude-Code-Agent-Monitor/wiki/) - English, Vietnamese, Chinese, Korean, and Spanish product and architecture tour
 - [Architecture Overview](../ARCHITECTURE.md) - System design and technical reference
 - [I18N Architecture](./I18N.md) - Internationalization architecture and usage guide
 - [CLI Reference](./CLI.md) - The `ccam` terminal CLI: every command, discovery, safety model
@@ -20,6 +22,7 @@ Start with the smallest set of documents for the job at hand, then use the catal
 
 | Goal | Start here | Continue with |
 | --- | --- | --- |
+| Use or troubleshoot CCAM day to day | [GitHub Wiki](https://github.com/hoangsonww/Claude-Code-Agent-Monitor/wiki) | [Localized product Wiki](https://hoangsonww.github.io/Claude-Code-Agent-Monitor/wiki/) or the exact references below |
 | Run CCAM locally | [INSTALL.md](../INSTALL.md) | [SETUP.md](../SETUP.md), then the dashboard |
 | Integrate with the API or WebSocket | [API.md](./API.md) | [MCP.md](./MCP.md) for an MCP-based integration |
 | Understand captured activity | [HOOKS.md](./HOOKS.md) | [DATABASE.md](./DATABASE.md) and [ARCHITECTURE.md](../ARCHITECTURE.md) |

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.0.3
 info:
   title: Agent Dashboard for Claude Code API
-  version: 2.0.6
+  version: 2.0.8
   description: HTTP API for real-time Claude Code session monitoring, agent lifecycle tracking, analytics, pricing, hooks ingestion, and workflow intelligence.
   contact:
     name: Son Nguyen
@@ -573,7 +573,7 @@ components:
         version:
           type: string
           description: Dashboard release version from package.json
-          example: 2.0.6
+          example: 2.0.8
         timestamp:
           type: string
           format: date-time

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-dashboard",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-dashboard",
-      "version": "2.0.6",
+      "version": "2.0.8",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-dashboard",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "bin": {
     "ccam": "bin/ccam.js"
   },

--- a/plugins/ccam-analytics/.claude-plugin/plugin.json
+++ b/plugins/ccam-analytics/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccam-analytics",
   "description": "Deep analytics and monitoring for Claude Code sessions — cost tracking, token usage breakdowns, usage trends, and productivity scoring powered by Agent Monitor.",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "author": { "name": "Son Nguyen", "url": "https://github.com/hoangsonww" },
   "homepage": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",
   "repository": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",

--- a/plugins/ccam-analytics/.codex-plugin/plugin.json
+++ b/plugins/ccam-analytics/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ccam-analytics",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "description": "Deep analytics and monitoring for Claude Code sessions — cost tracking, token usage breakdowns, usage trends, and productivity scoring powered by Agent Monitor.",
   "author": {
     "name": "Son Nguyen",

--- a/plugins/ccam-config/.claude-plugin/plugin.json
+++ b/plugins/ccam-config/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccam-config",
   "description": "Audit and govern your Claude Code configuration and file-based memory via the Agent Monitor Config Explorer API — skills, subagents, commands, MCP servers, hooks, settings, and the per-project memory store. Surfaces sprawl, duplication, risky hooks, and stale facts, all read through the dashboard at http://localhost:4820.",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "author": { "name": "Son Nguyen", "url": "https://github.com/hoangsonww" },
   "homepage": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",
   "repository": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",

--- a/plugins/ccam-config/.codex-plugin/plugin.json
+++ b/plugins/ccam-config/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ccam-config",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "description": "Audit and govern your Claude Code configuration and file-based memory via the Agent Monitor Config Explorer API — skills, subagents, commands, MCP servers, hooks, settings, and the per-project memory store. Surfaces sprawl, duplication, risky hooks, and stale facts, all read through the dashboard at http://localhost:4820.",
   "author": {
     "name": "Son Nguyen",

--- a/plugins/ccam-cost-guard/.claude-plugin/plugin.json
+++ b/plugins/ccam-cost-guard/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccam-cost-guard",
   "description": "Budget tracking, spend forecasting, and cost-threshold alerts for Claude Code usage via the Agent Monitor pricing engine. Watches spend against a target budget, projects month-end cost from the daily trend, surfaces the priciest sessions, estimates savings from cheaper-model routing, and wires up cost alert rules — all backed by the dashboard at http://localhost:4820.",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "author": { "name": "Son Nguyen", "url": "https://github.com/hoangsonww" },
   "homepage": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",
   "repository": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",

--- a/plugins/ccam-cost-guard/.codex-plugin/plugin.json
+++ b/plugins/ccam-cost-guard/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ccam-cost-guard",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "description": "Budget tracking, spend forecasting, and cost-threshold alerts for Claude Code usage via the Agent Monitor pricing engine. Watches spend against a target budget, projects month-end cost from the daily trend, surfaces the priciest sessions, estimates savings from cheaper-model routing, and wires up cost alert rules — all backed by the dashboard at http://localhost:4820.",
   "author": {
     "name": "Son Nguyen",

--- a/plugins/ccam-dashboard/.claude-plugin/plugin.json
+++ b/plugins/ccam-dashboard/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccam-dashboard",
   "description": "Direct MCP integration with the Claude Code Agent Monitor dashboard — real-time session data access, quick stats, and dashboard health monitoring via Model Context Protocol.",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "author": { "name": "Son Nguyen", "url": "https://github.com/hoangsonww" },
   "homepage": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",
   "repository": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",

--- a/plugins/ccam-dashboard/.codex-plugin/plugin.json
+++ b/plugins/ccam-dashboard/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ccam-dashboard",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "description": "Direct MCP integration with the Claude Code Agent Monitor dashboard — real-time session data access, quick stats, and dashboard health monitoring via Model Context Protocol.",
   "author": {
     "name": "Son Nguyen",

--- a/plugins/ccam-devtools/.claude-plugin/plugin.json
+++ b/plugins/ccam-devtools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccam-devtools",
   "description": "Developer tools for Claude Code Agent Monitor — session debugging, hook diagnostics, data export, and system health checks for maintaining a healthy monitoring setup.",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "author": { "name": "Son Nguyen", "url": "https://github.com/hoangsonww" },
   "homepage": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",
   "repository": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",

--- a/plugins/ccam-devtools/.codex-plugin/plugin.json
+++ b/plugins/ccam-devtools/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ccam-devtools",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "description": "Developer tools for Claude Code Agent Monitor — session debugging, hook diagnostics, data export, and system health checks for maintaining a healthy monitoring setup.",
   "author": {
     "name": "Son Nguyen",

--- a/plugins/ccam-insights/.claude-plugin/plugin.json
+++ b/plugins/ccam-insights/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccam-insights",
   "description": "AI-powered insights for Claude Code — pattern detection, anomaly alerting, optimization recommendations, and session comparison using Agent Monitor analytics.",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "author": { "name": "Son Nguyen", "url": "https://github.com/hoangsonww" },
   "homepage": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",
   "repository": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",

--- a/plugins/ccam-insights/.codex-plugin/plugin.json
+++ b/plugins/ccam-insights/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ccam-insights",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "description": "AI-powered insights for Claude Code — pattern detection, anomaly alerting, optimization recommendations, and session comparison using Agent Monitor analytics.",
   "author": {
     "name": "Son Nguyen",

--- a/plugins/ccam-integrations/.claude-plugin/plugin.json
+++ b/plugins/ccam-integrations/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccam-integrations",
   "description": "Manage CCAM alert rules, universal webhook providers, browser push notifications, and SSH Remote Data Sources with explicit mutation and external-send confirmation.",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "author": { "name": "Son Nguyen", "url": "https://github.com/hoangsonww" },
   "homepage": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",
   "repository": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",

--- a/plugins/ccam-integrations/.codex-plugin/plugin.json
+++ b/plugins/ccam-integrations/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ccam-integrations",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "description": "Manage CCAM alert rules, universal webhook providers, browser push notifications, and SSH Remote Data Sources with explicit mutation and external-send confirmation.",
   "author": {
     "name": "Son Nguyen",

--- a/plugins/ccam-platform/.claude-plugin/plugin.json
+++ b/plugins/ccam-platform/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccam-platform",
   "description": "Administer CCAM's Claude Code and Codex configuration explorers, provider-aware history import, backup restore, hook installation, home directories, updates, and MCP server.",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "author": { "name": "Son Nguyen", "url": "https://github.com/hoangsonww" },
   "homepage": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",
   "repository": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",

--- a/plugins/ccam-platform/.codex-plugin/plugin.json
+++ b/plugins/ccam-platform/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ccam-platform",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "description": "Administer CCAM's Claude Code and Codex configuration explorers, provider-aware history import, backup restore, hook installation, home directories, updates, and MCP server.",
   "author": {
     "name": "Son Nguyen",

--- a/plugins/ccam-productivity/.claude-plugin/plugin.json
+++ b/plugins/ccam-productivity/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccam-productivity",
   "description": "Productivity workflows for Claude Code — daily standups, weekly reports, sprint summaries, and intelligent workflow optimization powered by Agent Monitor session data.",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "author": { "name": "Son Nguyen", "url": "https://github.com/hoangsonww" },
   "homepage": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",
   "repository": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",

--- a/plugins/ccam-productivity/.codex-plugin/plugin.json
+++ b/plugins/ccam-productivity/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ccam-productivity",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "description": "Productivity workflows for Claude Code — daily standups, weekly reports, sprint summaries, and intelligent workflow optimization powered by Agent Monitor session data.",
   "author": {
     "name": "Son Nguyen",

--- a/plugins/ccam-quality/.claude-plugin/plugin.json
+++ b/plugins/ccam-quality/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccam-quality",
   "description": "Reliability and error monitoring for Claude Code sessions — surfaces APIError events, hook delivery failures, tool-failure ratios (PreToolUse/PostToolUse gaps), and SLO tracking with error-budget reporting, all derived from the Claude Code Agent Monitor event stream at http://localhost:4820.",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "author": { "name": "Son Nguyen", "url": "https://github.com/hoangsonww" },
   "homepage": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",
   "repository": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",

--- a/plugins/ccam-quality/.codex-plugin/plugin.json
+++ b/plugins/ccam-quality/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ccam-quality",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "description": "Reliability and error monitoring for Claude Code sessions — surfaces APIError events, hook delivery failures, tool-failure ratios (PreToolUse/PostToolUse gaps), and SLO tracking with error-budget reporting, all derived from the Claude Code Agent Monitor event stream at http://localhost:4820.",
   "author": {
     "name": "Son Nguyen",

--- a/plugins/ccam-reports/.claude-plugin/plugin.json
+++ b/plugins/ccam-reports/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccam-reports",
   "description": "Generate stakeholder-ready CCAM reports from local session, cost, reliability, and workflow data with explicit scope, evidence, and export-friendly Markdown.",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "author": { "name": "Son Nguyen", "url": "https://github.com/hoangsonww" },
   "homepage": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",
   "repository": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",

--- a/plugins/ccam-reports/.codex-plugin/plugin.json
+++ b/plugins/ccam-reports/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ccam-reports",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "description": "Generate stakeholder-ready CCAM reports from local session, cost, reliability, and workflow data with explicit scope, evidence, and export-friendly Markdown.",
   "author": {
     "name": "Son Nguyen",

--- a/plugins/ccam-runner/.claude-plugin/plugin.json
+++ b/plugins/ccam-runner/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccam-runner",
   "description": "Operate dashboard-launched Claude Code and Codex runs with safe launch, follow-up, stop, resume, model discovery, and persistent run-history workflows.",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "author": { "name": "Son Nguyen", "url": "https://github.com/hoangsonww" },
   "homepage": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",
   "repository": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",

--- a/plugins/ccam-runner/.codex-plugin/plugin.json
+++ b/plugins/ccam-runner/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ccam-runner",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "description": "Operate dashboard-launched Claude Code and Codex runs with safe launch, follow-up, stop, resume, model discovery, and persistent run-history workflows.",
   "author": {
     "name": "Son Nguyen",

--- a/plugins/ccam-sessions/.claude-plugin/plugin.json
+++ b/plugins/ccam-sessions/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccam-sessions",
   "description": "Search, inspect, replay, and manage Claude Code sessions tracked by the Agent Monitor dashboard — find sessions by project, model, status, or date; reconstruct event timelines; walk transcripts turn-by-turn; roll up activity per working directory; and identify stale or empty sessions before cleanup.",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "author": { "name": "Son Nguyen", "url": "https://github.com/hoangsonww" },
   "homepage": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",
   "repository": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",

--- a/plugins/ccam-sessions/.codex-plugin/plugin.json
+++ b/plugins/ccam-sessions/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ccam-sessions",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "description": "Search, inspect, replay, and manage Claude Code sessions tracked by the Agent Monitor dashboard — find sessions by project, model, status, or date; reconstruct event timelines; walk transcripts turn-by-turn; roll up activity per working directory; and identify stale or empty sessions before cleanup.",
   "author": {
     "name": "Son Nguyen",

--- a/plugins/ccam-workflows/.claude-plugin/plugin.json
+++ b/plugins/ccam-workflows/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccam-workflows",
   "description": "Analyze multi-agent orchestration and Workflow-tool fleet runs — DAGs, delegation, concurrency, error propagation, and effectiveness — via the Agent Monitor workflow intelligence API at http://localhost:4820. Maps parent→child subagent edges, scores model delegation and subagent success, surfaces concurrency lanes and serialization bottlenecks, and traces error cascades by agent depth.",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "author": { "name": "Son Nguyen", "url": "https://github.com/hoangsonww" },
   "homepage": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",
   "repository": "https://github.com/hoangsonww/Claude-Code-Agent-Monitor",

--- a/plugins/ccam-workflows/.codex-plugin/plugin.json
+++ b/plugins/ccam-workflows/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ccam-workflows",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "description": "Analyze multi-agent orchestration and Workflow-tool fleet runs — DAGs, delegation, concurrency, error propagation, and effectiveness — via the Agent Monitor workflow intelligence API at http://localhost:4820. Maps parent→child subagent edges, scores model delegation and subagent success, surfaces concurrency lanes and serialization bottlenecks, and traces error cascades by agent depth.",
   "author": {
     "name": "Son Nguyen",

--- a/server/openapi.js
+++ b/server/openapi.js
@@ -478,7 +478,7 @@ function createOpenApiSpec() {
             version: {
               type: "string",
               description: "Dashboard release version from package.json",
-              example: "2.0.6",
+              example: "2.0.8",
             },
             timestamp: { type: "string", format: "date-time" },
           },


### PR DESCRIPTION
## Summary

Bumps CCAM from v2.0.6 to v2.0.8 across every shipping release surface and adds a clear path from the repository documentation to the practical GitHub Wiki.

## Release surfaces synchronized

- Root CLI/package metadata and lockfile
- Desktop package metadata and lockfile
- OpenAPI JSON/YAML examples
- Docker Compose image tag
- Helm chart version and appVersion
- Kubernetes base, components, overlays, labels, and image tags
- Deployment helper defaults and deployment guides
- Claude/Codex extension manifests generated from the canonical catalog
- Version-sensitive client snapshot

The independently versioned client, MCP package, and VS Code extension remain unchanged.

## Documentation

- Adds GitHub Wiki links to the English, Vietnamese, Chinese, Korean, and Spanish READMEs and the docs index
- Clarifies the roles of the practical GitHub Wiki, localized static product tour, and technical docs

## Validation

- `npm run build`
- `npm run test:server` — 948 tests, 947 passed, 1 skipped
- `npm run mcp:typecheck`
- `npm run mcp:build`
- MCP tests — 149 passed
- Desktop tests and build
- `npm run extensions:validate` — 14 plugins, 66 skills
- Release-version consistency tests — 5 passed
- `node bin/ccam.js --version` — `ccam 2.0.8`
- Source header check
- Prettier check
- `git diff --check`

`npm run deploy:validate` could not complete locally because the Docker daemon is unavailable; GitHub CI remains the authoritative deployment validation.

## Release note

This intentionally follows v2.0.6 directly at the requested v2.0.8 version. This PR does not create a tag or GitHub Release.
