### PR TITLE
Remote/multi-machine session ingestion + fixes (idle-vs-actionable notification, subagent notification guard, 1h/fast/geo/tier pricing parity)

### DIFF
--- a/scripts/import-history.js
+++ b/scripts/import-history.js
@@ -868,7 +868,12 @@ function importSubagentFromJsonl(dbModule, sessionId, mainAgentId, subData) {
 
   const jsonlSubId = `${sessionId}-jsonl-${subData.agentId}`;
   const liveSub = findLiveSubagentForJsonl(dbModule, sessionId, subData);
-  const targetAgentId = liveSub ? liveSub.id : jsonlSubId;
+  // A remote/transcript-less synth row (SubagentStop fallback in routes/hooks.js,
+  // id `<sessionId>-sub-<agent_id>`) may already represent this subagent. If the
+  // transcript later becomes readable on this host and the scan runs, merge into
+  // that row rather than inserting a parallel jsonl-keyed one. No-op when absent.
+  const synthSub = stmts.getAgent.get(`${sessionId}-sub-${subData.agentId}`);
+  const targetAgentId = liveSub ? liveSub.id : synthSub ? synthSub.id : jsonlSubId;
   const existingJsonl = stmts.getAgent.get(jsonlSubId);
 
   const subName = subData.agentType ? subData.agentType : `Subagent ${subData.agentId.slice(0, 8)}`;
@@ -881,7 +886,7 @@ function importSubagentFromJsonl(dbModule, sessionId, mainAgentId, subData) {
   // Live subagents (created via the PreToolUse "Agent" hook) are detected by
   // findLiveSubagentForJsonl above; in that case tool events are emitted under
   // the live row's id and no parallel JSONL-keyed row is needed.
-  if (!liveSub && !existingJsonl) {
+  if (!liveSub && !synthSub && !existingJsonl) {
     stmts.insertAgent.run(
       jsonlSubId,
       sessionId,

--- a/scripts/import-history.js
+++ b/scripts/import-history.js
@@ -876,6 +876,19 @@ function importSubagentFromJsonl(dbModule, sessionId, mainAgentId, subData) {
   const targetAgentId = liveSub ? liveSub.id : synthSub ? synthSub.id : jsonlSubId;
   const existingJsonl = stmts.getAgent.get(jsonlSubId);
 
+  // A synth row is stamped with its INGEST time (when the SubagentStop fallback
+  // ran), not the subagent's real run time — the transcript wasn't readable yet,
+  // so there was nothing truer to use. Now that it is, backfill the real
+  // started_at/ended_at from the transcript, or the row keeps showing a
+  // near-zero (ingest-to-ingest) duration forever.
+  if (!liveSub && synthSub && subData.startedAt && subData.endedAt) {
+    db.prepare("UPDATE agents SET started_at = ?, ended_at = ? WHERE id = ?").run(
+      subData.startedAt,
+      subData.endedAt,
+      synthSub.id
+    );
+  }
+
   const subName = subData.agentType ? subData.agentType : `Subagent ${subData.agentId.slice(0, 8)}`;
   // This subagent's OWN token usage, so the UI can price it independently of the
   // session total (which would otherwise be shown on every card, misleadingly).

--- a/server/__tests__/awaiting-subagent-guard.test.js
+++ b/server/__tests__/awaiting-subagent-guard.test.js
@@ -1,0 +1,168 @@
+/**
+ * @file Regression: a BACKGROUND subagent's tool events must not clear a
+ * genuine 'notification' waiting flag held by the MAIN agent (blocked on the
+ * user via AskUserQuestion / permission). Before the fix, PreToolUse/PostToolUse
+ * cleared awaiting_input_since unconditionally, so a session that was truly
+ * "waiting for you" oscillated back to active on every subagent tool event —
+ * AI-Deck (12s poll) and deck-web (5s WS) then disagreed about the same session.
+ *
+ * The guard reuses the existing subagent-actor heuristic (findDeepestWorkingAgent
+ * while main is 'waiting'): when a subagent is the actor, only PASSIVE waits
+ * (stop/session_start/interrupted) are cleared; a 'notification' wait is
+ * preserved. When MAIN is the actor, clearing is unconditional (keeps the
+ * documented permission-mid-tool path intact).
+ *
+ * This test lives in the fork's own suite so a future upstream merge that
+ * silently reverts the guard fails loudly here (home-network monitor fork,
+ * see decisions/).
+ */
+
+const { describe, it, before, after } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("path");
+const os = require("os");
+const http = require("http");
+
+const TEST_DB = path.join(os.tmpdir(), `awaiting-guard-${Date.now()}-${process.pid}.db`);
+process.env.DASHBOARD_DB_PATH = TEST_DB;
+process.env.DASHBOARD_LIVENESS_PROBE = "0";
+
+const { createApp, startServer } = require("../index");
+
+let server;
+let BASE;
+
+function fetch(urlPath, options = {}) {
+  return new Promise((resolve, reject) => {
+    const url = new URL(urlPath, BASE);
+    const req = http.request(
+      {
+        hostname: url.hostname,
+        port: url.port,
+        path: url.pathname + url.search,
+        method: options.method || "GET",
+        headers: { "Content-Type": "application/json", ...options.headers },
+      },
+      (res) => {
+        let body = "";
+        res.on("data", (c) => (body += c));
+        res.on("end", () => {
+          let parsed;
+          try {
+            parsed = JSON.parse(body);
+          } catch {
+            parsed = body;
+          }
+          resolve({ status: res.statusCode, body: parsed });
+        });
+      }
+    );
+    req.on("error", reject);
+    if (options.body) req.write(JSON.stringify(options.body));
+    req.end();
+  });
+}
+
+const post = (p, body) => fetch(p, { method: "POST", body });
+const hook = (hook_type, data) => post("/api/hooks/event", { hook_type, data });
+const sessionOf = async (id) => (await fetch(`/api/sessions/${id}`)).body.session;
+
+/**
+ * Drive a session into: main agent 'waiting' with the given reason, AND a live
+ * working subagent (so findDeepestWorkingAgent returns it). Returns nothing;
+ * asserts each precondition so a harness regression is obvious.
+ */
+async function sessionWaitingWithWorkingSubagent(sid, { notification }) {
+  await hook("SessionStart", { session_id: sid });
+  // UserPromptSubmit clears the session_start wait and promotes main → working.
+  await hook("UserPromptSubmit", { session_id: sid, prompt: "go" });
+  // Main (working) spawns a subagent → subagent row inserted with status working.
+  await hook("PreToolUse", {
+    session_id: sid,
+    tool_name: "Agent",
+    tool_input: { subagent_type: "reviewer", prompt: "review" },
+  });
+  // Now block the MAIN agent. A waiting-for-user Notification stamps
+  // reason='notification'; a Stop stamps the passive reason='stop'.
+  if (notification) {
+    await hook("Notification", { session_id: sid, message: "Claude is waiting for your input" });
+  } else {
+    await hook("Stop", { session_id: sid });
+  }
+  const sess = await sessionOf(sid);
+  assert.ok(sess.awaiting_input_since, "precondition: session should be awaiting");
+  assert.equal(
+    sess.awaiting_reason,
+    notification ? "notification" : "stop",
+    "precondition: expected awaiting_reason"
+  );
+}
+
+before(async () => {
+  server = await startServer(createApp(), 0);
+  BASE = `http://127.0.0.1:${server.address().port}`;
+});
+
+after(() => {
+  if (server) server.close();
+});
+
+describe("awaiting guard: subagent tool events vs. main-agent waiting", () => {
+  it("PRESERVES a 'notification' wait when a background subagent fires PreToolUse", async () => {
+    const sid = "guard-notif-pre";
+    await sessionWaitingWithWorkingSubagent(sid, { notification: true });
+
+    // Subagent (deepest working, main is waiting) runs a tool. This must NOT
+    // clear the main agent's genuine "waiting for you" flag.
+    await hook("PreToolUse", { session_id: sid, tool_name: "Bash" });
+
+    const sess = await sessionOf(sid);
+    assert.ok(sess.awaiting_input_since, "notification wait must survive subagent PreToolUse");
+    assert.equal(sess.awaiting_reason, "notification");
+  });
+
+  it("PRESERVES a 'notification' wait when a background subagent fires PostToolUse", async () => {
+    const sid = "guard-notif-post";
+    await sessionWaitingWithWorkingSubagent(sid, { notification: true });
+
+    await hook("PostToolUse", { session_id: sid, tool_name: "Bash" });
+
+    const sess = await sessionOf(sid);
+    assert.ok(sess.awaiting_input_since, "notification wait must survive subagent PostToolUse");
+    assert.equal(sess.awaiting_reason, "notification");
+  });
+
+  it("CLEARS a passive 'stop' wait when a background subagent fires a tool event", async () => {
+    // Passive-clear is desirable: a backgrounded subagent's activity should flip
+    // a merely-Stopped session back to active ("done/idle only while no agent works").
+    const sid = "guard-stop-pre";
+    await sessionWaitingWithWorkingSubagent(sid, { notification: false });
+
+    await hook("PreToolUse", { session_id: sid, tool_name: "Bash" });
+
+    const sess = await sessionOf(sid);
+    assert.equal(
+      sess.awaiting_input_since,
+      null,
+      "passive stop wait should be cleared by subagent activity"
+    );
+    assert.equal(sess.awaiting_reason, null);
+  });
+
+  it("CLEARS a 'notification' wait when MAIN (no working subagent) resumes with a tool", async () => {
+    // Control: main was waiting on the user, no subagent running. A PreToolUse
+    // means main itself resumed — clearing is correct (unchanged behaviour).
+    const sid = "guard-notif-mainactor";
+    await hook("SessionStart", { session_id: sid });
+    await hook("UserPromptSubmit", { session_id: sid, prompt: "go" });
+    await hook("Notification", { session_id: sid, message: "Claude is waiting for your input" });
+    let sess = await sessionOf(sid);
+    assert.ok(sess.awaiting_input_since && sess.awaiting_reason === "notification", "precondition");
+
+    await hook("PreToolUse", { session_id: sid, tool_name: "Bash" });
+
+    sess = await sessionOf(sid);
+    assert.equal(sess.awaiting_input_since, null, "main resuming must clear its own wait");
+    assert.equal(sess.awaiting_reason, null);
+  });
+});

--- a/server/__tests__/awaiting-subagent-guard.test.js
+++ b/server/__tests__/awaiting-subagent-guard.test.js
@@ -15,6 +15,7 @@
  * This test lives in the fork's own suite so a future upstream merge that
  * silently reverts the guard fails loudly here (home-network monitor fork,
  * see decisions/).
+ * @author Son Nguyen <hoangson091104@gmail.com>
  */
 
 const { describe, it, before, after } = require("node:test");

--- a/server/__tests__/awaiting-subagent-guard.test.js
+++ b/server/__tests__/awaiting-subagent-guard.test.js
@@ -85,7 +85,10 @@ async function sessionWaitingWithWorkingSubagent(sid, { notification }) {
   // Now block the MAIN agent. A waiting-for-user Notification stamps
   // reason='notification'; a Stop stamps the passive reason='stop'.
   if (notification) {
-    await hook("Notification", { session_id: sid, message: "Claude is waiting for your input" });
+    await hook("Notification", {
+      session_id: sid,
+      message: "Claude needs your permission to use Bash",
+    }); // actionable → reason=notification
   } else {
     await hook("Stop", { session_id: sid });
   }
@@ -155,7 +158,10 @@ describe("awaiting guard: subagent tool events vs. main-agent waiting", () => {
     const sid = "guard-notif-mainactor";
     await hook("SessionStart", { session_id: sid });
     await hook("UserPromptSubmit", { session_id: sid, prompt: "go" });
-    await hook("Notification", { session_id: sid, message: "Claude is waiting for your input" });
+    await hook("Notification", {
+      session_id: sid,
+      message: "Claude needs your permission to use Bash",
+    }); // actionable → reason=notification
     let sess = await sessionOf(sid);
     assert.ok(sess.awaiting_input_since && sess.awaiting_reason === "notification", "precondition");
 

--- a/server/__tests__/first-user-descriptor.test.js
+++ b/server/__tests__/first-user-descriptor.test.js
@@ -222,6 +222,90 @@ describe("hook ingestor — descriptor fills placeholders", () => {
     assert.equal(main.task, "add dark mode to settings");
   });
 
+  it("remote fallback: fills placeholders from data.prompt when the transcript is unreadable on this host", async () => {
+    // Household/remote session: the JSONL lives on the origin machine, so
+    // transcript_path does not resolve on this host and extract() yields null.
+    const cwd = "C:\\Users\\matsp\\chats\\veeam-smb-repo-add";
+    const sid = "10000000-0000-0000-0000-00000000000a";
+    const tpath = "C:\\Users\\matsp\\.claude\\projects\\enc\\" + sid + ".jsonl";
+    const res = await req("POST", "/api/hooks/event", {
+      hook_type: "UserPromptSubmit",
+      data: { session_id: sid, cwd, transcript_path: tpath, prompt: "set up the veeam smb repo" },
+    });
+    assert.equal(res.status, 200);
+    assert.equal(stmts.getSession.get(sid).name, "set up the veeam smb repo");
+    const main = stmts.getAgent.get(`${sid}-main`);
+    assert.equal(main.name, "Main Agent - set up the veeam smb repo");
+    assert.equal(main.task, "set up the veeam smb repo");
+  });
+
+  it("remote fallback: a readable local transcript still wins over data.prompt", async () => {
+    // Both a readable transcript AND an inline prompt are present — the
+    // transcript is the source of truth; the payload fallback must no-op.
+    const cwd = "/tmp/fud-hook-both";
+    const sid = "10000000-0000-0000-0000-00000000000b";
+    const tpath = writeTranscript(cwd, sid, [
+      { type: "user", message: { role: "user", content: "descriptor from transcript" } },
+    ]);
+    await req("POST", "/api/hooks/event", {
+      hook_type: "UserPromptSubmit",
+      data: { session_id: sid, cwd, transcript_path: tpath, prompt: "prompt from payload" },
+    });
+    assert.equal(stmts.getSession.get(sid).name, "descriptor from transcript");
+    assert.equal(stmts.getAgent.get(`${sid}-main`).task, "descriptor from transcript");
+  });
+
+  it("remote fallback: a later ai-title takes over a descriptor-filled name", async () => {
+    const cwd = "C:\\Users\\matsp\\chats\\veeam";
+    const sid = "10000000-0000-0000-0000-00000000000c";
+    const tpath = "C:\\Users\\matsp\\.claude\\projects\\enc\\" + sid + ".jsonl";
+    await req("POST", "/api/hooks/event", {
+      hook_type: "UserPromptSubmit",
+      data: { session_id: sid, cwd, transcript_path: tpath, prompt: "set up the veeam smb repo" },
+    });
+    assert.equal(stmts.getSession.get(sid).name, "set up the veeam smb repo");
+    // aideck-hook forwards remote_ai_title on a later event once Claude generates
+    // it — it must be able to replace the descriptor-derived name (regression).
+    await req("POST", "/api/hooks/event", {
+      hook_type: "Stop",
+      data: {
+        session_id: sid,
+        cwd,
+        transcript_path: tpath,
+        remote_ai_title: "Veeam SMB repo setup",
+      },
+    });
+    assert.equal(stmts.getSession.get(sid).name, "Veeam SMB repo setup");
+  });
+
+  it("remote fallback: a bare slash-command prompt is NOT adopted as the name", async () => {
+    const cwd = "C:\\Users\\matsp\\chats\\lagre";
+    const sid = "10000000-0000-0000-0000-00000000000d";
+    const tpath = "C:\\Users\\matsp\\.claude\\projects\\enc\\" + sid + ".jsonl";
+    await req("POST", "/api/hooks/event", {
+      hook_type: "UserPromptSubmit",
+      data: { session_id: sid, cwd, transcript_path: tpath, prompt: "/lagre" },
+    });
+    // Stays the placeholder — matches the transcript path (which filters
+    // <command-name> plumbing) and keeps a later ai-title takeover available.
+    assert.equal(stmts.getSession.get(sid).name, `Session ${sid.slice(0, 8)}`);
+  });
+
+  it("remote fallback: collapses whitespace/newlines and caps the task at 500 chars", async () => {
+    const cwd = "C:\\Users\\matsp\\chats\\multi";
+    const sid = "10000000-0000-0000-0000-00000000000e";
+    const tpath = "C:\\Users\\matsp\\.claude\\projects\\enc\\" + sid + ".jsonl";
+    const prompt = "fix\nthe   login\nbug" + " x".repeat(600); // > 500 chars after collapse
+    await req("POST", "/api/hooks/event", {
+      hook_type: "UserPromptSubmit",
+      data: { session_id: sid, cwd, transcript_path: tpath, prompt },
+    });
+    const name = stmts.getSession.get(sid).name;
+    assert.ok(!name.includes("\n"), "no raw newline in the name");
+    assert.ok(name.startsWith("fix the login bug"), "whitespace runs collapsed to single spaces");
+    assert.ok(stmts.getAgent.get(`${sid}-main`).task.length <= 500, "task capped at 500 chars");
+  });
+
   it("truncates long prompts to 60 chars for names but keeps the task longer", async () => {
     const cwd = "/tmp/fud-hook-trunc";
     const sid = "10000000-0000-0000-0000-000000000002";

--- a/server/__tests__/ingest-batch.test.js
+++ b/server/__tests__/ingest-batch.test.js
@@ -341,4 +341,157 @@ describe("POST /api/hooks/ingest-batch", () => {
     assert.equal(turnCount, 1);
     assert.ok(stmts.getAgent.get(`${id}-sub-soft-ok-sub`));
   });
+
+  it("sets session.model via the same last-write-wins mechanism as the local pipeline", async () => {
+    const id = sid();
+    await seedSession(id);
+    assert.equal(stmts.getSession.get(id).model, null);
+
+    const res = await req("POST", "/api/hooks/ingest-batch", {
+      session_id: id,
+      transcript_path: UNREADABLE,
+      schema_version: SCHEMA_VERSION,
+      model: "claude-opus-4-6",
+    });
+    assert.equal(res.status, 200);
+    assert.equal(stmts.getSession.get(id).model, "claude-opus-4-6");
+  });
+
+  it("merges usage_extras/thinking_blocks into sessions.metadata in the exact local-pipeline shape", async () => {
+    const id = sid();
+    await seedSession(id);
+
+    const res = await req("POST", "/api/hooks/ingest-batch", {
+      session_id: id,
+      transcript_path: UNREADABLE,
+      schema_version: SCHEMA_VERSION,
+      usage_extras: {
+        service_tiers: ["standard"],
+        speeds: ["standard"],
+        inference_geos: [],
+        thinking_blocks: 4,
+      },
+    });
+    assert.equal(res.status, 200);
+
+    const meta = JSON.parse(stmts.getSession.get(id).metadata);
+    assert.deepEqual(meta, {
+      usage_extras: { service_tiers: ["standard"], speeds: ["standard"], inference_geos: [] },
+      thinking_blocks: 4,
+    });
+  });
+
+  it("usage_extras merge does not clobber other metadata keys", async () => {
+    const id = sid();
+    await seedSession(id);
+
+    // Seed an unrelated metadata key the way the local pipeline would
+    // (e.g. turn_count from the transcript-driven path).
+    const existing = { turn_count: 7, total_turn_duration_ms: 12345 };
+    stmts.updateSession.run(null, null, null, JSON.stringify(existing), id);
+
+    const res = await req("POST", "/api/hooks/ingest-batch", {
+      session_id: id,
+      transcript_path: UNREADABLE,
+      schema_version: SCHEMA_VERSION,
+      usage_extras: { service_tiers: ["batch"], speeds: [], inference_geos: ["us"] },
+    });
+    assert.equal(res.status, 200);
+
+    const meta = JSON.parse(stmts.getSession.get(id).metadata);
+    assert.equal(meta.turn_count, 7);
+    assert.equal(meta.total_turn_duration_ms, 12345);
+    assert.deepEqual(meta.usage_extras, {
+      service_tiers: ["batch"],
+      speeds: [],
+      inference_geos: ["us"],
+    });
+  });
+
+  it("model + usage_extras are idempotent — reposting the same values twice yields the same state", async () => {
+    const id = sid();
+    await seedSession(id);
+    const payload = {
+      session_id: id,
+      transcript_path: UNREADABLE,
+      schema_version: SCHEMA_VERSION,
+      model: "claude-sonnet-5",
+      usage_extras: {
+        service_tiers: ["standard"],
+        speeds: ["fast"],
+        inference_geos: ["us"],
+        thinking_blocks: 2,
+      },
+    };
+
+    await req("POST", "/api/hooks/ingest-batch", payload);
+    const after1 = stmts.getSession.get(id);
+    await req("POST", "/api/hooks/ingest-batch", payload);
+    const after2 = stmts.getSession.get(id);
+
+    assert.equal(after1.model, "claude-sonnet-5");
+    assert.equal(after2.model, "claude-sonnet-5");
+    assert.deepEqual(JSON.parse(after1.metadata), JSON.parse(after2.metadata));
+    assert.equal(JSON.parse(after2.metadata).thinking_blocks, 2);
+  });
+
+  it("omitting model/usage_extras leaves session.model and metadata unchanged", async () => {
+    const id = sid();
+    await seedSession(id);
+    stmts.updateSessionModel.run("pre-existing-model", id, "pre-existing-model");
+    stmts.updateSession.run(null, null, null, JSON.stringify({ turn_count: 3 }), id);
+
+    const res = await req("POST", "/api/hooks/ingest-batch", {
+      session_id: id,
+      transcript_path: UNREADABLE,
+      schema_version: SCHEMA_VERSION,
+      tokens: [{ model: "claude-x", input: 5 }],
+    });
+    assert.equal(res.status, 200);
+
+    const session = stmts.getSession.get(id);
+    assert.equal(session.model, "pre-existing-model");
+    assert.deepEqual(JSON.parse(session.metadata), { turn_count: 3 });
+  });
+
+  it("400s on invalid model/usage_extras types", async () => {
+    const id = sid();
+    await seedSession(id);
+
+    let res = await req("POST", "/api/hooks/ingest-batch", {
+      session_id: id,
+      transcript_path: UNREADABLE,
+      schema_version: SCHEMA_VERSION,
+      model: 42,
+    });
+    assert.equal(res.status, 400);
+    assert.equal(res.body.error.code, "INVALID_INPUT");
+
+    res = await req("POST", "/api/hooks/ingest-batch", {
+      session_id: id,
+      transcript_path: UNREADABLE,
+      schema_version: SCHEMA_VERSION,
+      usage_extras: "not-an-object",
+    });
+    assert.equal(res.status, 400);
+    assert.equal(res.body.error.code, "INVALID_INPUT");
+
+    res = await req("POST", "/api/hooks/ingest-batch", {
+      session_id: id,
+      transcript_path: UNREADABLE,
+      schema_version: SCHEMA_VERSION,
+      usage_extras: { service_tiers: "standard" },
+    });
+    assert.equal(res.status, 400);
+    assert.equal(res.body.error.code, "INVALID_INPUT");
+
+    res = await req("POST", "/api/hooks/ingest-batch", {
+      session_id: id,
+      transcript_path: UNREADABLE,
+      schema_version: SCHEMA_VERSION,
+      usage_extras: { thinking_blocks: -1 },
+    });
+    assert.equal(res.status, 400);
+    assert.equal(res.body.error.code, "INVALID_INPUT");
+  });
 });

--- a/server/__tests__/ingest-batch.test.js
+++ b/server/__tests__/ingest-batch.test.js
@@ -154,6 +154,60 @@ describe("POST /api/hooks/ingest-batch", () => {
     assert.equal(tokenRow(id, "claude-x"), undefined, "no token row should have been written");
   });
 
+  it("404s UNKNOWN_MAIN_AGENT when the session exists but has no main agent row (POST /api/sessions path), and does not partially write the batch", async () => {
+    const id = sid();
+    // Bypass SessionStart entirely — this is the pre-existing route that
+    // creates a session row without ever inserting the `${id}-main` agent
+    // row (server/routes/sessions.js POST / calls insertSession only).
+    const created = await req("POST", "/api/sessions", { id, cwd: WIN_CWD });
+    assert.equal(created.status, 201);
+    assert.equal(stmts.getAgent.get(`${id}-main`), undefined, "test setup: no main agent expected");
+
+    const res = await req("POST", "/api/hooks/ingest-batch", {
+      session_id: id,
+      transcript_path: UNREADABLE,
+      schema_version: SCHEMA_VERSION,
+      tokens: [{ model: "claude-orphan-session", input: 10 }],
+      tool_events: [{ uuid: "orphan-evt-1", tool_name: "Read" }],
+    });
+
+    // Contract: a structured JSON error, never Express' default HTML 500 —
+    // and specifically not a 500 at all, since this is now caught before
+    // the transaction runs.
+    assert.equal(res.status, 404);
+    assert.equal(typeof res.body, "object", "response must be parsed JSON, not raw HTML");
+    assert.equal(res.body.error.code, "UNKNOWN_MAIN_AGENT");
+
+    // Nothing from the batch should have landed — not even the valid token
+    // row that preceded the (formerly) transaction-killing tool_event.
+    assert.equal(tokenRow(id, "claude-orphan-session"), undefined);
+    const toolCount = db
+      .prepare("SELECT COUNT(*) AS c FROM events WHERE session_id = ? AND event_type = 'ToolEvent'")
+      .get(id).c;
+    assert.equal(toolCount, 0);
+  });
+
+  it("maps an unexpected DB-constraint failure inside the transaction (e.g. a bogus tool_event.agent_id) to a structured 500, not HTML — session DOES have a main agent here", async () => {
+    const id = sid();
+    await seedSession(id); // main agent exists — the UNKNOWN_MAIN_AGENT gate does not fire
+
+    const res = await req("POST", "/api/hooks/ingest-batch", {
+      session_id: id,
+      transcript_path: UNREADABLE,
+      schema_version: SCHEMA_VERSION,
+      tool_events: [{ uuid: "bad-agent-evt", agent_id: "no-such-agent-row", tool_name: "Bash" }],
+    });
+
+    assert.equal(res.status, 500);
+    assert.equal(typeof res.body, "object", "response must be parsed JSON, not raw HTML");
+    assert.equal(res.body.error.code, "INGEST_BATCH_FAILED");
+
+    const toolCount = db
+      .prepare("SELECT COUNT(*) AS c FROM events WHERE session_id = ? AND event_type = 'ToolEvent'")
+      .get(id).c;
+    assert.equal(toolCount, 0, "the failed transaction must not have partially written");
+  });
+
   it("400s when transcript_path is missing", async () => {
     const id = sid();
     await seedSession(id);

--- a/server/__tests__/ingest-batch.test.js
+++ b/server/__tests__/ingest-batch.test.js
@@ -8,6 +8,7 @@
  * sessions seeded via the real SessionStart hook path (so the route is
  * exercised the way a real forwarder would hit it — session already known,
  * transcript unreadable on this host).
+ * @author Son Nguyen <hoangson091104@gmail.com>
  */
 
 const { describe, it, before, after } = require("node:test");

--- a/server/__tests__/ingest-batch.test.js
+++ b/server/__tests__/ingest-batch.test.js
@@ -24,6 +24,10 @@ const TMP = path.join(os.tmpdir(), STAMP);
 process.env.DASHBOARD_DB_PATH = path.join(TMP, "dashboard.db");
 process.env.CLAUDE_HOME = path.join(TMP, "home");
 process.env.DASHBOARD_DATA_DIR = path.join(TMP, "data");
+// ingest-batch requires DASHBOARD_TOKEN unconditionally (CWE-306 fix) — every
+// request below authenticates with it via req()'s default Authorization
+// header. Tests that exercise the auth gate itself override/unset it.
+process.env.DASHBOARD_TOKEN = "test-ingest-batch-token";
 fs.mkdirSync(TMP, { recursive: true });
 
 const { createApp, startServer } = require("../index");
@@ -33,10 +37,14 @@ const { db, stmts } = dbModule;
 let server;
 let BASE;
 
-function req(method, urlPath, body) {
+// `headers` lets the handful of auth-focused tests below override/omit the
+// Authorization header; every other call in this file gets it for free.
+function req(method, urlPath, body, headers) {
   return new Promise((resolve, reject) => {
     const url = new URL(urlPath, BASE);
     const payload = body !== undefined ? JSON.stringify(body) : null;
+    const authHeaders =
+      headers !== undefined ? headers : { Authorization: `Bearer ${process.env.DASHBOARD_TOKEN}` };
     const r = http.request(
       {
         hostname: url.hostname,
@@ -44,8 +52,12 @@ function req(method, urlPath, body) {
         path: url.pathname + url.search,
         method,
         headers: payload
-          ? { "Content-Type": "application/json", "Content-Length": Buffer.byteLength(payload) }
-          : {},
+          ? {
+              "Content-Type": "application/json",
+              "Content-Length": Buffer.byteLength(payload),
+              ...authHeaders,
+            }
+          : authHeaders,
       },
       (res) => {
         let b = "";
@@ -111,6 +123,144 @@ after(() => {
   } catch {
     /* ignore */
   }
+});
+
+describe("POST /api/hooks/ingest-batch — auth gate (CWE-306)", () => {
+  it("401s a request with no Authorization header, even for an unknown session (never leaks past auth)", async () => {
+    const res = await req(
+      "POST",
+      "/api/hooks/ingest-batch",
+      {
+        session_id: sid(),
+        transcript_path: UNREADABLE,
+        schema_version: SCHEMA_VERSION,
+        tokens: [],
+      },
+      {}
+    );
+    assert.equal(res.status, 401);
+    assert.equal(res.body.error.code, "EUNAUTHORIZED");
+  });
+
+  it("401s a request with the wrong token", async () => {
+    const res = await req(
+      "POST",
+      "/api/hooks/ingest-batch",
+      {
+        session_id: sid(),
+        transcript_path: UNREADABLE,
+        schema_version: SCHEMA_VERSION,
+        tokens: [],
+      },
+      { Authorization: "Bearer wrong-token" }
+    );
+    assert.equal(res.status, 401);
+    assert.equal(res.body.error.code, "EUNAUTHORIZED");
+  });
+
+  it("503s every request when DASHBOARD_TOKEN isn't configured at all — fails closed, not open", async () => {
+    const saved = process.env.DASHBOARD_TOKEN;
+    delete process.env.DASHBOARD_TOKEN;
+    try {
+      const res = await req(
+        "POST",
+        "/api/hooks/ingest-batch",
+        {
+          session_id: sid(),
+          transcript_path: UNREADABLE,
+          schema_version: SCHEMA_VERSION,
+          tokens: [],
+        },
+        {}
+      );
+      assert.equal(res.status, 503);
+      assert.equal(res.body.error.code, "REMOTE_INGEST_DISABLED");
+    } finally {
+      process.env.DASHBOARD_TOKEN = saved;
+    }
+  });
+
+  it("an unauthenticated request never reaches the fs.existsSync check (no info leak, CWE-200) — a request for a REAL, readable transcript_path still 401s, not 409", async () => {
+    // __filename is guaranteed to exist on this host. If auth ran after the
+    // existsSync check (or not at all), this would 409 LOCAL_TRANSCRIPT_OWNS_SESSION
+    // instead of 401 — proving auth gates it, not just "happens to run first
+    // in the cases already tested above".
+    const res = await req(
+      "POST",
+      "/api/hooks/ingest-batch",
+      {
+        session_id: sid(),
+        transcript_path: __filename,
+        schema_version: SCHEMA_VERSION,
+        tokens: [],
+      },
+      {}
+    );
+    assert.equal(res.status, 401);
+  });
+});
+
+describe("POST /api/hooks/ingest-batch — token numeric validation (DB-integrity)", () => {
+  it("rejects a negative token count per-item instead of persisting it (replaceTokenUsage overwrites, so one bad item corrupts the total)", async () => {
+    const id = sid();
+    await seedSession(id);
+    const res = await req("POST", "/api/hooks/ingest-batch", {
+      session_id: id,
+      transcript_path: UNREADABLE,
+      schema_version: SCHEMA_VERSION,
+      tokens: [{ model: "claude-opus-4-8", input: -1, output: 10 }],
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.written, 0);
+    assert.equal(res.body.errors.length, 1);
+    assert.equal(res.body.errors[0].kind, "tokens");
+    assert.match(res.body.errors[0].error, /input must be a non-negative number/);
+
+    const row = db
+      .prepare(
+        "SELECT input_tokens FROM token_usage WHERE session_id = ? AND model = 'claude-opus-4-8'"
+      )
+      .get(id);
+    assert.equal(row, undefined, "the negative-input item must never reach the database");
+  });
+
+  it("rejects NaN/Infinity the same as negative — Number.isFinite guards both", async () => {
+    const id = sid();
+    await seedSession(id);
+    const res = await req("POST", "/api/hooks/ingest-batch", {
+      session_id: id,
+      transcript_path: UNREADABLE,
+      schema_version: SCHEMA_VERSION,
+      tokens: [{ model: "claude-opus-4-8", cacheRead: Infinity }],
+    });
+    assert.equal(res.body.written, 0);
+    assert.equal(res.body.errors[0].error, "cacheRead must be a non-negative number");
+  });
+
+  it("still accepts a valid item with every numeric field present and non-negative, including zero", async () => {
+    const id = sid();
+    await seedSession(id);
+    const res = await req("POST", "/api/hooks/ingest-batch", {
+      session_id: id,
+      transcript_path: UNREADABLE,
+      schema_version: SCHEMA_VERSION,
+      tokens: [
+        {
+          model: "claude-opus-4-8",
+          input: 100,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          cacheWrite1h: 0,
+          webSearch: 0,
+          webFetch: 0,
+          codeExec: 0,
+        },
+      ],
+    });
+    assert.equal(res.body.written, 1);
+    assert.equal(res.body.errors.length, 0);
+  });
 });
 
 describe("POST /api/hooks/ingest-batch", () => {

--- a/server/__tests__/ingest-batch.test.js
+++ b/server/__tests__/ingest-batch.test.js
@@ -1,0 +1,344 @@
+/**
+ * @file Tests for POST /api/hooks/ingest-batch — bulk ingestion for a future
+ * remote/household forwarder that has been collecting hook-derived facts
+ * (whole-file token totals, tool events, turn durations, subagent
+ * completions) about a session whose JSONL transcript lives on another
+ * machine's disk. Mirrors the setup/request-helper pattern in
+ * remote-subagent-synth.test.js: in-process server, temp CLAUDE_HOME/DATA_DIR,
+ * sessions seeded via the real SessionStart hook path (so the route is
+ * exercised the way a real forwarder would hit it — session already known,
+ * transcript unreadable on this host).
+ */
+
+const { describe, it, before, after } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+const http = require("http");
+const { SCHEMA_VERSION } = require("../lib/transcript-line-classifier");
+
+const STAMP = `ingest-batch-${Date.now()}-${process.pid}`;
+const TMP = path.join(os.tmpdir(), STAMP);
+process.env.DASHBOARD_DB_PATH = path.join(TMP, "dashboard.db");
+process.env.CLAUDE_HOME = path.join(TMP, "home");
+process.env.DASHBOARD_DATA_DIR = path.join(TMP, "data");
+fs.mkdirSync(TMP, { recursive: true });
+
+const { createApp, startServer } = require("../index");
+const dbModule = require("../db");
+const { db, stmts } = dbModule;
+
+let server;
+let BASE;
+
+function req(method, urlPath, body) {
+  return new Promise((resolve, reject) => {
+    const url = new URL(urlPath, BASE);
+    const payload = body !== undefined ? JSON.stringify(body) : null;
+    const r = http.request(
+      {
+        hostname: url.hostname,
+        port: url.port,
+        path: url.pathname + url.search,
+        method,
+        headers: payload
+          ? { "Content-Type": "application/json", "Content-Length": Buffer.byteLength(payload) }
+          : {},
+      },
+      (res) => {
+        let b = "";
+        res.on("data", (c) => (b += c));
+        res.on("end", () => {
+          let parsed;
+          try {
+            parsed = JSON.parse(b || "{}");
+          } catch {
+            parsed = b;
+          }
+          resolve({ status: res.statusCode, body: parsed });
+        });
+      }
+    );
+    r.on("error", reject);
+    if (payload) r.write(payload);
+    r.end();
+  });
+}
+
+// A path guaranteed not to exist on this host — stands in for a remote
+// machine's transcript that this monitor cannot read.
+const UNREADABLE = "C:\\Users\\matsp\\.claude\\projects\\enc\\does-not-exist.jsonl";
+const WIN_CWD = "C:\\Users\\matsp\\chats\\ingest-batch-session";
+
+let seq = 0;
+function sid() {
+  seq++;
+  return `30000000-0000-0000-0000-${String(seq).padStart(12, "0")}`;
+}
+
+/** Create a session (+ main agent) via the real SessionStart hook path, transcript unreadable here. */
+async function seedSession(sessionId, transcriptPath = UNREADABLE) {
+  await req("POST", "/api/hooks/event", {
+    hook_type: "SessionStart",
+    data: { session_id: sessionId, cwd: WIN_CWD, transcript_path: transcriptPath },
+  });
+}
+
+function tokenRow(sessionId, model) {
+  return db
+    .prepare(
+      "SELECT * FROM token_usage WHERE session_id = ? AND model = ? AND speed = 'standard' AND inference_geo = 'global' AND service_tier = 'standard'"
+    )
+    .get(sessionId, model);
+}
+
+function effectiveInput(row) {
+  return (row?.input_tokens || 0) + (row?.baseline_input || 0);
+}
+
+before(async () => {
+  server = await startServer(createApp(), 0);
+  BASE = `http://127.0.0.1:${server.address().port}`;
+});
+
+after(() => {
+  if (server) server.close();
+  if (db) db.close();
+  try {
+    fs.rmSync(TMP, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+describe("POST /api/hooks/ingest-batch", () => {
+  it("404s when the session is unknown (never calls ensureSession itself)", async () => {
+    const id = sid();
+    const res = await req("POST", "/api/hooks/ingest-batch", {
+      session_id: id,
+      transcript_path: UNREADABLE,
+      schema_version: SCHEMA_VERSION,
+      tokens: [],
+    });
+    assert.equal(res.status, 404);
+    assert.equal(res.body.error.code, "UNKNOWN_SESSION");
+  });
+
+  it("409s on a schema_version mismatch", async () => {
+    const id = sid();
+    await seedSession(id);
+    const res = await req("POST", "/api/hooks/ingest-batch", {
+      session_id: id,
+      transcript_path: UNREADABLE,
+      schema_version: "999",
+      tokens: [],
+    });
+    assert.equal(res.status, 409);
+    assert.equal(res.body.error.code, "SCHEMA_VERSION_MISMATCH");
+  });
+
+  it("409s (skips) when the transcript IS readable on this host — local pipeline owns it", async () => {
+    const id = sid();
+    await seedSession(id);
+    const localPath = path.join(TMP, `${id}.jsonl`);
+    fs.writeFileSync(localPath, "{}\n");
+    const res = await req("POST", "/api/hooks/ingest-batch", {
+      session_id: id,
+      transcript_path: localPath,
+      schema_version: SCHEMA_VERSION,
+      tokens: [{ model: "claude-x", input: 100 }],
+    });
+    assert.equal(res.status, 409);
+    assert.equal(res.body.error.code, "LOCAL_TRANSCRIPT_OWNS_SESSION");
+    assert.equal(tokenRow(id, "claude-x"), undefined, "no token row should have been written");
+  });
+
+  it("400s when transcript_path is missing", async () => {
+    const id = sid();
+    await seedSession(id);
+    const res = await req("POST", "/api/hooks/ingest-batch", {
+      session_id: id,
+      schema_version: SCHEMA_VERSION,
+      tokens: [],
+    });
+    assert.equal(res.status, 400);
+    assert.equal(res.body.error.code, "INVALID_INPUT");
+  });
+
+  it("token replace is idempotent (high-water mark): same totals twice → unchanged; larger totals → updated", async () => {
+    const id = sid();
+    await seedSession(id);
+    const model = "claude-ingest-test";
+
+    const batch1 = {
+      session_id: id,
+      transcript_path: UNREADABLE,
+      schema_version: SCHEMA_VERSION,
+      tokens: [{ model, input: 1000, output: 200, cacheRead: 50 }],
+    };
+    let res = await req("POST", "/api/hooks/ingest-batch", batch1);
+    assert.equal(res.status, 200);
+    assert.equal(res.body.written, 1);
+    assert.equal(effectiveInput(tokenRow(id, model)), 1000);
+
+    // Re-post the exact same totals — high-water-mark replace means the
+    // effective value must not grow (would double-count a whole-file total).
+    res = await req("POST", "/api/hooks/ingest-batch", batch1);
+    assert.equal(res.status, 200);
+    assert.equal(effectiveInput(tokenRow(id, model)), 1000);
+
+    // Larger totals (transcript grew) → the row updates to the new total.
+    const batch2 = {
+      ...batch1,
+      tokens: [{ model, input: 2500, output: 400, cacheRead: 50 }],
+    };
+    res = await req("POST", "/api/hooks/ingest-batch", batch2);
+    assert.equal(res.status, 200);
+    assert.equal(effectiveInput(tokenRow(id, model)), 2500);
+  });
+
+  it("dedupes tool_events by uuid — a redelivered item is a no-op", async () => {
+    const id = sid();
+    await seedSession(id);
+    const item = {
+      uuid: "tool-evt-1",
+      tool_name: "Bash",
+      status: "completed",
+      timestamp: new Date().toISOString(),
+    };
+
+    let res = await req("POST", "/api/hooks/ingest-batch", {
+      session_id: id,
+      transcript_path: UNREADABLE,
+      schema_version: SCHEMA_VERSION,
+      tool_events: [item],
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.written, 1);
+
+    res = await req("POST", "/api/hooks/ingest-batch", {
+      session_id: id,
+      transcript_path: UNREADABLE,
+      schema_version: SCHEMA_VERSION,
+      tool_events: [item],
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.written, 0, "redelivered tool_event should not be re-inserted");
+
+    const count = db
+      .prepare("SELECT COUNT(*) AS c FROM events WHERE session_id = ? AND event_type = 'ToolEvent'")
+      .get(id).c;
+    assert.equal(count, 1);
+  });
+
+  it("dedupes turns by uuid — a redelivered item is a no-op", async () => {
+    const id = sid();
+    await seedSession(id);
+    const item = { uuid: "turn-1", duration_ms: 4200, timestamp: new Date().toISOString() };
+
+    let res = await req("POST", "/api/hooks/ingest-batch", {
+      session_id: id,
+      transcript_path: UNREADABLE,
+      schema_version: SCHEMA_VERSION,
+      turns: [item],
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.written, 1);
+
+    res = await req("POST", "/api/hooks/ingest-batch", {
+      session_id: id,
+      transcript_path: UNREADABLE,
+      schema_version: SCHEMA_VERSION,
+      turns: [item],
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.written, 0);
+
+    const count = db
+      .prepare(
+        "SELECT COUNT(*) AS c FROM events WHERE session_id = ? AND event_type = 'TurnDuration'"
+      )
+      .get(id).c;
+    assert.equal(count, 1);
+  });
+
+  it("subagent idempotency — same agent_id twice creates exactly one row, type='subagent' satisfies the CHECK constraint", async () => {
+    const id = sid();
+    await seedSession(id);
+    const sub = {
+      agent_id: "sub-batch-1",
+      agent_type: "code-reviewer",
+      last_assistant_message: "Reviewed the diff.",
+      prompt: "Review this diff",
+    };
+
+    let res = await req("POST", "/api/hooks/ingest-batch", {
+      session_id: id,
+      transcript_path: UNREADABLE,
+      schema_version: SCHEMA_VERSION,
+      subagents: [sub],
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.written, 1);
+
+    res = await req("POST", "/api/hooks/ingest-batch", {
+      session_id: id,
+      transcript_path: UNREADABLE,
+      schema_version: SCHEMA_VERSION,
+      subagents: [sub],
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.written, 0, "redelivered subagent should not count as written");
+
+    const rows = db
+      .prepare("SELECT * FROM agents WHERE session_id = ? AND type = 'subagent'")
+      .all(id);
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].id, `${id}-sub-sub-batch-1`);
+    assert.equal(rows[0].type, "subagent");
+    assert.equal(rows[0].status, "completed");
+    assert.equal(rows[0].name, "code-reviewer");
+    assert.equal(rows[0].subagent_type, "code-reviewer");
+    assert.ok(rows[0].ended_at);
+  });
+
+  it("per-item soft-fail: invalid items are reported and skipped, valid items in the same batch still land", async () => {
+    const id = sid();
+    await seedSession(id);
+
+    const res = await req("POST", "/api/hooks/ingest-batch", {
+      session_id: id,
+      transcript_path: UNREADABLE,
+      schema_version: SCHEMA_VERSION,
+      tokens: [{ model: "claude-soft-fail-ok", input: 10 }, { input: 10 /* missing model */ }],
+      tool_events: [
+        { uuid: "soft-ok-1", tool_name: "Read" },
+        { tool_name: "NoUuid" /* missing uuid */ },
+      ],
+      turns: [{ uuid: "soft-ok-turn", duration_ms: 100 }, { duration_ms: 100 /* missing uuid */ }],
+      subagents: [
+        { agent_id: "soft-ok-sub" },
+        { last_assistant_message: "no agent_id" /* missing agent_id */ },
+      ],
+    });
+
+    assert.equal(res.status, 200);
+    assert.equal(res.body.failed, 4);
+    assert.equal(res.body.errors.length, 4);
+    assert.equal(res.body.written, 4);
+
+    assert.ok(tokenRow(id, "claude-soft-fail-ok"));
+    const toolCount = db
+      .prepare("SELECT COUNT(*) AS c FROM events WHERE session_id = ? AND event_type = 'ToolEvent'")
+      .get(id).c;
+    assert.equal(toolCount, 1);
+    const turnCount = db
+      .prepare(
+        "SELECT COUNT(*) AS c FROM events WHERE session_id = ? AND event_type = 'TurnDuration'"
+      )
+      .get(id).c;
+    assert.equal(turnCount, 1);
+    assert.ok(stmts.getAgent.get(`${id}-sub-soft-ok-sub`));
+  });
+});

--- a/server/__tests__/notification-idle-vs-actionable.test.js
+++ b/server/__tests__/notification-idle-vs-actionable.test.js
@@ -8,6 +8,7 @@
  *
  * home-network monitor fork (see ai-deck decisions/). Lives in the fork's suite
  * so an upstream merge that reverts the split fails loudly here.
+ * @author Son Nguyen <hoangson091104@gmail.com>
  */
 
 const { describe, it, before, after } = require("node:test");

--- a/server/__tests__/notification-idle-vs-actionable.test.js
+++ b/server/__tests__/notification-idle-vs-actionable.test.js
@@ -1,0 +1,106 @@
+/**
+ * @file Regression: the generic idle-timeout notification "Claude is waiting for
+ * your input" (fires ~60 s after a turn ends) must NOT be treated as an
+ * actionable "asked you something" wait. It is semantically identical to Stop —
+ * the session is simply idle — so it is stamped as the passive 'stop' reason
+ * (idle everywhere: AI-Deck Zzz, deck-web PASSIV, no toast). Only ACTIONABLE
+ * notifications (permission / a real question) get reason 'notification' (???).
+ *
+ * home-network monitor fork (see ai-deck decisions/). Lives in the fork's suite
+ * so an upstream merge that reverts the split fails loudly here.
+ */
+
+const { describe, it, before, after } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("path");
+const os = require("os");
+const http = require("http");
+
+const TEST_DB = path.join(os.tmpdir(), `notif-split-${Date.now()}-${process.pid}.db`);
+process.env.DASHBOARD_DB_PATH = TEST_DB;
+process.env.DASHBOARD_LIVENESS_PROBE = "0";
+
+const { createApp, startServer } = require("../index");
+
+let server;
+let BASE;
+
+function fetch(urlPath, options = {}) {
+  return new Promise((resolve, reject) => {
+    const url = new URL(urlPath, BASE);
+    const req = http.request(
+      {
+        hostname: url.hostname,
+        port: url.port,
+        path: url.pathname + url.search,
+        method: options.method || "GET",
+        headers: { "Content-Type": "application/json" },
+      },
+      (res) => {
+        let body = "";
+        res.on("data", (c) => (body += c));
+        res.on("end", () => {
+          let parsed;
+          try {
+            parsed = JSON.parse(body);
+          } catch {
+            parsed = body;
+          }
+          resolve({ status: res.statusCode, body: parsed });
+        });
+      }
+    );
+    req.on("error", reject);
+    if (options.body) req.write(JSON.stringify(options.body));
+    req.end();
+  });
+}
+
+const hook = (hook_type, data) =>
+  fetch("/api/hooks/event", { method: "POST", body: { hook_type, data } });
+const reasonOf = async (id) => (await fetch(`/api/sessions/${id}`)).body.session.awaiting_reason;
+
+before(async () => {
+  server = await startServer(createApp(), 0);
+  BASE = `http://127.0.0.1:${server.address().port}`;
+});
+after(() => {
+  if (server) server.close();
+});
+
+describe("Notification: idle-timeout vs. actionable", () => {
+  it("'Claude is waiting for your input' → passive 'stop' (idle, no false ???)", async () => {
+    const sid = "notif-idle";
+    await hook("SessionStart", { session_id: sid });
+    await hook("UserPromptSubmit", { session_id: sid, prompt: "go" });
+    await hook("Notification", { session_id: sid, message: "Claude is waiting for your input" });
+    assert.equal(
+      await reasonOf(sid),
+      "stop",
+      "generic idle-wait must be passive, not 'notification'"
+    );
+  });
+
+  it("'Claude needs your permission' → actionable 'notification' (???)", async () => {
+    const sid = "notif-perm";
+    await hook("SessionStart", { session_id: sid });
+    await hook("UserPromptSubmit", { session_id: sid, prompt: "go" });
+    await hook("Notification", {
+      session_id: sid,
+      message: "Claude needs your permission to use Bash",
+    });
+    assert.equal(await reasonOf(sid), "notification", "permission prompt must stay actionable");
+  });
+
+  it("a real question notification stays actionable 'notification'", async () => {
+    const sid = "notif-q";
+    await hook("SessionStart", { session_id: sid });
+    await hook("UserPromptSubmit", { session_id: sid, prompt: "go" });
+    // AskUserQuestion-style: awaiting your approval/response — actionable.
+    await hook("Notification", {
+      session_id: sid,
+      message: "Waiting for your approval to proceed",
+    });
+    assert.equal(await reasonOf(sid), "notification");
+  });
+});

--- a/server/__tests__/remote-subagent-synth.test.js
+++ b/server/__tests__/remote-subagent-synth.test.js
@@ -1,0 +1,195 @@
+/**
+ * @file Tests for the remote/transcript-less subagent synth on SubagentStop.
+ * Household/remote sessions run Claude on another machine, so their subagent
+ * sidechains never reach this host: neither PreToolUse (subagent creation) nor
+ * the post-commit transcript scan creates a subagent row, and the SubagentStop
+ * would otherwise leave the session showing only its main agent. The ingestor
+ * synthesizes a completed subagent row for these — gated on the SubagentStop's
+ * transcript_path NOT being readable on this host (origin/host-agnostic, and a
+ * strict no-op for local sessions whose JSONL is on disk), idempotent by
+ * agent_id. Uses Node's built-in test runner with temp CLAUDE_HOME / DATA_DIR.
+ */
+
+const { describe, it, before, after } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+const http = require("http");
+
+const STAMP = `remote-subagent-synth-${Date.now()}-${process.pid}`;
+const TMP = path.join(os.tmpdir(), STAMP);
+process.env.DASHBOARD_DB_PATH = path.join(TMP, "dashboard.db");
+process.env.CLAUDE_HOME = path.join(TMP, "home");
+process.env.DASHBOARD_DATA_DIR = path.join(TMP, "data");
+fs.mkdirSync(TMP, { recursive: true });
+
+const { createApp, startServer } = require("../index");
+const dbModule = require("../db");
+const { db, stmts } = dbModule;
+
+let server;
+let BASE;
+
+function req(method, urlPath, body) {
+  return new Promise((resolve, reject) => {
+    const url = new URL(urlPath, BASE);
+    const payload = body ? JSON.stringify(body) : null;
+    const r = http.request(
+      {
+        hostname: url.hostname,
+        port: url.port,
+        path: url.pathname + url.search,
+        method,
+        headers: payload
+          ? { "Content-Type": "application/json", "Content-Length": Buffer.byteLength(payload) }
+          : {},
+      },
+      (res) => {
+        let b = "";
+        res.on("data", (c) => (b += c));
+        res.on("end", () => {
+          let parsed;
+          try {
+            parsed = JSON.parse(b || "{}");
+          } catch {
+            parsed = b;
+          }
+          resolve({ status: res.statusCode, body: parsed });
+        });
+      }
+    );
+    r.on("error", reject);
+    if (payload) r.write(payload);
+    r.end();
+  });
+}
+
+/** Count subagent rows for a session. */
+function subagentCount(sid) {
+  return db
+    .prepare("SELECT COUNT(*) AS c FROM agents WHERE session_id = ? AND type = 'subagent'")
+    .get(sid).c;
+}
+
+// A path guaranteed not to exist on this host — stands in for a remote machine's
+// transcript that the monitor cannot read.
+const UNREADABLE = "C:\\Users\\matsp\\.claude\\projects\\enc\\does-not-exist.jsonl";
+
+before(async () => {
+  server = await startServer(createApp(), 0);
+  BASE = `http://127.0.0.1:${server.address().port}`;
+});
+
+after(() => {
+  if (server) server.close();
+  if (db) db.close();
+  try {
+    fs.rmSync(TMP, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+describe("SubagentStop — remote synth", () => {
+  const WIN_CWD = "C:\\Users\\matsp\\chats\\mcp-csr-ipsec-big-session";
+
+  it("synthesizes a completed subagent row when the transcript is unreadable on this host", async () => {
+    const sid = "20000000-0000-0000-0000-000000000001";
+    const res = await req("POST", "/api/hooks/event", {
+      hook_type: "SubagentStop",
+      data: {
+        session_id: sid,
+        cwd: WIN_CWD,
+        transcript_path: UNREADABLE,
+        agent_id: "sub-abc123",
+        last_assistant_message: "Verified the IPsec CSR chain end to end.",
+      },
+    });
+    assert.equal(res.status, 200);
+    assert.equal(subagentCount(sid), 1);
+    const sub = stmts.getAgent.get(`${sid}-sub-sub-abc123`);
+    assert.ok(sub, "synth subagent row should exist");
+    assert.equal(sub.type, "subagent");
+    assert.equal(sub.status, "completed");
+    assert.equal(sub.parent_agent_id, `${sid}-main`);
+    assert.ok(sub.ended_at, "completed subagent should have ended_at set");
+    // No agent_type/description on the event → label falls back to the inline msg.
+    assert.equal(sub.name, "Verified the IPsec CSR chain end to end.");
+  });
+
+  it("is idempotent — a redelivered SubagentStop does not create a second row", async () => {
+    const sid = "20000000-0000-0000-0000-000000000002";
+    const data = {
+      session_id: sid,
+      cwd: WIN_CWD,
+      transcript_path: UNREADABLE,
+      agent_id: "sub-dup",
+      last_assistant_message: "done",
+    };
+    await req("POST", "/api/hooks/event", { hook_type: "SubagentStop", data });
+    await req("POST", "/api/hooks/event", { hook_type: "SubagentStop", data });
+    assert.equal(subagentCount(sid), 1);
+  });
+
+  it("prefers agent_type/description over the inline message for the label + type", async () => {
+    const sid = "20000000-0000-0000-0000-000000000003";
+    await req("POST", "/api/hooks/event", {
+      hook_type: "SubagentStop",
+      data: {
+        session_id: sid,
+        cwd: WIN_CWD,
+        transcript_path: UNREADABLE,
+        agent_id: "sub-typed",
+        agent_type: "frontend-security-accessibility-reviewer",
+        last_assistant_message: "should not be used as the label",
+      },
+    });
+    const sub = stmts.getAgent.get(`${sid}-sub-sub-typed`);
+    assert.equal(sub.name, "frontend-security-accessibility-reviewer");
+    assert.equal(sub.subagent_type, "frontend-security-accessibility-reviewer");
+  });
+
+  it("fires for a remote POSIX-origin session too (origin-agnostic, not Windows-only)", async () => {
+    // A remote Linux laptop reporting to this monitor: POSIX-absolute cwd, but the
+    // transcript still lives on that machine so its path is unreadable here.
+    const sid = "20000000-0000-0000-0000-000000000005";
+    await req("POST", "/api/hooks/event", {
+      hook_type: "SubagentStop",
+      data: {
+        session_id: sid,
+        cwd: "/home/mats/work/project",
+        transcript_path: "/home/mats/.claude/projects/enc/nope.jsonl",
+        agent_id: "sub-posix",
+        last_assistant_message: "remote posix subagent",
+      },
+    });
+    assert.equal(subagentCount(sid), 1);
+  });
+
+  it("does NOT synth when the transcript IS readable on this host (local pipeline owns it)", async () => {
+    const sid = "20000000-0000-0000-0000-000000000004";
+    const tpath = path.join(TMP, `${sid}.jsonl`);
+    fs.writeFileSync(tpath, "{}\n");
+    await req("POST", "/api/hooks/event", {
+      hook_type: "SubagentStop",
+      data: {
+        session_id: sid,
+        cwd: "/home/claude/projects/ai-deck",
+        transcript_path: tpath,
+        agent_id: "sub-local",
+        last_assistant_message: "local subagent",
+      },
+    });
+    assert.equal(subagentCount(sid), 0);
+  });
+
+  it("does NOT synth when the SubagentStop carries no transcript_path", async () => {
+    const sid = "20000000-0000-0000-0000-000000000006";
+    await req("POST", "/api/hooks/event", {
+      hook_type: "SubagentStop",
+      data: { session_id: sid, cwd: WIN_CWD, agent_id: "sub-notp", last_assistant_message: "x" },
+    });
+    assert.equal(subagentCount(sid), 0);
+  });
+});

--- a/server/__tests__/remote-subagent-synth.test.js
+++ b/server/__tests__/remote-subagent-synth.test.js
@@ -8,6 +8,7 @@
  * transcript_path NOT being readable on this host (origin/host-agnostic, and a
  * strict no-op for local sessions whose JSONL is on disk), idempotent by
  * agent_id. Uses Node's built-in test runner with temp CLAUDE_HOME / DATA_DIR.
+ * @author Son Nguyen <hoangson091104@gmail.com>
  */
 
 const { describe, it, before, after } = require("node:test");

--- a/server/__tests__/session-list-cost-parity.test.js
+++ b/server/__tests__/session-list-cost-parity.test.js
@@ -1,0 +1,170 @@
+/**
+ * @file Regression test for a cost-metering bug found in the live dashboard
+ * after the gateway cutover: GET /api/sessions (both the default list and the
+ * sort_by=price branch) priced a session's tokens LOWER than GET
+ * /api/pricing/cost/:sessionId (used by the session-detail page) for the same
+ * completed session — $22.31 vs $23.92 on a real 84.8M-cache-read session.
+ *
+ * Root cause: the two inline SQL queries in server/routes/sessions.js
+ * (buildRows's price-sort branch and its default branch) selected only
+ * {session_id, model, input_tokens, output_tokens, cache_read_tokens,
+ * cache_write_tokens} from token_usage — omitting speed, inference_geo,
+ * service_tier, cache_write_1h_tokens, web_search_requests,
+ * web_fetch_requests, and code_execution_requests. calculateCost's
+ * ratesForBucket (server/routes/pricing.js) reads those missing fields to
+ * pick the correct rate per bucket; with them undefined every bucket priced
+ * as though ALL cache-write tokens were 5m-tier (never 1h) and speed/geo/tier
+ * modifiers never applied. GET /api/pricing/cost/:sessionId (via
+ * stmts.getTokensBySession) always selected the full column set and priced
+ * correctly. This is a pre-existing query/schema drift (the bulk-cost query
+ * predates the cache_write_1h_tokens/speed/geo/tier columns added later for
+ * fast-mode/1h-caching pricing) — unrelated to the remote-ingest-batch work.
+ *
+ * This test reproduces the exact shape of the live session: a single
+ * claude-sonnet-5/standard/global/standard bucket where cache_write_tokens
+ * are ENTIRELY 1h-tier (cache_write_1h_tokens === cache_write_tokens), which
+ * makes the two rates diverge enough to be unmissable.
+ */
+
+const { describe, it, before, after } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+const http = require("http");
+
+const STAMP = `session-list-cost-parity-${Date.now()}-${process.pid}`;
+const TMP = path.join(os.tmpdir(), STAMP);
+process.env.DASHBOARD_DB_PATH = path.join(TMP, "dashboard.db");
+process.env.CLAUDE_HOME = path.join(TMP, "home");
+process.env.DASHBOARD_DATA_DIR = path.join(TMP, "data");
+fs.mkdirSync(TMP, { recursive: true });
+
+const { createApp, startServer } = require("../index");
+const dbModule = require("../db");
+const { db, stmts } = dbModule;
+
+let server;
+let BASE;
+
+function req(method, urlPath, body) {
+  return new Promise((resolve, reject) => {
+    const url = new URL(urlPath, BASE);
+    const payload = body !== undefined ? JSON.stringify(body) : null;
+    const r = http.request(
+      {
+        hostname: url.hostname,
+        port: url.port,
+        path: url.pathname + url.search,
+        method,
+        headers: payload
+          ? { "Content-Type": "application/json", "Content-Length": Buffer.byteLength(payload) }
+          : {},
+      },
+      (res) => {
+        let b = "";
+        res.on("data", (c) => (b += c));
+        res.on("end", () => {
+          let parsed;
+          try {
+            parsed = JSON.parse(b || "{}");
+          } catch {
+            parsed = b;
+          }
+          resolve({ status: res.statusCode, body: parsed });
+        });
+      }
+    );
+    r.on("error", reject);
+    if (payload) r.write(payload);
+    r.end();
+  });
+}
+
+const UNREADABLE = "C:\\Users\\matsp\\.claude\\projects\\enc\\does-not-exist.jsonl";
+const SESSION = "40000000-0000-0000-0000-000000000001";
+
+before(async () => {
+  server = await startServer(createApp(), 0);
+  BASE = `http://127.0.0.1:${server.address().port}`;
+
+  // Deterministic pricing matching the live rule shape: 1h cache-write costs
+  // MORE per token than 5m cache-write, so mispricing every 1h token as 5m
+  // undercounts the total — exactly the live symptom (list < detail).
+  stmts.upsertPricing.run(
+    "claude-sonnet-5%",
+    "Claude Sonnet 5",
+    3.0,
+    15.0,
+    0.3,
+    3.75, // cache_write_per_mtok (5m)
+    6.0, // cache_write_1h_per_mtok
+    0,
+    0
+  );
+
+  // Seed the session via the real SessionStart hook path (transcript
+  // unreadable here, same as a remote/forwarded session) so it has a main
+  // agent row, then write a token_usage bucket directly — mirrors what
+  // ingest-batch's replaceTokenUsage call produces.
+  await req("POST", "/api/hooks/event", {
+    hook_type: "SessionStart",
+    data: { session_id: SESSION, cwd: "/tmp/x", transcript_path: UNREADABLE },
+  });
+
+  stmts.replaceTokenUsage.run(
+    SESSION,
+    "claude-sonnet-5",
+    "standard",
+    "global",
+    "standard",
+    3596, // input
+    266465, // output
+    84802034, // cache_read
+    1070688, // cache_write (total)
+    1070688, // cache_write_1h — ALL of it is 1h-tier
+    0,
+    0,
+    0
+  );
+});
+
+after(() => {
+  if (server) server.close();
+  if (db) db.close();
+  try {
+    fs.rmSync(TMP, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+describe("GET /api/sessions cost parity with GET /api/pricing/cost/:sessionId", () => {
+  it("default-sort list cost matches the detail-page cost", async () => {
+    const detail = await req("GET", `/api/pricing/cost/${SESSION}`);
+    assert.equal(detail.status, 200);
+    assert.ok(detail.body.total_cost > 0, "sanity: detail cost computed");
+
+    const list = await req("GET", `/api/sessions?q=${SESSION}`);
+    assert.equal(list.status, 200);
+    const row = list.body.sessions.find((s) => s.id === SESSION);
+    assert.ok(row, "session present in default list");
+
+    assert.equal(
+      row.cost,
+      detail.body.total_cost,
+      `default list cost (${row.cost}) must match detail cost (${detail.body.total_cost}) — ` +
+        `1h cache-write tokens must be priced at the 1h rate, not silently treated as 5m`
+    );
+  });
+
+  it("sort_by=price list cost matches the detail-page cost", async () => {
+    const detail = await req("GET", `/api/pricing/cost/${SESSION}`);
+    const list = await req("GET", `/api/sessions?q=${SESSION}&sort_by=price`);
+    assert.equal(list.status, 200);
+    const row = list.body.sessions.find((s) => s.id === SESSION);
+    assert.ok(row, "session present in price-sorted list");
+
+    assert.equal(row.cost, detail.body.total_cost);
+  });
+});

--- a/server/__tests__/session-list-cost-parity.test.js
+++ b/server/__tests__/session-list-cost-parity.test.js
@@ -24,6 +24,7 @@
  * claude-sonnet-5/standard/global/standard bucket where cache_write_tokens
  * are ENTIRELY 1h-tier (cache_write_1h_tokens === cache_write_tokens), which
  * makes the two rates diverge enough to be unmissable.
+ * @author Son Nguyen <hoangson091104@gmail.com>
  */
 
 const { describe, it, before, after } = require("node:test");

--- a/server/__tests__/subagent-attribution.test.js
+++ b/server/__tests__/subagent-attribution.test.js
@@ -404,6 +404,63 @@ describe("importSubagentFromJsonl — event attribution", () => {
       }
     }
   });
+
+  it("merging into a synth row backfills the real started_at/ended_at from the transcript", async () => {
+    const tmpFile = path.join(os.tmpdir(), `agent-synth-ts-${Date.now()}-${process.pid}.jsonl`);
+    writeSubagentJsonl(tmpFile, buildSubagentLines("synth-timed"));
+    writeMetaJson(tmpFile.replace(/\.jsonl$/, ".meta.json"), "synth-timed");
+
+    try {
+      const data = await importHistory.parseSubagentFile(tmpFile);
+
+      // Pre-seed a synth row (SubagentStop fallback in routes/hooks.js) as it
+      // would exist BEFORE the transcript was readable: stamped at ingest time,
+      // not the subagent's real run time.
+      const synthId = `${sessionId}-sub-${data.agentId}`;
+      stmts.insertAgent.run(
+        synthId,
+        sessionId,
+        "synth-timed",
+        "subagent",
+        "synth-timed",
+        "completed",
+        null,
+        mainAgentId,
+        null
+      );
+      const before = stmts.getAgent.get(synthId);
+      assert.notEqual(
+        before.started_at,
+        data.startedAt,
+        "sanity: synth row starts with an ingest timestamp, not the transcript's"
+      );
+
+      importHistory.importSubagentFromJsonl(dbModule, sessionId, mainAgentId, data);
+
+      const after = stmts.getAgent.get(synthId);
+      assert.equal(
+        after.started_at,
+        data.startedAt,
+        "started_at should be backfilled from the transcript"
+      );
+      assert.equal(
+        after.ended_at,
+        data.endedAt,
+        "ended_at should be backfilled from the transcript"
+      );
+
+      // No parallel JSONL-keyed row should have been created — events merge
+      // into the synth row, same contract as the live-subagent merge case.
+      assert.equal(stmts.getAgent.get(`${sessionId}-jsonl-${data.agentId}`), undefined);
+    } finally {
+      fs.unlinkSync(tmpFile);
+      try {
+        fs.unlinkSync(tmpFile.replace(/\.jsonl$/, ".meta.json"));
+      } catch {
+        /* ignore */
+      }
+    }
+  });
 });
 
 // ── Per-subagent model token attribution (issue #185) ──────────────────

--- a/server/db.js
+++ b/server/db.js
@@ -411,6 +411,16 @@ try {
 }
 db.prepare("CREATE INDEX IF NOT EXISTS idx_agents_workflow ON agents(workflow_run_id)").run();
 
+// POST /api/hooks/ingest-batch dedups each tool_event/turn against events by
+// (session_id, event_type, json_extract(data,'$.uuid')) — without this, that
+// lookup falls back to a per-session scan re-evaluating json_extract() on
+// every row for every batch item. Expression index mirrors the query exactly,
+// so it's actually usable by SQLite's planner (a plain column index wouldn't
+// match a json_extract() predicate).
+db.prepare(
+  "CREATE INDEX IF NOT EXISTS idx_events_session_type_uuid ON events(session_id, event_type, json_extract(data, '$.uuid'))"
+).run();
+
 // Migrate: add the 1h-ephemeral cache-write rate column to model_pricing.
 // Older DBs predate the 5m/1h cache-write split. ADD COLUMN defaults every
 // existing row to 0, which is not a realistic rate — so immediately backfill a

--- a/server/lib/security.js
+++ b/server/lib/security.js
@@ -122,6 +122,10 @@ function extractToken(req) {
 //   /health, /openapi.json, /docs — harmless metadata / docs.
 //   /hooks  — local Claude Code hook ingestion (the hook handler posts to
 //             loopback and carries no token); loopback bind already protects it.
+//             EXCEPTION: /hooks/ingest-batch is a remote/cross-machine route —
+//             "posted from loopback" is never true for it, so it enforces its
+//             OWN unconditional token check inside the handler
+//             (server/routes/hooks.js) rather than relying on this exemption.
 const TOKEN_EXEMPT_PREFIXES = ["/health", "/openapi.json", "/docs", "/hooks"];
 
 /**

--- a/server/lib/transcript-cache.js
+++ b/server/lib/transcript-cache.js
@@ -13,15 +13,15 @@ const {
   normalizeTier,
   accumulateBucket,
 } = require("./token-usage");
+const {
+  hasInterruptText,
+  isCompactionEntry,
+  isTurnActivityEntry,
+  extractTurnDuration,
+  extractApiError,
+} = require("./transcript-line-classifier");
 
 const MAX_CACHE_ENTRIES = 200;
-
-// Marker text Claude Code writes into the transcript when a turn is cancelled
-// by the user (Esc). The synthetic entry is `type:"user"` and also carries an
-// `interruptedMessageId` field; we accept either signal so detection survives
-// minor format drift. No hook fires on interrupt, so this is the only on-disk
-// evidence the watchdog can use to un-stick a session left in "working".
-const INTERRUPT_RE = /\[Request interrupted by user/i;
 
 // True when the transcript's tail is a user-interrupt that was never followed
 // by real turn activity (a new prompt or model output). Both timestamps come
@@ -32,18 +32,6 @@ function computePendingInterrupt(lastInterruptTs, lastTurnTs) {
   if (!lastInterruptTs) return false;
   if (!lastTurnTs) return true;
   return lastInterruptTs >= lastTurnTs;
-}
-
-function hasInterruptText(message) {
-  if (!message || typeof message !== "object") return false;
-  const c = message.content;
-  if (typeof c === "string") return INTERRUPT_RE.test(c);
-  if (Array.isArray(c)) {
-    for (const block of c) {
-      if (block && typeof block.text === "string" && INTERRUPT_RE.test(block.text)) return true;
-    }
-  }
-  return false;
 }
 
 // Hard cap on the length of each per-entry growable array (turnDurations,
@@ -433,7 +421,7 @@ class TranscriptCache {
     // prompt. Tracking its latest timestamp lets _finalizeState decide whether
     // a later interrupt was superseded by the user resuming (new prompt /
     // model output) or is still the unrecovered tail of the transcript.
-    if ((entry.type === "assistant" || entry.type === "user") && entry.timestamp) {
+    if (isTurnActivityEntry(entry)) {
       if (!state.lastTurnTs || entry.timestamp > state.lastTurnTs)
         state.lastTurnTs = entry.timestamp;
     }
@@ -446,7 +434,7 @@ class TranscriptCache {
       if (firstText) state.firstUserMessage = firstText;
     }
 
-    if (entry.isCompactSummary) {
+    if (isCompactionEntry(entry)) {
       if (!state.compaction) state.compaction = { count: 0, entries: [] };
       state.compaction.count++;
       state.compaction.entries.push({
@@ -458,39 +446,18 @@ class TranscriptCache {
       }
     }
 
-    if (entry.type === "system" && entry.subtype === "turn_duration" && entry.durationMs) {
-      const turnTs = entry.timestamp
-        ? typeof entry.timestamp === "number"
-          ? new Date(entry.timestamp).toISOString()
-          : entry.timestamp
-        : null;
-      state.turnDurations.push({ durationMs: entry.durationMs, timestamp: turnTs });
+    const turnDuration = extractTurnDuration(entry);
+    if (turnDuration) {
+      state.turnDurations.push(turnDuration);
       if (state.turnDurations.length >= PARSE_TRIM_WATERMARK) {
         this._trimArray(state.turnDurations);
       }
     }
 
     const msg = entry.message || entry;
-    if (msg.type === "error" && msg.error) {
-      state.errors.push({
-        type: msg.error.type || "unknown_error",
-        message: msg.error.message || "Unknown API error",
-        timestamp: entry.timestamp || null,
-      });
-      if (state.errors.length >= PARSE_TRIM_WATERMARK) {
-        this._trimArray(state.errors);
-      }
-      return;
-    }
-
-    if (entry.isApiErrorMessage) {
-      const errContent = Array.isArray(entry.message?.content) ? entry.message.content : [];
-      const errText = errContent[0]?.text ? errContent[0].text.slice(0, 500) : "Unknown error";
-      state.errors.push({
-        type: entry.error || "unknown_error",
-        message: errText,
-        timestamp: entry.timestamp || null,
-      });
+    const apiError = extractApiError(entry);
+    if (apiError) {
+      state.errors.push(apiError);
       if (state.errors.length >= PARSE_TRIM_WATERMARK) {
         this._trimArray(state.errors);
       }

--- a/server/lib/transcript-line-classifier.js
+++ b/server/lib/transcript-line-classifier.js
@@ -1,0 +1,111 @@
+/**
+ * @file Pure, line-level classification predicates extracted from
+ * TranscriptCache._consumeLine (server/lib/transcript-cache.js) so the same
+ * JSONL-entry classification logic (compaction, interrupt markers, API
+ * errors, turn duration, turn activity) can be reused outside the streaming
+ * parser — starting with POST /api/hooks/ingest-batch's schema-version
+ * assertion (server/routes/hooks.js). Behavior-preserving extraction: each
+ * function here reproduces exactly what _consumeLine tested/computed inline
+ * before this refactor, and the existing transcript-cache test suite is the
+ * proof (unchanged pass/fail after the switch-over).
+ *
+ * NOT moved: TranscriptCache._streamRange (the chunked file reader). It's a
+ * plausible sharing candidate for a future remote-transcript forwarder too,
+ * but pulling it out is out of scope here — flagged for whoever builds that
+ * forwarder next.
+ * @author Son Nguyen <hoangson091104@gmail.com>
+ */
+
+// Schema version for the POST /api/hooks/ingest-batch payload contract
+// (server/routes/hooks.js). Bumping this is a breaking change for forwarders.
+const SCHEMA_VERSION = "1";
+
+// Marker text Claude Code writes into the transcript when a turn is cancelled
+// by the user (Esc). The synthetic entry is `type:"user"` and also carries an
+// `interruptedMessageId` field; callers accept either signal so detection
+// survives minor format drift.
+const INTERRUPT_RE = /\[Request interrupted by user/i;
+
+/** True when a transcript entry's message contains the interrupt marker text. */
+function hasInterruptText(message) {
+  if (!message || typeof message !== "object") return false;
+  const c = message.content;
+  if (typeof c === "string") return INTERRUPT_RE.test(c);
+  if (Array.isArray(c)) {
+    for (const block of c) {
+      if (block && typeof block.text === "string" && INTERRUPT_RE.test(block.text)) return true;
+    }
+  }
+  return false;
+}
+
+/** True when `entry` is a compaction summary line (isCompactSummary). */
+function isCompactionEntry(entry) {
+  return !!(entry && entry.isCompactSummary);
+}
+
+/**
+ * True when `entry` is real turn activity — assistant output or a genuine
+ * (non-interrupt) user prompt carrying a timestamp. Distinguishes "the
+ * transcript actually progressed" from interrupt markers, which carry no
+ * turn-activity signal of their own.
+ */
+function isTurnActivityEntry(entry) {
+  return !!(entry && (entry.type === "assistant" || entry.type === "user") && entry.timestamp);
+}
+
+/**
+ * Extract a {durationMs, timestamp} record from a `system`/`turn_duration`
+ * entry, or null when `entry` isn't one. `timestamp` is normalized to an ISO
+ * string (Claude Code emits it as either an epoch number or an ISO string).
+ */
+function extractTurnDuration(entry) {
+  if (!entry || entry.type !== "system" || entry.subtype !== "turn_duration" || !entry.durationMs) {
+    return null;
+  }
+  const timestamp = entry.timestamp
+    ? typeof entry.timestamp === "number"
+      ? new Date(entry.timestamp).toISOString()
+      : entry.timestamp
+    : null;
+  return { durationMs: entry.durationMs, timestamp };
+}
+
+/**
+ * Extract a {type, message, timestamp} API-error record from `entry`, or
+ * null when it isn't one. Two on-disk shapes carry API errors: a nested
+ * `message.error` (or a bare `entry.error` when `entry` itself is the
+ * message), and the `isApiErrorMessage` flag Claude Code stamps on some
+ * error entries.
+ */
+function extractApiError(entry) {
+  if (!entry) return null;
+  const msg = entry.message || entry;
+  if (msg.type === "error" && msg.error) {
+    return {
+      type: msg.error.type || "unknown_error",
+      message: msg.error.message || "Unknown API error",
+      timestamp: entry.timestamp || null,
+    };
+  }
+  if (entry.isApiErrorMessage) {
+    const errContent = Array.isArray(entry.message?.content) ? entry.message.content : [];
+    const errText = errContent[0]?.text ? errContent[0].text.slice(0, 500) : "Unknown error";
+    return {
+      type: entry.error || "unknown_error",
+      message: errText,
+      timestamp: entry.timestamp || null,
+    };
+  }
+  return null;
+}
+
+module.exports = {
+  SCHEMA_VERSION,
+  INTERRUPT_RE,
+  hasInterruptText,
+  isCompactionEntry,
+  isTurnActivityEntry,
+  extractTurnDuration,
+  extractApiError,
+};

--- a/server/routes/hooks.js
+++ b/server/routes/hooks.js
@@ -1191,6 +1191,24 @@ router.post("/event", (req, res) => {
 //      shape above), so one bad item can never roll back the rest of an
 //      otherwise-good batch nor partially apply a batch that IS entirely
 //      good.
+//
+// Two further OPTIONAL top-level fields close the parity gap with the local
+// pipeline (verified against a live .213 session whose forwarder-derived copy
+// was missing both):
+//   - "model": string — applied via the same stmts.updateSessionModel used by
+//     the transcript-driven `latestModel` write above (last-write-wins, only
+//     changes the row — and broadcasts — when the value actually differs).
+//   - "usage_extras": { service_tiers[], speeds[], inference_geos[],
+//     thinking_blocks } — merged into sessions.metadata in EXACTLY the shape
+//     the local pipeline writes (see the `result.usageExtras`/
+//     `thinkingBlockCount` block above): `metadata.usage_extras` holds the
+//     three arrays, `metadata.thinking_blocks` sits as a sibling key. Unlike
+//     the local path's per-hook thinking_blocks ACCUMULATION (additive,
+//     because each hook only sees a transcript delta), this batch field is a
+//     whole-session-to-date total — consistent with `tokens` being whole-file
+//     totals elsewhere in this contract — so it is a straight replace: a
+//     re-posted batch is idempotent, and other metadata keys are preserved
+//     (merged into the existing parsed object, never clobbered wholesale).
 router.post("/ingest-batch", (req, res) => {
   const body = req.body || {};
   const sessionId = body.session_id;
@@ -1206,6 +1224,39 @@ router.post("/ingest-batch", (req, res) => {
     return res.status(400).json({
       error: { code: "INVALID_INPUT", message: "transcript_path is required" },
     });
+  }
+  if (body.model !== undefined && typeof body.model !== "string") {
+    return res.status(400).json({
+      error: { code: "INVALID_INPUT", message: "model must be a string" },
+    });
+  }
+  if (body.usage_extras !== undefined) {
+    const ue = body.usage_extras;
+    if (!ue || typeof ue !== "object" || Array.isArray(ue)) {
+      return res.status(400).json({
+        error: { code: "INVALID_INPUT", message: "usage_extras must be an object" },
+      });
+    }
+    for (const key of ["service_tiers", "speeds", "inference_geos"]) {
+      if (ue[key] !== undefined && !Array.isArray(ue[key])) {
+        return res.status(400).json({
+          error: { code: "INVALID_INPUT", message: `usage_extras.${key} must be an array` },
+        });
+      }
+    }
+    if (
+      ue.thinking_blocks !== undefined &&
+      (typeof ue.thinking_blocks !== "number" ||
+        !Number.isFinite(ue.thinking_blocks) ||
+        ue.thinking_blocks < 0)
+    ) {
+      return res.status(400).json({
+        error: {
+          code: "INVALID_INPUT",
+          message: "usage_extras.thinking_blocks must be a non-negative number",
+        },
+      });
+    }
   }
   if (schemaVersion !== SCHEMA_VERSION) {
     return res.status(409).json({
@@ -1278,6 +1329,39 @@ router.post("/ingest-batch", (req, res) => {
   let written = 0;
 
   const runBatch = db.transaction(() => {
+    // Model sync — same prepared statement + last-write-wins semantics as the
+    // transcript-driven `latestModel` write above; a no-op (no broadcast)
+    // when the value is unchanged.
+    if (typeof body.model === "string" && body.model) {
+      const upd = stmts.updateSessionModel.run(body.model, sessionId, body.model);
+      if (upd.changes > 0) {
+        broadcast("session_updated", stmts.getSession.get(sessionId));
+      }
+    }
+
+    // usage_extras / thinking_blocks — merged into sessions.metadata in the
+    // same shape the local pipeline writes (metadata.usage_extras holds the
+    // three arrays, metadata.thinking_blocks is a sibling key). Re-parses the
+    // CURRENT row so other metadata keys (e.g. turn_count written by the
+    // local path) are preserved, not clobbered. No broadcast — mirrors the
+    // local metadata-merge block above, which doesn't broadcast either.
+    if (body.usage_extras) {
+      const metaSession = stmts.getSession.get(sessionId);
+      if (metaSession) {
+        const meta = metaSession.metadata ? JSON.parse(metaSession.metadata) : {};
+        const ue = body.usage_extras;
+        meta.usage_extras = {
+          service_tiers: Array.isArray(ue.service_tiers) ? ue.service_tiers : [],
+          speeds: Array.isArray(ue.speeds) ? ue.speeds : [],
+          inference_geos: Array.isArray(ue.inference_geos) ? ue.inference_geos : [],
+        };
+        if (typeof ue.thinking_blocks === "number") {
+          meta.thinking_blocks = ue.thinking_blocks;
+        }
+        stmts.updateSession.run(null, null, null, JSON.stringify(meta), sessionId);
+      }
+    }
+
     // Whole-file totals per bucket — replaceTokenUsage is already a
     // high-water-mark replace (db.js:1063-1110), so re-posting the same
     // totals is a no-op and posting larger totals updates in place. The

--- a/server/routes/hooks.js
+++ b/server/routes/hooks.js
@@ -65,6 +65,51 @@ function clearAwaitingInput(sessionId, mainAgentId, broadcastUpdates) {
   }
 }
 
+// Reason-aware guarded clear (2026-07-17, AI-Deck/deck-web fork patch — see
+// decisions/ in the home-network repo). PreToolUse/PostToolUse clear the
+// waiting flag on the assumption that a tool event means the human resumed.
+// That assumption breaks when the MAIN agent is blocked on the user
+// (AskUserQuestion / permission) while a BACKGROUND subagent keeps firing
+// PreToolUse/PostToolUse: the subagent's tool event is not the human
+// responding, yet it wiped the flag — so AI-Deck/deck-web lost the "waiting
+// for you" signal (it oscillated on/off in seconds).
+//
+// The existing subagent-actor heuristic (findDeepestWorkingAgent, used just
+// below in each case) already tells us when a subagent — not main — is the
+// actor. We reuse it here: when a subagent is the actor we clear ONLY passive
+// waits (stop/session_start/interrupted); a genuine 'notification' wait (main
+// blocked on the user) is preserved. When MAIN is the actor we clear
+// unconditionally, exactly as before — this keeps the documented
+// permission-mid-tool path (PostToolUse clearing an approved prompt) intact.
+//
+// Passive-clear-by-subagent is deliberate and desirable: it is what lets a
+// backgrounded subagent's activity flip a session that merely Stop-ed
+// (reason='stop') back to active — i.e. "done/idle only while no agent works".
+function clearAwaitingInputRespectingActor(
+  sessionId,
+  mainAgentId,
+  subagentIsActor,
+  broadcastUpdates
+) {
+  if (subagentIsActor) {
+    const sess = stmts.getSession.get(sessionId);
+    if (sess && sess.awaiting_reason === "notification") {
+      // Main is blocked on the user; a subagent tool event must not clear it.
+      return;
+    }
+  }
+  clearAwaitingInput(sessionId, mainAgentId, broadcastUpdates);
+}
+
+// True when the deepest currently-working agent is a subagent while the main
+// agent is in 'waiting' — i.e. an incoming tool event is attributable to a
+// subagent, not to the main agent resuming. Mirrors the inline heuristic the
+// PreToolUse/PostToolUse cases already use for agent attribution.
+function subagentIsActorNow(sessionId, mainAgent) {
+  if (!mainAgent || mainAgent.status !== "waiting") return false;
+  return !!stmts.findDeepestWorkingAgent.get(sessionId, sessionId);
+}
+
 // Land a session that was cancelled with no hook (Esc) in the same
 // waiting + awaiting-input state a normal Stop produces, and log a timeline
 // event. Used by both watchdog recovery paths: the transcript-marker path
@@ -367,8 +412,17 @@ const processEvent = db.transaction((hookType, data) => {
 
       // PreToolUse means Claude is actively running a tool, ergo the user
       // has resumed (Stop only fires at end of turn — Claude can't start a
-      // new tool call without fresh user input). Clear waiting now.
-      clearAwaitingInput(sessionId, mainAgentId, true);
+      // new tool call without fresh user input). Clear waiting now — UNLESS a
+      // background subagent is the actor and main is blocked on the user
+      // (reason='notification'), in which case the flag is preserved
+      // (clearAwaitingInputRespectingActor). Computed before the clear because
+      // the Agent-spawn branch below mutates agent rows.
+      clearAwaitingInputRespectingActor(
+        sessionId,
+        mainAgentId,
+        subagentIsActorNow(sessionId, mainAgent),
+        true
+      );
 
       // If the tool is Agent, a subagent is being created
       if (toolName === "Agent") {
@@ -447,7 +501,14 @@ const processEvent = db.transaction((hookType, data) => {
       // Code prompts the user mid-tool). The Notification stamps waiting,
       // the user approves, the tool completes, PostToolUse arrives. Without
       // a clear here, we'd be stuck in waiting until the next PreToolUse.
-      clearAwaitingInput(sessionId, mainAgentId, true);
+      // Same actor-guard as PreToolUse: a background subagent's PostToolUse
+      // must not clear a genuine 'notification' wait held by the main agent.
+      clearAwaitingInputRespectingActor(
+        sessionId,
+        mainAgentId,
+        subagentIsActorNow(sessionId, mainAgent),
+        true
+      );
 
       // NOTE: PostToolUse for "Agent" tool fires immediately when a subagent is
       // backgrounded — it does NOT mean the subagent finished its work.

--- a/server/routes/hooks.js
+++ b/server/routes/hooks.js
@@ -9,6 +9,10 @@ const dbModule = require("../db");
 const { stmts, db } = dbModule;
 const { broadcast } = require("../websocket");
 const TranscriptCache = require("../lib/transcript-cache");
+// Shared with the transcript path so payload-derived descriptors normalize
+// (whitespace collapse, 500-char cap, synthetic/tool-result skip) identically.
+const { extractFirstUserText } = TranscriptCache;
+const fs = require("fs");
 const { scanAndImportSubagents } = require("../../scripts/import-history");
 const { evaluateEvent } = require("../lib/alerts");
 const { ingestWorkflowsForSession } = require("../lib/workflow-ingest");
@@ -173,6 +177,24 @@ function firstUserLabel(result) {
 }
 
 /**
+ * Derive a descriptor label from a raw UserPromptSubmit `prompt` payload, reusing
+ * the shared extractFirstUserText so a payload-derived descriptor is byte-identical
+ * to the transcript-derived one (same whitespace collapse, 500-char cap, and
+ * synthetic/tool-result skip). Additionally skips bare slash-command prompts
+ * (e.g. "/lagre", "/kunnskap args") — in the transcript these arrive as filtered
+ * <command-name> plumbing, so the descriptor must not adopt them from the raw
+ * payload either. The slash test intentionally does NOT match a POSIX path like
+ * "/home/claude/..." (the char after the first segment is "/", not whitespace/end).
+ * Returns null when the prompt is not a usable first message.
+ */
+function descriptorFromPrompt(prompt) {
+  const text = extractFirstUserText({ message: { role: "user", content: prompt } });
+  if (!text) return null;
+  if (/^\/[A-Za-z0-9_:-]+(?:\s|$)/.test(text)) return null;
+  return text;
+}
+
+/**
  * True when the main agent's name is still an auto-generated label:
  * "Main Agent" (seed/API fallback) or "Main Agent - <auto session label>"
  * (hook / import creation paths). A suffix that is a real title — or the
@@ -281,6 +303,13 @@ const processEvent = db.transaction((hookType, data) => {
           ? data.remote_custom_title.slice(0, 200)
           : null,
       aiTitle: typeof data.remote_ai_title === "string" ? data.remote_ai_title.slice(0, 200) : null,
+      // The remote descriptor fallback (UserPromptSubmit handling below) may have
+      // named this session from an earlier prompt. Surface that label so
+      // syncSessionName's replaceable check lets a later ai-title take over a
+      // descriptor-derived name — exactly as it does on the local transcript path.
+      // The main agent's task holds the full first-user message written there, and
+      // firstUserLabel reproduces the same label that was written to sessions.name.
+      firstUserMessage: getMainAgent(sessionId)?.task || null,
     });
   }
 
@@ -540,6 +569,61 @@ const processEvent = db.transaction((hookType, data) => {
 
         // Session stays active — SubagentStop just means one subagent finished,
         // the session is not over until the user explicitly closes it.
+      } else if (
+        typeof data.agent_id === "string" &&
+        data.agent_id &&
+        typeof data.transcript_path === "string" &&
+        data.transcript_path &&
+        !fs.existsSync(data.transcript_path)
+      ) {
+        // Remote/transcript-less synth. For household sessions the subagent
+        // sidechains live in the origin machine's JSONL, so neither PreToolUse
+        // (subagent creation) nor the post-commit transcript scan ever creates a
+        // subagent row here — the SubagentStop would otherwise vanish and the
+        // session shows only its main agent. Gated on the transcript_path this
+        // event carries NOT being readable on this host — the exact condition
+        // being compensated for, origin/host-agnostic (Windows or remote-POSIX
+        // alike), and false for local sessions whose JSONL is on disk, so the
+        // richer local PreToolUse/transcript-scan pipeline is never duplicated.
+        // Synthesize a completed subagent row so the agent count + tree reflect
+        // the real fan-out. Idempotent by agent_id. agent_type is usually absent
+        // on this event, so the label falls back to the inline last-assistant
+        // message; started_at≈ended_at since the true start isn't known here.
+        const subId = `${sessionId}-sub-${data.agent_id}`;
+        if (stmts.getAgent.get(subId)) {
+          agentId = subId; // already synthesized (redelivered event) — no dup
+        } else {
+          const rawLabel =
+            (typeof data.description === "string" && data.description) ||
+            (typeof data.agent_type === "string" && data.agent_type) ||
+            (typeof data.subagent_type === "string" && data.subagent_type) ||
+            (typeof data.last_assistant_message === "string" && data.last_assistant_message) ||
+            "Subagent";
+          const collapsed = rawLabel.replace(/\s+/g, " ").trim() || "Subagent";
+          const label = collapsed.length > 60 ? collapsed.slice(0, 57) + "..." : collapsed;
+          const subType =
+            (typeof data.agent_type === "string" && data.agent_type) ||
+            (typeof data.subagent_type === "string" && data.subagent_type) ||
+            null;
+          stmts.insertAgent.run(
+            subId,
+            sessionId,
+            label,
+            "subagent",
+            subType,
+            "completed",
+            typeof data.prompt === "string" ? data.prompt.slice(0, 500) : null,
+            mainAgentId,
+            null
+          );
+          // Stamp ended_at (insertAgent only sets started_at) via the shared
+          // prepared statement — current_tool is written verbatim as null, fine
+          // for a just-created row that never had one.
+          stmts.updateAgent.run(null, null, null, null, new Date().toISOString(), null, subId);
+          broadcast("agent_created", stmts.getAgent.get(subId));
+          agentId = subId;
+          summary = `Subagent completed: ${label}`;
+        }
       }
       break;
     }
@@ -916,6 +1000,23 @@ const processEvent = db.transaction((hookType, data) => {
         }
       }
     }
+  }
+
+  // Remote/transcript-less fallback for the session descriptor. When the JSONL
+  // lives on another machine's disk (household/remote sessions whose paths point
+  // off this host), transcriptCache.extract() above returns null and the
+  // descriptor block never runs, so the session stays "Session <hex>" and the
+  // main agent's task stays empty. Claude Code's UserPromptSubmit payload carries
+  // the raw prompt inline, so we can still fill placeholder session/main-agent
+  // names + the main-agent task from it. descriptorFromPrompt applies the SAME
+  // normalization/filtering as the transcript path, so the two produce
+  // byte-identical labels — which keeps a later ai-title takeover working and
+  // makes this a strict no-op for local sessions (applyFirstUserDescriptor only
+  // fills auto/placeholder rows; it also heals a transient local transcript-read
+  // miss on a brand-new session whose JSONL isn't flushed yet at first prompt).
+  if (hookType === "UserPromptSubmit") {
+    const label = descriptorFromPrompt(data.prompt);
+    if (label) applyFirstUserDescriptor(sessionId, { firstUserMessage: label });
   }
 
   // Evict transcript from cache on SessionEnd — session is done, no more reads expected.

--- a/server/routes/hooks.js
+++ b/server/routes/hooks.js
@@ -794,16 +794,30 @@ const processEvent = db.transaction((hookType, data) => {
         eventType = "Compaction";
         summary = msg;
       } else if (isWaitingForUserMessage(msg)) {
-        // Claude Code is blocked waiting for the user (permission prompt or
-        // explicit "waiting for input" notice). Stamp session + main agent
-        // so the dashboard can surface a yellow "Waiting" badge until the
-        // user responds — at which point the next PreToolUse/Stop clears it.
+        // Claude Code is blocked waiting for the user. Two distinct cases share
+        // this branch (2026-07-17, home-network fork — see ai-deck decisions/):
+        //   - ACTIONABLE ("needs your permission", approval, a real question)
+        //     → reason 'notification': the user must respond → yellow "Waiting"
+        //     + toast. This is the "asked YOU something" signal.
+        //   - GENERIC IDLE-TIMEOUT ("Claude is waiting for your input", fires
+        //     after ~60 s idle at the prompt) → semantically identical to Stop:
+        //     the session simply finished and is sitting idle. Stamping it as
+        //     'notification' made a merely-idle session flip to the yellow
+        //     "asked you" state (and flashed ??? in AI-Deck) even though nothing
+        //     was asked. Stamp it as the passive 'stop' reason instead, so every
+        //     consumer (AI-Deck / deck-web) treats it as idle — no toast, no
+        //     false "waiting for you". No client change needed: 'stop' already
+        //     maps to idle everywhere.
+        const isIdleWait =
+          /\bwaiting for (your )?input\b/i.test(msg) &&
+          !/\b(permission|approval|needs?\s+your)\b/i.test(msg);
+        const reason = isIdleWait ? "stop" : "notification";
         const ts = new Date().toISOString();
-        stmts.setSessionAwaitingInput.run(ts, "notification", sessionId);
+        stmts.setSessionAwaitingInput.run(ts, reason, sessionId);
         broadcast("session_updated", stmts.getSession.get(sessionId));
         if (mainAgentId) {
           stmts.updateAgent.run(null, "waiting", null, null, null, null, mainAgentId);
-          stmts.setAgentAwaitingInput.run(ts, "notification", mainAgentId);
+          stmts.setAgentAwaitingInput.run(ts, reason, mainAgentId);
           broadcast("agent_updated", stmts.getAgent.get(mainAgentId));
         }
         summary = msg;

--- a/server/routes/hooks.js
+++ b/server/routes/hooks.js
@@ -23,6 +23,7 @@ const liveness = require("../lib/session-liveness");
 // with server/lib/transcript-line-classifier.js so a bump there and the
 // version assert here can never drift apart.
 const { SCHEMA_VERSION } = require("../lib/transcript-line-classifier");
+const { getDashboardToken, extractToken, tokensMatch } = require("../lib/security");
 
 const router = Router();
 
@@ -1265,10 +1266,11 @@ const MAX_BATCH_ITEMS = 2000;
  * forwarder that has been collecting hook-derived facts (token totals, tool
  * events, turn durations, subagent completions) about a session whose JSONL
  * transcript lives on another machine's disk. Mounted under /api/hooks (not a
- * new top-level prefix) so it inherits the same Traefik/DASHBOARD_TOKEN
- * exemption as /api/hooks/event (server/lib/security.js TOKEN_EXEMPT_PREFIXES
- * includes "/hooks") — a new prefix would 401 once an operator sets
- * DASHBOARD_TOKEN.
+ * new top-level prefix) purely for Traefik path-routing convenience —
+ * despite the mount point, it does NOT inherit the rest of /hooks' exemption
+ * from DASHBOARD_TOKEN (server/lib/security.js TOKEN_EXEMPT_PREFIXES); see
+ * the auth gate at the top of the handler for why this one route opts back
+ * into requiring it.
  *
  * Contract, enforced in order:
  *   1. transcript_path must be a non-empty string, and must NOT be readable
@@ -1323,14 +1325,55 @@ const MAX_BATCH_ITEMS = 2000;
  *     re-posted batch is idempotent, and other metadata keys are preserved
  *     (merged into the existing parsed object, never clobbered wholesale).
  *
+ * Unlike every other route under /hooks, this one is NOT exempt from
+ * DASHBOARD_TOKEN (see the auth gate at the top of the handler): it exists
+ * specifically for a caller on another machine, so the loopback-bind
+ * protection the rest of /hooks relies on never applies to it. A bearer
+ * token is required unconditionally — including a 503 refusal when the
+ * server has no DASHBOARD_TOKEN configured at all, rather than accepting
+ * unauthenticated remote writes by default.
+ *
  * @name POST/api/hooks/ingest-batch
  * @param {import("express").Request} req - Body per the contract above.
+ *   Requires an `Authorization: Bearer <DASHBOARD_TOKEN>` header (or
+ *   `x-dashboard-token` / `?token=`, per server/lib/security.js).
  * @param {import("express").Response} res - 200 `{written, errors}` on
  *   success (partial per-item failures reported in `errors`, not thrown);
- *   400/404/409/500 with `{error:{code,message}}` on the hard-fail cases.
+ *   401 EUNAUTHORIZED on a missing/wrong token, 503 REMOTE_INGEST_DISABLED
+ *   when no token is configured; 400/404/409/500 with
+ *   `{error:{code,message}}` on the other hard-fail cases.
  * @returns {void}
  */
 router.post("/ingest-batch", (req, res) => {
+  // ── Auth gate (CWE-306) ────────────────────────────────────────────────
+  // Every OTHER route under /hooks is intentionally exempt from
+  // DASHBOARD_TOKEN (server/lib/security.js TOKEN_EXEMPT_PREFIXES) because
+  // they're posted by the LOCAL Claude Code hook script over loopback, which
+  // never carries a token — loopback bind is the actual protection there.
+  // ingest-batch breaks that assumption on purpose: it exists specifically
+  // for a caller on ANOTHER machine, so "posted from loopback" is never true
+  // for it. Carve this one route back OUT of the /hooks exemption and
+  // require DASHBOARD_TOKEN unconditionally — including refusing to run at
+  // all when no token is configured, rather than silently accepting
+  // unauthenticated remote writes just because the operator never set one.
+  // This also closes the info-leak below (fs.existsSync on a caller-supplied
+  // path): an unauthenticated caller now never reaches that line.
+  const expectedToken = getDashboardToken();
+  if (!expectedToken) {
+    return res.status(503).json({
+      error: {
+        code: "REMOTE_INGEST_DISABLED",
+        message:
+          "POST /api/hooks/ingest-batch requires DASHBOARD_TOKEN to be configured on this server",
+      },
+    });
+  }
+  if (!tokensMatch(extractToken(req), expectedToken)) {
+    return res
+      .status(401)
+      .json({ error: { code: "EUNAUTHORIZED", message: "missing or invalid dashboard token" } });
+  }
+
   const body = req.body || {};
   const sessionId = body.session_id;
   const transcriptPath = body.transcript_path;
@@ -1449,10 +1492,41 @@ router.post("/ingest-batch", (req, res) => {
 
   // ── Validate items before the transaction (per-item soft-fail) ──────────
   const errors = [];
+
+  // A negative count here isn't just nonsensical — replaceTokenUsage
+  // OVERWRITES a session's whole-file totals (not additive), so one bad item
+  // permanently corrupts a cost total no later valid batch can self-heal.
+  // Every field is optional (`t.field || 0` at the write site), so only
+  // reject a PRESENT value that's actually invalid — absence still means 0.
+  const TOKEN_NUMERIC_FIELDS = [
+    "input",
+    "output",
+    "cacheRead",
+    "cacheWrite",
+    "cacheWrite1h",
+    "webSearch",
+    "webFetch",
+    "codeExec",
+  ];
+  function invalidTokenField(t) {
+    for (const key of TOKEN_NUMERIC_FIELDS) {
+      const v = t[key];
+      if (v !== undefined && (typeof v !== "number" || !Number.isFinite(v) || v < 0)) {
+        return key;
+      }
+    }
+    return null;
+  }
+
   const validTokens = [];
   for (const [index, t] of (Array.isArray(body.tokens) ? body.tokens : []).entries()) {
     if (!t || typeof t !== "object" || typeof t.model !== "string" || !t.model) {
       errors.push({ kind: "tokens", index, error: "missing model" });
+      continue;
+    }
+    const badField = invalidTokenField(t);
+    if (badField) {
+      errors.push({ kind: "tokens", index, error: `${badField} must be a non-negative number` });
       continue;
     }
     validTokens.push(t);

--- a/server/routes/hooks.js
+++ b/server/routes/hooks.js
@@ -1185,12 +1185,25 @@ router.post("/event", (req, res) => {
 //      forwarded through /event). This route never calls ensureSession —
 //      insertSession is not an upsert, so racing it here against a live
 //      SessionStart could create a duplicate/conflicting row.
-//   4. Items are validated BEFORE the transaction (per-item soft-fail):
+//   4. The session's main agent (`${sessionId}-main`) must exist too. A
+//      SessionStart-created session always has one (ensureSession inserts
+//      both rows together), but a session created via the bare
+//      POST /api/sessions route does not — that route only inserts the
+//      session. Resolving mainAgentId without verifying the row exists let
+//      tool_events/turns/subagents insertEvent() calls throw a FOREIGN KEY
+//      constraint failure INSIDE the transaction below, rolling back an
+//      otherwise-good batch with no structured error. 404s as
+//      UNKNOWN_MAIN_AGENT before anything is written.
+//   5. Items are validated BEFORE the transaction (per-item soft-fail):
 //      malformed entries are skipped and reported in `errors`, valid ones are
 //      written atomically in a single db.transaction (mirrors processEvent's
 //      shape above), so one bad item can never roll back the rest of an
 //      otherwise-good batch nor partially apply a batch that IS entirely
-//      good.
+//      good. Any OTHER exception out of that transaction (e.g. a
+//      caller-supplied tool_event.agent_id that doesn't exist) is caught
+//      around the runBatch() call and mapped to a structured JSON 500
+//      (INGEST_BATCH_FAILED) rather than falling through to Express'
+//      generic HTML error handler.
 //
 // Two further OPTIONAL top-level fields close the parity gap with the local
 // pipeline (verified against a live .213 session whose forwarder-derived copy
@@ -1286,6 +1299,30 @@ router.post("/ingest-batch", (req, res) => {
     });
   }
 
+  // A session created via SessionStart always gets a `${sessionId}-main`
+  // agent row (ensureSession above). But a session can also come into
+  // existence via POST /api/sessions (server/routes/sessions.js), which
+  // inserts the session row only and never calls insertAgent — so a session
+  // can legitimately exist here with no main agent. Prior to this check,
+  // that case fell through to a synthesized mainAgentId that was never
+  // verified against the agents table: the first insertEvent referencing it
+  // (tool_events/turns) threw a FOREIGN KEY constraint failure *inside*
+  // db.transaction, which auto-rolled back the entire batch — including
+  // otherwise-valid items — and produced no `error.code` a caller could
+  // branch on (see the try/catch around runBatch() below). Gate it here,
+  // before any item is written, same as the other hard per-batch checks
+  // above.
+  const mainAgent = getMainAgent(sessionId);
+  if (!mainAgent) {
+    return res.status(404).json({
+      error: {
+        code: "UNKNOWN_MAIN_AGENT",
+        message: `session ${sessionId} has no main agent (${sessionId}-main) — session must be created via the SessionStart hook, not POST /api/sessions`,
+      },
+    });
+  }
+  const mainAgentId = mainAgent.id;
+
   // ── Validate items before the transaction (per-item soft-fail) ──────────
   const errors = [];
   const validTokens = [];
@@ -1324,8 +1361,6 @@ router.post("/ingest-batch", (req, res) => {
     validSubagents.push(s);
   }
 
-  const mainAgent = getMainAgent(sessionId);
-  const mainAgentId = mainAgent ? mainAgent.id : `${sessionId}-main`;
   let written = 0;
 
   const runBatch = db.transaction(() => {
@@ -1495,7 +1530,25 @@ router.post("/ingest-batch", (req, res) => {
     stmts.touchSession.run(sessionId);
   });
 
-  runBatch();
+  // The per-item validation above only checks shape (missing uuid/agent_id/
+  // model). It can't catch every way a batch item breaks a DB constraint
+  // (e.g. an explicit tool_event.agent_id that doesn't exist in `agents`)
+  // and better-sqlite3/node:sqlite both throw synchronously on constraint
+  // violations, which db.transaction rethrows after rolling back. Without
+  // this catch, that exception fell through to Express' default error
+  // handler — a generic HTML 500, not this route's {error:{code,message}}
+  // JSON contract — breaking any forwarder that parses res.body.error.code.
+  try {
+    runBatch();
+  } catch (err) {
+    console.error(`[HOOKS] ingest-batch transaction failed for session ${sessionId}:`, err);
+    return res.status(500).json({
+      error: {
+        code: "INGEST_BATCH_FAILED",
+        message: err && err.message ? err.message : "ingest-batch transaction failed",
+      },
+    });
+  }
 
   res.json({ ok: true, written, failed: errors.length, errors });
 });

--- a/server/routes/hooks.js
+++ b/server/routes/hooks.js
@@ -1297,6 +1297,15 @@ router.post("/event", (req, res) => {
 //     totals elsewhere in this contract — so it is a straight replace: a
 //     re-posted batch is idempotent, and other metadata keys are preserved
 //     (merged into the existing parsed object, never clobbered wholesale).
+// Hard cap per array, per batch. A well-behaved forwarder posts once per
+// session lifecycle worth of accumulated facts (dozens to low hundreds of
+// tool events for a typical session) — an array in the thousands signals a
+// misbehaving/looping caller, not legitimate backlog, and every extra item
+// costs one more (now-indexed, but still real) dedup lookup inside the
+// transaction. Rejecting the whole batch (not silently truncating) matches
+// this route's existing "hard per-batch check" style above.
+const MAX_BATCH_ITEMS = 2000;
+
 router.post("/ingest-batch", (req, res) => {
   const body = req.body || {};
   const sessionId = body.session_id;
@@ -1398,6 +1407,22 @@ router.post("/ingest-batch", (req, res) => {
   }
   const mainAgentId = mainAgent.id;
 
+  for (const [kind, arr] of [
+    ["tokens", body.tokens],
+    ["tool_events", body.tool_events],
+    ["turns", body.turns],
+    ["subagents", body.subagents],
+  ]) {
+    if (Array.isArray(arr) && arr.length > MAX_BATCH_ITEMS) {
+      return res.status(400).json({
+        error: {
+          code: "BATCH_TOO_LARGE",
+          message: `${kind} has ${arr.length} items, exceeding the ${MAX_BATCH_ITEMS}-item limit per batch — split into multiple requests`,
+        },
+      });
+    }
+  }
+
   // ── Validate items before the transaction (per-item soft-fail) ──────────
   const errors = [];
   const validTokens = [];
@@ -1438,6 +1463,16 @@ router.post("/ingest-batch", (req, res) => {
 
   let written = 0;
 
+  // Broadcasts are collected here and flushed only AFTER runBatch() commits
+  // successfully. Calling the real broadcast() from inside the transaction
+  // would fire it before a later statement in the same batch can still throw
+  // and roll everything back — clients would then see data (via the socket
+  // push) that was never actually persisted. queueBroadcast has the same
+  // (type, payload) signature as broadcast(), so every call site below is an
+  // otherwise-unchanged drop-in swap.
+  const pendingBroadcasts = [];
+  const queueBroadcast = (type, payload) => pendingBroadcasts.push([type, payload]);
+
   const runBatch = db.transaction(() => {
     // Model sync — same prepared statement + last-write-wins semantics as the
     // transcript-driven `latestModel` write above; a no-op (no broadcast)
@@ -1445,7 +1480,7 @@ router.post("/ingest-batch", (req, res) => {
     if (typeof body.model === "string" && body.model) {
       const upd = stmts.updateSessionModel.run(body.model, sessionId, body.model);
       if (upd.changes > 0) {
-        broadcast("session_updated", stmts.getSession.get(sessionId));
+        queueBroadcast("session_updated", stmts.getSession.get(sessionId));
       }
     }
 
@@ -1518,7 +1553,7 @@ router.post("/ingest-batch", (req, res) => {
         `Tool ${status}: ${toolName || "unknown"}`,
         JSON.stringify({ uuid: e.uuid, status, timestamp: e.timestamp || null })
       );
-      broadcast("new_event", {
+      queueBroadcast("new_event", {
         session_id: sessionId,
         agent_id: agentId,
         event_type: "ToolEvent",
@@ -1546,7 +1581,7 @@ router.post("/ingest-batch", (req, res) => {
         summary,
         JSON.stringify({ durationMs, uuid: t.uuid })
       );
-      broadcast("new_event", {
+      queueBroadcast("new_event", {
         session_id: sessionId,
         agent_id: mainAgentId,
         event_type: "TurnDuration",
@@ -1598,7 +1633,7 @@ router.post("/ingest-batch", (req, res) => {
       // synthesized subagent shows as completed with a real (if approximate)
       // duration instead of an open-ended one.
       stmts.updateAgent.run(null, null, null, null, new Date().toISOString(), null, subId);
-      broadcast("agent_created", stmts.getAgent.get(subId));
+      queueBroadcast("agent_created", stmts.getAgent.get(subId));
       written++;
     }
 
@@ -1624,6 +1659,10 @@ router.post("/ingest-batch", (req, res) => {
       },
     });
   }
+
+  // Only reachable once runBatch() has actually committed — safe to tell
+  // clients about state that now genuinely exists in the database.
+  for (const [type, payload] of pendingBroadcasts) broadcast(type, payload);
 
   res.json({ ok: true, written, failed: errors.length, errors });
 });

--- a/server/routes/hooks.js
+++ b/server/routes/hooks.js
@@ -65,26 +65,35 @@ function clearAwaitingInput(sessionId, mainAgentId, broadcastUpdates) {
   }
 }
 
-// Reason-aware guarded clear (2026-07-17, AI-Deck/deck-web fork patch — see
-// decisions/ in the home-network repo). PreToolUse/PostToolUse clear the
-// waiting flag on the assumption that a tool event means the human resumed.
-// That assumption breaks when the MAIN agent is blocked on the user
-// (AskUserQuestion / permission) while a BACKGROUND subagent keeps firing
-// PreToolUse/PostToolUse: the subagent's tool event is not the human
-// responding, yet it wiped the flag — so AI-Deck/deck-web lost the "waiting
-// for you" signal (it oscillated on/off in seconds).
-//
-// The existing subagent-actor heuristic (findDeepestWorkingAgent, used just
-// below in each case) already tells us when a subagent — not main — is the
-// actor. We reuse it here: when a subagent is the actor we clear ONLY passive
-// waits (stop/session_start/interrupted); a genuine 'notification' wait (main
-// blocked on the user) is preserved. When MAIN is the actor we clear
-// unconditionally, exactly as before — this keeps the documented
-// permission-mid-tool path (PostToolUse clearing an approved prompt) intact.
-//
-// Passive-clear-by-subagent is deliberate and desirable: it is what lets a
-// backgrounded subagent's activity flip a session that merely Stop-ed
-// (reason='stop') back to active — i.e. "done/idle only while no agent works".
+/**
+ * Reason-aware guarded clear (2026-07-17, AI-Deck/deck-web fork patch — see
+ * decisions/ in the home-network repo). PreToolUse/PostToolUse clear the
+ * waiting flag on the assumption that a tool event means the human resumed.
+ * That assumption breaks when the MAIN agent is blocked on the user
+ * (AskUserQuestion / permission) while a BACKGROUND subagent keeps firing
+ * PreToolUse/PostToolUse: the subagent's tool event is not the human
+ * responding, yet it wiped the flag — so AI-Deck/deck-web lost the "waiting
+ * for you" signal (it oscillated on/off in seconds).
+ *
+ * The existing subagent-actor heuristic (findDeepestWorkingAgent, used just
+ * below in each case) already tells us when a subagent — not main — is the
+ * actor. We reuse it here: when a subagent is the actor we clear ONLY passive
+ * waits (stop/session_start/interrupted); a genuine 'notification' wait (main
+ * blocked on the user) is preserved. When MAIN is the actor we clear
+ * unconditionally, exactly as before — this keeps the documented
+ * permission-mid-tool path (PostToolUse clearing an approved prompt) intact.
+ *
+ * Passive-clear-by-subagent is deliberate and desirable: it is what lets a
+ * backgrounded subagent's activity flip a session that merely Stop-ed
+ * (reason='stop') back to active — i.e. "done/idle only while no agent works".
+ *
+ * @param {string} sessionId - Session whose awaiting-input state may clear.
+ * @param {string} mainAgentId - Main agent id (clearAwaitingInput targets it).
+ * @param {boolean} subagentIsActor - True when a background subagent, not
+ *   main, is the agent that just fired the triggering tool event.
+ * @param {boolean} broadcastUpdates - Forwarded to clearAwaitingInput.
+ * @returns {void}
+ */
 function clearAwaitingInputRespectingActor(
   sessionId,
   mainAgentId,
@@ -101,10 +110,16 @@ function clearAwaitingInputRespectingActor(
   clearAwaitingInput(sessionId, mainAgentId, broadcastUpdates);
 }
 
-// True when the deepest currently-working agent is a subagent while the main
-// agent is in 'waiting' — i.e. an incoming tool event is attributable to a
-// subagent, not to the main agent resuming. Mirrors the inline heuristic the
-// PreToolUse/PostToolUse cases already use for agent attribution.
+/**
+ * True when the deepest currently-working agent is a subagent while the main
+ * agent is in 'waiting' — i.e. an incoming tool event is attributable to a
+ * subagent, not to the main agent resuming. Mirrors the inline heuristic the
+ * PreToolUse/PostToolUse cases already use for agent attribution.
+ *
+ * @param {string} sessionId - Session to inspect.
+ * @param {object} mainAgent - The session's main agent row.
+ * @returns {boolean} True when a background subagent, not main, is the actor.
+ */
 function subagentIsActorNow(sessionId, mainAgent) {
   if (!mainAgent || mainAgent.status !== "waiting") return false;
   return !!stmts.findDeepestWorkingAgent.get(sessionId, sessionId);
@@ -1236,76 +1251,85 @@ router.post("/event", (req, res) => {
 });
 
 // ── Remote batch ingest ──────────────────────────────────────────────────
-// POST /api/hooks/ingest-batch — bulk ingestion for a future household/remote
-// forwarder that has been collecting hook-derived facts (token totals, tool
-// events, turn durations, subagent completions) about a session whose JSONL
-// transcript lives on another machine's disk. Mounted under /api/hooks (not a
-// new top-level prefix) so it inherits the same Traefik/DASHBOARD_TOKEN
-// exemption as /api/hooks/event (server/lib/security.js TOKEN_EXEMPT_PREFIXES
-// includes "/hooks") — a new prefix would 401 once an operator sets
-// DASHBOARD_TOKEN.
-//
-// Contract, enforced in order:
-//   1. transcript_path must be a non-empty string, and must NOT be readable
-//      on this host. If it IS readable, the local hook pipeline (the
-//      transcript-driven code above, and the regular SessionStart/Stop/etc.
-//      hook flow) already owns this session — accepting the batch too would
-//      double-write token_usage from two different scopes, which is exactly
-//      the 11x-baseline bug documented at db.js:1063-1082. Mirrors the
-//      SubagentStop remote synth gate (hooks.js "!fs.existsSync(...)").
-//   2. schema_version must match SCHEMA_VERSION (server/lib/
-//      transcript-line-classifier.js) — a mismatch is a breaking forwarder/
-//      server skew, not a per-item problem, so it 409s the whole batch.
-//   3. The session must already exist (created via a prior SessionStart hook
-//      forwarded through /event). This route never calls ensureSession —
-//      insertSession is not an upsert, so racing it here against a live
-//      SessionStart could create a duplicate/conflicting row.
-//   4. The session's main agent (`${sessionId}-main`) must exist too. A
-//      SessionStart-created session always has one (ensureSession inserts
-//      both rows together), but a session created via the bare
-//      POST /api/sessions route does not — that route only inserts the
-//      session. Resolving mainAgentId without verifying the row exists let
-//      tool_events/turns/subagents insertEvent() calls throw a FOREIGN KEY
-//      constraint failure INSIDE the transaction below, rolling back an
-//      otherwise-good batch with no structured error. 404s as
-//      UNKNOWN_MAIN_AGENT before anything is written.
-//   5. Items are validated BEFORE the transaction (per-item soft-fail):
-//      malformed entries are skipped and reported in `errors`, valid ones are
-//      written atomically in a single db.transaction (mirrors processEvent's
-//      shape above), so one bad item can never roll back the rest of an
-//      otherwise-good batch nor partially apply a batch that IS entirely
-//      good. Any OTHER exception out of that transaction (e.g. a
-//      caller-supplied tool_event.agent_id that doesn't exist) is caught
-//      around the runBatch() call and mapped to a structured JSON 500
-//      (INGEST_BATCH_FAILED) rather than falling through to Express'
-//      generic HTML error handler.
-//
-// Two further OPTIONAL top-level fields close the parity gap with the local
-// pipeline (verified against a live .213 session whose forwarder-derived copy
-// was missing both):
-//   - "model": string — applied via the same stmts.updateSessionModel used by
-//     the transcript-driven `latestModel` write above (last-write-wins, only
-//     changes the row — and broadcasts — when the value actually differs).
-//   - "usage_extras": { service_tiers[], speeds[], inference_geos[],
-//     thinking_blocks } — merged into sessions.metadata in EXACTLY the shape
-//     the local pipeline writes (see the `result.usageExtras`/
-//     `thinkingBlockCount` block above): `metadata.usage_extras` holds the
-//     three arrays, `metadata.thinking_blocks` sits as a sibling key. Unlike
-//     the local path's per-hook thinking_blocks ACCUMULATION (additive,
-//     because each hook only sees a transcript delta), this batch field is a
-//     whole-session-to-date total — consistent with `tokens` being whole-file
-//     totals elsewhere in this contract — so it is a straight replace: a
-//     re-posted batch is idempotent, and other metadata keys are preserved
-//     (merged into the existing parsed object, never clobbered wholesale).
 // Hard cap per array, per batch. A well-behaved forwarder posts once per
 // session lifecycle worth of accumulated facts (dozens to low hundreds of
 // tool events for a typical session) — an array in the thousands signals a
 // misbehaving/looping caller, not legitimate backlog, and every extra item
 // costs one more (now-indexed, but still real) dedup lookup inside the
 // transaction. Rejecting the whole batch (not silently truncating) matches
-// this route's existing "hard per-batch check" style above.
+// this route's existing "hard per-batch check" style below.
 const MAX_BATCH_ITEMS = 2000;
 
+/**
+ * POST /api/hooks/ingest-batch — bulk ingestion for a future household/remote
+ * forwarder that has been collecting hook-derived facts (token totals, tool
+ * events, turn durations, subagent completions) about a session whose JSONL
+ * transcript lives on another machine's disk. Mounted under /api/hooks (not a
+ * new top-level prefix) so it inherits the same Traefik/DASHBOARD_TOKEN
+ * exemption as /api/hooks/event (server/lib/security.js TOKEN_EXEMPT_PREFIXES
+ * includes "/hooks") — a new prefix would 401 once an operator sets
+ * DASHBOARD_TOKEN.
+ *
+ * Contract, enforced in order:
+ *   1. transcript_path must be a non-empty string, and must NOT be readable
+ *      on this host. If it IS readable, the local hook pipeline (the
+ *      transcript-driven code above, and the regular SessionStart/Stop/etc.
+ *      hook flow) already owns this session — accepting the batch too would
+ *      double-write token_usage from two different scopes, which is exactly
+ *      the 11x-baseline bug documented at db.js:1063-1082. Mirrors the
+ *      SubagentStop remote synth gate (hooks.js "!fs.existsSync(...)").
+ *   2. schema_version must match SCHEMA_VERSION (server/lib/
+ *      transcript-line-classifier.js) — a mismatch is a breaking forwarder/
+ *      server skew, not a per-item problem, so it 409s the whole batch.
+ *   3. The session must already exist (created via a prior SessionStart hook
+ *      forwarded through /event). This route never calls ensureSession —
+ *      insertSession is not an upsert, so racing it here against a live
+ *      SessionStart could create a duplicate/conflicting row.
+ *   4. The session's main agent (`${sessionId}-main`) must exist too. A
+ *      SessionStart-created session always has one (ensureSession inserts
+ *      both rows together), but a session created via the bare
+ *      POST /api/sessions route does not — that route only inserts the
+ *      session. Resolving mainAgentId without verifying the row exists let
+ *      tool_events/turns/subagents insertEvent() calls throw a FOREIGN KEY
+ *      constraint failure INSIDE the transaction below, rolling back an
+ *      otherwise-good batch with no structured error. 404s as
+ *      UNKNOWN_MAIN_AGENT before anything is written.
+ *   5. Items are validated BEFORE the transaction (per-item soft-fail):
+ *      malformed entries are skipped and reported in `errors`, valid ones are
+ *      written atomically in a single db.transaction (mirrors processEvent's
+ *      shape above), so one bad item can never roll back the rest of an
+ *      otherwise-good batch nor partially apply a batch that IS entirely
+ *      good. Any OTHER exception out of that transaction (e.g. a
+ *      caller-supplied tool_event.agent_id that doesn't exist) is caught
+ *      around the runBatch() call and mapped to a structured JSON 500
+ *      (INGEST_BATCH_FAILED) rather than falling through to Express'
+ *      generic HTML error handler.
+ *
+ * Two further OPTIONAL top-level fields close the parity gap with the local
+ * pipeline (verified against a live .213 session whose forwarder-derived copy
+ * was missing both):
+ *   - "model": string — applied via the same stmts.updateSessionModel used by
+ *     the transcript-driven `latestModel` write above (last-write-wins, only
+ *     changes the row — and broadcasts — when the value actually differs).
+ *   - "usage_extras": { service_tiers[], speeds[], inference_geos[],
+ *     thinking_blocks } — merged into sessions.metadata in EXACTLY the shape
+ *     the local pipeline writes (see the `result.usageExtras`/
+ *     `thinkingBlockCount` block above): `metadata.usage_extras` holds the
+ *     three arrays, `metadata.thinking_blocks` sits as a sibling key. Unlike
+ *     the local path's per-hook thinking_blocks ACCUMULATION (additive,
+ *     because each hook only sees a transcript delta), this batch field is a
+ *     whole-session-to-date total — consistent with `tokens` being whole-file
+ *     totals elsewhere in this contract — so it is a straight replace: a
+ *     re-posted batch is idempotent, and other metadata keys are preserved
+ *     (merged into the existing parsed object, never clobbered wholesale).
+ *
+ * @name POST/api/hooks/ingest-batch
+ * @param {import("express").Request} req - Body per the contract above.
+ * @param {import("express").Response} res - 200 `{written, errors}` on
+ *   success (partial per-item failures reported in `errors`, not thrown);
+ *   400/404/409/500 with `{error:{code,message}}` on the hard-fail cases.
+ * @returns {void}
+ */
 router.post("/ingest-batch", (req, res) => {
   const body = req.body || {};
   const sessionId = body.session_id;

--- a/server/routes/hooks.js
+++ b/server/routes/hooks.js
@@ -19,6 +19,10 @@ const { ingestWorkflowsForSession } = require("../lib/workflow-ingest");
 // Required as a module object (not destructured) so tests can swap
 // `liveness.probeLiveCwds` and the watchdog picks the stub up at call time.
 const liveness = require("../lib/session-liveness");
+// Schema-version constant for the POST /ingest-batch payload contract — shared
+// with server/lib/transcript-line-classifier.js so a bump there and the
+// version assert here can never drift apart.
+const { SCHEMA_VERSION } = require("../lib/transcript-line-classifier");
 
 const router = Router();
 
@@ -1154,6 +1158,262 @@ router.post("/event", (req, res) => {
         // non-fatal — partial workflow artifacts during a live run are expected
       });
   }
+});
+
+// ── Remote batch ingest ──────────────────────────────────────────────────
+// POST /api/hooks/ingest-batch — bulk ingestion for a future household/remote
+// forwarder that has been collecting hook-derived facts (token totals, tool
+// events, turn durations, subagent completions) about a session whose JSONL
+// transcript lives on another machine's disk. Mounted under /api/hooks (not a
+// new top-level prefix) so it inherits the same Traefik/DASHBOARD_TOKEN
+// exemption as /api/hooks/event (server/lib/security.js TOKEN_EXEMPT_PREFIXES
+// includes "/hooks") — a new prefix would 401 once an operator sets
+// DASHBOARD_TOKEN.
+//
+// Contract, enforced in order:
+//   1. transcript_path must be a non-empty string, and must NOT be readable
+//      on this host. If it IS readable, the local hook pipeline (the
+//      transcript-driven code above, and the regular SessionStart/Stop/etc.
+//      hook flow) already owns this session — accepting the batch too would
+//      double-write token_usage from two different scopes, which is exactly
+//      the 11x-baseline bug documented at db.js:1063-1082. Mirrors the
+//      SubagentStop remote synth gate (hooks.js "!fs.existsSync(...)").
+//   2. schema_version must match SCHEMA_VERSION (server/lib/
+//      transcript-line-classifier.js) — a mismatch is a breaking forwarder/
+//      server skew, not a per-item problem, so it 409s the whole batch.
+//   3. The session must already exist (created via a prior SessionStart hook
+//      forwarded through /event). This route never calls ensureSession —
+//      insertSession is not an upsert, so racing it here against a live
+//      SessionStart could create a duplicate/conflicting row.
+//   4. Items are validated BEFORE the transaction (per-item soft-fail):
+//      malformed entries are skipped and reported in `errors`, valid ones are
+//      written atomically in a single db.transaction (mirrors processEvent's
+//      shape above), so one bad item can never roll back the rest of an
+//      otherwise-good batch nor partially apply a batch that IS entirely
+//      good.
+router.post("/ingest-batch", (req, res) => {
+  const body = req.body || {};
+  const sessionId = body.session_id;
+  const transcriptPath = body.transcript_path;
+  const schemaVersion = body.schema_version;
+
+  if (typeof sessionId !== "string" || !sessionId) {
+    return res.status(400).json({
+      error: { code: "INVALID_INPUT", message: "session_id is required" },
+    });
+  }
+  if (typeof transcriptPath !== "string" || !transcriptPath) {
+    return res.status(400).json({
+      error: { code: "INVALID_INPUT", message: "transcript_path is required" },
+    });
+  }
+  if (schemaVersion !== SCHEMA_VERSION) {
+    return res.status(409).json({
+      error: {
+        code: "SCHEMA_VERSION_MISMATCH",
+        message: `expected schema_version "${SCHEMA_VERSION}", got ${JSON.stringify(schemaVersion)}`,
+      },
+    });
+  }
+  if (fs.existsSync(transcriptPath)) {
+    // Readable on this host → the local pipeline owns this session already.
+    return res.status(409).json({
+      error: {
+        code: "LOCAL_TRANSCRIPT_OWNS_SESSION",
+        message: "transcript_path is readable on this host; local hook pipeline owns this session",
+      },
+    });
+  }
+
+  const session = stmts.getSession.get(sessionId);
+  if (!session) {
+    return res.status(404).json({
+      error: {
+        code: "UNKNOWN_SESSION",
+        message: `session ${sessionId} not found — must be created via SessionStart first`,
+      },
+    });
+  }
+
+  // ── Validate items before the transaction (per-item soft-fail) ──────────
+  const errors = [];
+  const validTokens = [];
+  for (const [index, t] of (Array.isArray(body.tokens) ? body.tokens : []).entries()) {
+    if (!t || typeof t !== "object" || typeof t.model !== "string" || !t.model) {
+      errors.push({ kind: "tokens", index, error: "missing model" });
+      continue;
+    }
+    validTokens.push(t);
+  }
+
+  const validToolEvents = [];
+  for (const [index, e] of (Array.isArray(body.tool_events) ? body.tool_events : []).entries()) {
+    if (!e || typeof e !== "object" || typeof e.uuid !== "string" || !e.uuid) {
+      errors.push({ kind: "tool_events", index, error: "missing uuid" });
+      continue;
+    }
+    validToolEvents.push(e);
+  }
+
+  const validTurns = [];
+  for (const [index, t] of (Array.isArray(body.turns) ? body.turns : []).entries()) {
+    if (!t || typeof t !== "object" || typeof t.uuid !== "string" || !t.uuid) {
+      errors.push({ kind: "turns", index, error: "missing uuid" });
+      continue;
+    }
+    validTurns.push(t);
+  }
+
+  const validSubagents = [];
+  for (const [index, s] of (Array.isArray(body.subagents) ? body.subagents : []).entries()) {
+    if (!s || typeof s !== "object" || typeof s.agent_id !== "string" || !s.agent_id) {
+      errors.push({ kind: "subagents", index, error: "missing agent_id" });
+      continue;
+    }
+    validSubagents.push(s);
+  }
+
+  const mainAgent = getMainAgent(sessionId);
+  const mainAgentId = mainAgent ? mainAgent.id : `${sessionId}-main`;
+  let written = 0;
+
+  const runBatch = db.transaction(() => {
+    // Whole-file totals per bucket — replaceTokenUsage is already a
+    // high-water-mark replace (db.js:1063-1110), so re-posting the same
+    // totals is a no-op and posting larger totals updates in place. The
+    // gate above guarantees the local hook writer never touches the same
+    // (session, model, speed, geo, tier) bucket concurrently.
+    for (const t of validTokens) {
+      stmts.replaceTokenUsage.run(
+        sessionId,
+        t.model,
+        t.speed || "standard",
+        t.geo || "global",
+        t.tier || "standard",
+        t.input || 0,
+        t.output || 0,
+        t.cacheRead || 0,
+        t.cacheWrite || 0,
+        t.cacheWrite1h || 0,
+        t.webSearch || 0,
+        t.webFetch || 0,
+        t.codeExec || 0
+      );
+      written++;
+    }
+
+    // Dedup by uuid — same pattern as the APIError/TurnDuration dedup above,
+    // except keyed on the batch item's own uuid (stored in events.data)
+    // rather than a summary/timestamp match, since re-posted batches are
+    // expected (a forwarder re-sending its backlog) and carry a real id.
+    for (const e of validToolEvents) {
+      const exists = db
+        .prepare(
+          "SELECT 1 FROM events WHERE session_id = ? AND event_type = 'ToolEvent' AND json_extract(data, '$.uuid') = ? LIMIT 1"
+        )
+        .get(sessionId, e.uuid);
+      if (exists) continue;
+      const agentId = typeof e.agent_id === "string" && e.agent_id ? e.agent_id : mainAgentId;
+      const toolName = typeof e.tool_name === "string" ? e.tool_name : null;
+      const status = typeof e.status === "string" ? e.status : "completed";
+      stmts.insertEvent.run(
+        sessionId,
+        agentId,
+        "ToolEvent",
+        toolName,
+        `Tool ${status}: ${toolName || "unknown"}`,
+        JSON.stringify({ uuid: e.uuid, status, timestamp: e.timestamp || null })
+      );
+      broadcast("new_event", {
+        session_id: sessionId,
+        agent_id: agentId,
+        event_type: "ToolEvent",
+        tool_name: toolName,
+        summary: `Tool ${status}: ${toolName || "unknown"}`,
+        created_at: e.timestamp || new Date().toISOString(),
+      });
+      written++;
+    }
+
+    for (const t of validTurns) {
+      const exists = db
+        .prepare(
+          "SELECT 1 FROM events WHERE session_id = ? AND event_type = 'TurnDuration' AND json_extract(data, '$.uuid') = ? LIMIT 1"
+        )
+        .get(sessionId, t.uuid);
+      if (exists) continue;
+      const durationMs = t.duration_ms || 0;
+      const summary = `Turn completed in ${(durationMs / 1000).toFixed(1)}s`;
+      stmts.insertEvent.run(
+        sessionId,
+        mainAgentId,
+        "TurnDuration",
+        null,
+        summary,
+        JSON.stringify({ durationMs, uuid: t.uuid })
+      );
+      broadcast("new_event", {
+        session_id: sessionId,
+        agent_id: mainAgentId,
+        event_type: "TurnDuration",
+        tool_name: null,
+        summary,
+        created_at: t.timestamp || new Date().toISOString(),
+      });
+      written++;
+    }
+
+    // Idempotency key + field precedence mirror the SubagentStop remote synth
+    // above verbatim (description > agent_type > subagent_type >
+    // last_assistant_message > "Subagent" fallback label; agent_type >
+    // subagent_type for the stored subagent_type column).
+    for (const s of validSubagents) {
+      const subId = `${sessionId}-sub-${s.agent_id}`;
+      if (stmts.getAgent.get(subId)) {
+        // Already synthesized (redelivered batch item) — no dup, and not
+        // counted in `written` (same "already present → no-op" accounting
+        // as the tool_events/turns dedup above).
+        continue;
+      }
+
+      const rawLabel =
+        (typeof s.description === "string" && s.description) ||
+        (typeof s.agent_type === "string" && s.agent_type) ||
+        (typeof s.subagent_type === "string" && s.subagent_type) ||
+        (typeof s.last_assistant_message === "string" && s.last_assistant_message) ||
+        "Subagent";
+      const collapsed = rawLabel.replace(/\s+/g, " ").trim() || "Subagent";
+      const label = collapsed.length > 60 ? collapsed.slice(0, 57) + "..." : collapsed;
+      const subType =
+        (typeof s.agent_type === "string" && s.agent_type) ||
+        (typeof s.subagent_type === "string" && s.subagent_type) ||
+        null;
+
+      stmts.insertAgent.run(
+        subId,
+        sessionId,
+        label,
+        "subagent",
+        subType,
+        "completed",
+        typeof s.prompt === "string" ? s.prompt.slice(0, 500) : null,
+        mainAgentId,
+        null
+      );
+      // insertAgent only sets started_at — stamp ended_at too so a batch-
+      // synthesized subagent shows as completed with a real (if approximate)
+      // duration instead of an open-ended one.
+      stmts.updateAgent.run(null, null, null, null, new Date().toISOString(), null, subId);
+      broadcast("agent_created", stmts.getAgent.get(subId));
+      written++;
+    }
+
+    stmts.touchSession.run(sessionId);
+  });
+
+  runBatch();
+
+  res.json({ ok: true, written, failed: errors.length, errors });
 });
 
 // ── Watchdog: detect API errors in active sessions ─────────────────────────

--- a/server/routes/sessions.js
+++ b/server/routes/sessions.js
@@ -170,11 +170,15 @@ router.get("/", (req, res) => {
         const placeholders = ids.map(() => "?").join(",");
         const chunkTokens = db
           .prepare(
-            `SELECT session_id, model,
+            `SELECT session_id, model, speed, inference_geo, service_tier,
               input_tokens + baseline_input as input_tokens,
               output_tokens + baseline_output as output_tokens,
               cache_read_tokens + baseline_cache_read as cache_read_tokens,
-              cache_write_tokens + baseline_cache_write as cache_write_tokens
+              cache_write_tokens + baseline_cache_write as cache_write_tokens,
+              cache_write_1h_tokens + baseline_cache_write_1h as cache_write_1h_tokens,
+              web_search_requests + baseline_web_search as web_search_requests,
+              web_fetch_requests + baseline_web_fetch as web_fetch_requests,
+              code_execution_requests + baseline_code_execution as code_execution_requests
             FROM token_usage WHERE session_id IN (${placeholders})`
           )
           .all(...ids);
@@ -220,11 +224,15 @@ router.get("/", (req, res) => {
       const placeholders = ids.map(() => "?").join(",");
       const allTokens = db
         .prepare(
-          `SELECT session_id, model,
+          `SELECT session_id, model, speed, inference_geo, service_tier,
             input_tokens + baseline_input as input_tokens,
             output_tokens + baseline_output as output_tokens,
             cache_read_tokens + baseline_cache_read as cache_read_tokens,
-            cache_write_tokens + baseline_cache_write as cache_write_tokens
+            cache_write_tokens + baseline_cache_write as cache_write_tokens,
+            cache_write_1h_tokens + baseline_cache_write_1h as cache_write_1h_tokens,
+            web_search_requests + baseline_web_search as web_search_requests,
+            web_fetch_requests + baseline_web_fetch as web_fetch_requests,
+            code_execution_requests + baseline_code_execution as code_execution_requests
           FROM token_usage WHERE session_id IN (${placeholders})`
         )
         .all(...ids);


### PR DESCRIPTION
## Summary

This bundles a set of fixes and a feature developed while running Claude Code Agent Monitor across multiple machines (a always-on server plus a workstation), where hook events for a session don't always arrive through the same local process.

- **`POST /api/hooks/ingest-batch`**: a batch ingestion endpoint so a remote/forwarding process can submit hook events for a session without a local transcript file being present on the dashboard host. Includes model + `usage_extras` parity with the existing single-event ingest path, and a guard against ingesting into a session with no main-agent row yet.
- **`reconstruct remote/household session data without a local transcript`**: lets the dashboard build a usable session record purely from forwarded hook events when the originating machine's transcript isn't locally readable.
- **Notification-status fix**: an idle-timeout notification was being surfaced as an actionable "waiting on you" state; it's idle, not a wait the user needs to act on.
- **Subagent notification-guard fix**: a background subagent completing was incorrectly clearing the main agent's own pending "notification" wait state.
- **Pricing fix**: session-list cost display wasn't correctly pricing 1h cache-write, fast-mode, geo, and service-tier token buckets — brought in line with the cost-calculation endpoint's existing logic.
- **Refactor**: extracted line-classification predicates out of `transcript-cache.js` for readability/testability, no behavior change.

All changes are covered by new/updated tests (`server/__tests__/`). No breaking changes to existing single-machine usage — the batch route and remote-reconstruction path are additive and only engage when a caller uses them.

## Test plan

- [x] `node --test server/__tests__/*.test.js` passes locally
- [x] Existing single-event hook ingestion path unaffected (separate route, untouched)
