### PR TITLE
server: index events by (agent_id, created_at) and (session_id, created_at)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1083,6 +1083,8 @@ erDiagram
 | `idx_events_created`   | events   | `created_at DESC` | Activity feed ordering         |
 | `idx_events_session_type` | events | `session_id, event_type` | Per-session event-type filters |
 | `idx_events_agent_type` | events  | `agent_id, event_type` | Keeps `importSubagentFromJsonl`'s per-tool-event `data LIKE` dedup an index seek instead of a full events scan — a large re-import (startup sweep touching a subagent-heavy session) drops from tens of seconds to sub-second |
+| `idx_events_agent_created` | events | `agent_id, created_at` | Makes the agent list's per-agent `MAX(created_at)` last-activity subquery an index seek instead of a walk over every event of the agent |
+| `idx_events_session_created` | events | `session_id, created_at` | Same for the session list's per-session last-activity subquery |
 | `idx_sessions_status`  | sessions | `status`          | Status filter on Sessions page and Kanban Sessions view |
 | `idx_sessions_started` | sessions | `started_at DESC` | Default sort order             |
 | `idx_sessions_source`  | sessions | `source`          | Data-scope (`?sources=`) filtering by source            |

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -583,6 +583,8 @@ CREATE INDEX idx_agents_status ON agents(status);
 -- before inserting; on a subagent-heavy re-import this drops a large sweep from
 -- tens of seconds to sub-second.
 CREATE INDEX idx_events_agent_type ON events(agent_id, event_type);
+CREATE INDEX idx_events_agent_created ON events(agent_id, created_at);
+CREATE INDEX idx_events_session_created ON events(session_id, created_at);
 ```
 
 ### tool_executions Indexes

--- a/server/__tests__/subagent-attribution.test.js
+++ b/server/__tests__/subagent-attribution.test.js
@@ -751,4 +751,21 @@ describe("events dedup index", () => {
       .get();
     assert.ok(row, "idx_events_agent_type must exist to keep subagent dedup indexed");
   });
+
+  it("keeps the per-agent and per-session last-activity lookups on covering indexes", () => {
+    for (const [column, index] of [
+      ["agent_id", "idx_events_agent_created"],
+      ["session_id", "idx_events_session_created"],
+    ]) {
+      const plan = db
+        .prepare(`EXPLAIN QUERY PLAN SELECT MAX(created_at) FROM events WHERE ${column} = ?`)
+        .all("x")
+        .map((step) => step.detail)
+        .join(" | ");
+      assert.ok(
+        plan.includes(`COVERING INDEX ${index}`),
+        `MAX(created_at) by ${column} must use ${index}, got: ${plan}`
+      );
+    }
+  });
 });

--- a/server/db.js
+++ b/server/db.js
@@ -336,6 +336,11 @@ db.exec(`
   -- session with many subagents) becomes tens of seconds and blocks the event
   -- loop. This composite narrows each dedup to the agent's events of that type.
   CREATE INDEX IF NOT EXISTS idx_events_agent_type ON events(agent_id, event_type);
+  -- The agent and session lists compute "last activity" with a correlated
+  -- MAX(created_at) per row; without these the subquery walks every event of
+  -- each agent/session on every list request.
+  CREATE INDEX IF NOT EXISTS idx_events_agent_created ON events(agent_id, created_at);
+  CREATE INDEX IF NOT EXISTS idx_events_session_created ON events(session_id, created_at);
   CREATE INDEX IF NOT EXISTS idx_agents_session_type ON agents(session_id, type);
   CREATE INDEX IF NOT EXISTS idx_dashboard_runs_started ON dashboard_runs(started_at DESC);
   CREATE INDEX IF NOT EXISTS idx_dashboard_runs_session ON dashboard_runs(session_id);


### PR DESCRIPTION
Closes #319.

Adds `idx_events_agent_created (agent_id, created_at)` and `idx_events_session_created (session_id, created_at)` in the startup schema block, the same way `idx_events_agent_type` was added. The agent and session lists compute last activity with a correlated `MAX(created_at)` per row; with these indexes `EXPLAIN QUERY PLAN` reports a covering-index lookup for each shape. On a copied 355k-event database the agent benchmark fell from 787 ms to 244 ms and the isolated session benchmark from 523 ms to 26 ms, for about 55 MB of index; details in #319.

A test asserts each isolated `MAX(created_at)` lookup uses its named covering index. `ARCHITECTURE.md` and `docs/DATABASE.md` list the indexes. Additive only; the first upgraded startup builds both once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014hT7ar2Jiuqtr8Rue4KLCG
