### PR TITLE
fix(update-check): don't let an inherited GIT_DIR redirect git at another repo

### DIFF
--- a/server/__tests__/update-check.test.js
+++ b/server/__tests__/update-check.test.js
@@ -12,11 +12,26 @@ const os = require("os");
 const path = require("path");
 const { execFileSync } = require("child_process");
 
-const { getUpdatesStatus } = require("../lib/update-check");
+const { getUpdatesStatus, GIT_LOCATION_VARS } = require("../lib/update-check");
+
+// Every `git` in this file must act on the throwaway repo named by `cwd` and
+// nothing else. That is not automatic: when the suite runs from a git hook
+// (.husky/pre-commit runs `npm run test:server`), git exports GIT_DIR,
+// GIT_INDEX_FILE, GIT_AUTHOR_* and friends into the hook's environment, and an
+// inherited GIT_DIR OVERRIDES `cwd` — so `git add .` here would stage against
+// the real repository, with the fixture directory as the work tree. That
+// rewrites the developer's actual branch (observed: a commit deleting every
+// tracked file, leaving only this fixture's README.md). Removing those variables
+// makes `cwd` authoritative again. The module's own list is reused so the
+// fixtures are isolated by exactly the rule the production code applies.
+const CLEAN_ENV = Object.fromEntries(
+  Object.entries(process.env).filter(([key]) => !GIT_LOCATION_VARS.includes(key))
+);
 
 function git(cwd, args) {
   return execFileSync("git", args, {
     cwd,
+    env: CLEAN_ENV,
     stdio: ["ignore", "pipe", "pipe"],
     encoding: "utf8",
   }).trim();
@@ -28,6 +43,7 @@ function makeBareRemote(parent, name) {
   // -c init.defaultBranch=master works on every git that supports -c init.*,
   // i.e. far older than --initial-branch.
   execFileSync("git", ["-c", "init.defaultBranch=master", "init", "--bare", repo], {
+    env: CLEAN_ENV,
     stdio: "ignore",
   });
   return repo;
@@ -36,7 +52,10 @@ function makeBareRemote(parent, name) {
 function makeWorkingRepo(parent, dir, originUrl) {
   const repo = path.join(parent, dir);
   fs.mkdirSync(repo, { recursive: true });
-  execFileSync("git", ["-c", "init.defaultBranch=master", "init", repo], { stdio: "ignore" });
+  execFileSync("git", ["-c", "init.defaultBranch=master", "init", repo], {
+    env: CLEAN_ENV,
+    stdio: "ignore",
+  });
   fs.writeFileSync(path.join(repo, "README.md"), "fixture\n");
   git(repo, ["-c", "user.email=t@t", "-c", "user.name=t", "add", "."]);
   git(repo, ["-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", "init"]);
@@ -153,7 +172,10 @@ describe("getUpdatesStatus — no remotes configured", () => {
   it("returns a soft no-remotes payload", async () => {
     const repo = path.join(tmpDir, "noremote");
     fs.mkdirSync(repo, { recursive: true });
-    execFileSync("git", ["-c", "init.defaultBranch=master", "init", repo], { stdio: "ignore" });
+    execFileSync("git", ["-c", "init.defaultBranch=master", "init", repo], {
+      env: CLEAN_ENV,
+      stdio: "ignore",
+    });
     fs.writeFileSync(path.join(repo, "README.md"), "lonely\n");
     git(repo, ["-c", "user.email=t@t", "-c", "user.name=t", "add", "."]);
     git(repo, ["-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", "init"]);

--- a/server/lib/update-check.js
+++ b/server/lib/update-check.js
@@ -17,13 +17,53 @@ const DEFAULT_ROOT = path.join(__dirname, "..", "..");
 // repo, "origin" points at the user's fork. Prefer upstream when both exist.
 const REMOTE_PRIORITY = ["upstream", "origin"];
 
+// The repository under inspection is the one named by `cwd` — always. An
+// inherited GIT_DIR / GIT_WORK_TREE / GIT_INDEX_FILE silently OVERRIDES `cwd`
+// and points every command at a different repository. That is not exotic: git
+// exports these to hooks, so anything started from inside a hook inherits them.
+//
+// Only the variables that redirect which repository (or whose identity) git
+// acts on are removed. The rest of the GIT_* namespace is deliberately kept —
+// this module runs `git fetch` over the network, and dropping GIT_SSH_COMMAND,
+// GIT_ASKPASS, GIT_PROXY_COMMAND or GIT_CONFIG_GLOBAL would break users whose
+// remote access depends on them.
+const GIT_LOCATION_VARS = [
+  "GIT_DIR",
+  "GIT_WORK_TREE",
+  "GIT_INDEX_FILE",
+  "GIT_OBJECT_DIRECTORY",
+  "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+  "GIT_COMMON_DIR",
+  "GIT_NAMESPACE",
+  "GIT_PREFIX",
+  "GIT_CEILING_DIRECTORIES",
+  "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+  "GIT_AUTHOR_NAME",
+  "GIT_AUTHOR_EMAIL",
+  "GIT_AUTHOR_DATE",
+  "GIT_COMMITTER_NAME",
+  "GIT_COMMITTER_EMAIL",
+  "GIT_COMMITTER_DATE",
+];
+
+const GIT_SAFE_ENV = Object.fromEntries(
+  Object.entries(process.env).filter(([key]) => !GIT_LOCATION_VARS.includes(key))
+);
+
 function execGit(cwd, args, opts = {}) {
   const timeout = opts.timeout ?? 120_000;
   return new Promise((resolve, reject) => {
     execFile(
       "git",
       args,
-      { cwd, timeout, maxBuffer: 2_000_000, encoding: "utf8", windowsHide: true },
+      {
+        cwd,
+        env: GIT_SAFE_ENV,
+        timeout,
+        maxBuffer: 2_000_000,
+        encoding: "utf8",
+        windowsHide: true,
+      },
       (err, stdout) => {
         if (err) reject(err);
         else resolve(String(stdout).trim());
@@ -251,4 +291,4 @@ async function getUpdatesStatus(gitRoot = DEFAULT_ROOT, options = {}) {
   };
 }
 
-module.exports = { getUpdatesStatus, DEFAULT_ROOT };
+module.exports = { getUpdatesStatus, DEFAULT_ROOT, GIT_LOCATION_VARS };


### PR DESCRIPTION
## The bug

`getUpdatesStatus(cwd)` is contracted to inspect the repository named by `cwd`. It isn't. `execGit` passes the ambient environment straight through, and git's location variables (`GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE`) **override `cwd`**.

That matters here specifically, because git exports those — plus `GIT_AUTHOR_*` — to hooks. This repo's own `.husky/pre-commit` runs `npm run test:server`. So every commit attempt runs the test suite with those variables set.

## Why it's destructive, not just wrong

`update-check.test.js` builds throw-away repos and commits into them. With `GIT_DIR` inherited, `git add .` uses the temp directory as the working directory but writes **the real repository's index** — which then contains only the fixture's `README.md`. The commit records every other tracked file as deleted.

We hit this for real. Four commits messaged `init` appeared on a working branch; one deleted **1,046 files / 280,563 lines**.

Two things identify it if you ever see it:

- **author and committer disagree** — committer `t <t@t>` from the test's `-c user.name=t`, author from the hook's inherited `GIT_AUTHOR_*`
- the surviving `README.md` contains `fixture` or `lonely` — the two fixture strings in this file

## The fix

Strip the offending variables from the environment `execGit` passes, so `cwd` is authoritative. Same list in the test helpers, imported rather than duplicated, so the rule can't rot in one copy.

**Only variables that redirect which repository, or whose identity, git acts on are removed.** The rest of `GIT_*` is deliberately kept — this module runs `git fetch` over the network (`update-check.js:154`), so dropping `GIT_SSH_COMMAND`, `GIT_ASKPASS`, `GIT_PROXY_COMMAND` or `GIT_CONFIG_GLOBAL` would break users whose remote access depends on them. An earlier draft of this patch stripped the whole `GIT_*` namespace and had exactly that bug.

## Verification

Using a decoy repository, with `GIT_DIR` / `GIT_WORK_TREE` / `GIT_INDEX_FILE` / `GIT_AUTHOR_*` pointed at the decoy:

| | before | after |
|---|---|---|
| `update-check.test.js` | 0/5 pass | **5/5 pass** |
| decoy HEAD | rewritten | **unchanged** |
| decoy file count | changed | **unchanged** |

`GIT_SSH_COMMAND` and `GIT_CONFIG_GLOBAL` confirmed to survive the filter; `GIT_DIR` and `GIT_AUTHOR_NAME` confirmed removed. Full server suite: **1065/1065**.

## Reproducing

```sh
mkdir /tmp/decoy && cd /tmp/decoy && git init -q . && echo x > f && \
  git -c user.email=c@c -c user.name=c add . && git -c user.email=c@c -c user.name=c commit -qm base
cd /path/to/Claude-Code-Agent-Monitor
GIT_DIR=/tmp/decoy/.git GIT_INDEX_FILE=/tmp/decoy/.git/index GIT_AUTHOR_NAME=x \
  node --test server/__tests__/update-check.test.js
git --git-dir=/tmp/decoy/.git log --oneline   # before the fix: a stray "init" commit
```

Found while implementing a downstream ingest feature — the failure fires on any commit attempt, since the pre-commit hook runs the tests.