### PR TITLE
fix(pricing): add missing claude-opus-5 model_pricing row

### DIFF
--- a/server/__tests__/model-pricing-seed.test.js
+++ b/server/__tests__/model-pricing-seed.test.js
@@ -1,0 +1,59 @@
+/**
+ * @file Regression test for the model_pricing seed data. `claude-opus-5` had
+ * no pricing rule at all (every opus-5 session priced at $0, "unpriced" in
+ * the API response) — this pins the row so it can't silently disappear again.
+ * Rates verified against Anthropic's own published pricing before writing
+ * this test, not derived from the code under test.
+ * @author Son Nguyen <hoangson091104@gmail.com>
+ */
+
+const { describe, it, before, after } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+
+const STAMP = `model-pricing-seed-${Date.now()}-${process.pid}`;
+const TMP = path.join(os.tmpdir(), STAMP);
+process.env.DASHBOARD_DB_PATH = path.join(TMP, "dashboard.db");
+process.env.CLAUDE_HOME = path.join(TMP, "home");
+process.env.DASHBOARD_DATA_DIR = path.join(TMP, "data");
+fs.mkdirSync(TMP, { recursive: true });
+
+const { db } = require("../db");
+
+after(() => {
+  if (db) db.close();
+  try {
+    fs.rmSync(TMP, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+describe("model_pricing seed — claude-opus-5", () => {
+  it("is present on a fresh DB with Anthropic's published rates", () => {
+    const row = db
+      .prepare("SELECT * FROM model_pricing WHERE model_pattern = 'claude-opus-5%'")
+      .get();
+    assert.ok(
+      row,
+      "claude-opus-5% must have a pricing rule — its absence priced every opus-5 session at $0"
+    );
+    assert.equal(row.input_per_mtok, 5);
+    assert.equal(row.output_per_mtok, 25);
+    assert.equal(row.cache_read_per_mtok, 0.5);
+    assert.equal(row.cache_write_per_mtok, 6.25);
+    assert.equal(row.cache_write_1h_per_mtok, 10);
+    assert.equal(row.fast_input_per_mtok, 10);
+    assert.equal(row.fast_output_per_mtok, 50);
+  });
+
+  it("the '%' wildcard matches both 'claude-opus-5' and the observed 'claude-opus-5[1m]' model string — same price, not a separate tier", () => {
+    const like = db
+      .prepare("SELECT model_pattern FROM model_pricing WHERE ? LIKE model_pattern")
+      .get("claude-opus-5[1m]");
+    assert.ok(like, "claude-opus-5[1m] must resolve to a pricing rule via LIKE-matching");
+    assert.equal(like.model_pattern, "claude-opus-5%");
+  });
+});

--- a/server/__tests__/model-pricing-seed.test.js
+++ b/server/__tests__/model-pricing-seed.test.js
@@ -23,7 +23,7 @@ process.env.CLAUDE_HOME = path.join(TMP, "home");
 process.env.DASHBOARD_DATA_DIR = path.join(TMP, "data");
 fs.mkdirSync(TMP, { recursive: true });
 
-const { db, correctSonnet5StandardRate } = require("../db");
+const { db, stmts, correctSonnet5StandardRate } = require("../db");
 const { calculateCost } = require("../routes/pricing");
 
 after(() => {
@@ -110,6 +110,38 @@ describe("model_pricing seed — models that had no rule or a stale rate", () =>
       assert.ok(rule, `${model} must resolve to a pricing rule`);
       assert.equal(rule.model_pattern, expected, `${model} must use its own rule`);
       assert.equal(rule.cache_read_per_mtok, cacheRead, `${model} cache read`);
+    }
+  });
+
+  it("stmts.matchPricing orders by specificity, so its LIMIT 1 is deterministic", () => {
+    // `LIMIT 1` without `ORDER BY` makes the chosen row UNDEFINED when several
+    // patterns match — and 5.1 matches both `claude-fable-5-1%` and
+    // `claude-fable-5%`, which differ on cache reads ($0.25 vs $1). SQLite
+    // currently happens to return the specific row, so a runtime-only
+    // assertion would pass with or without the fix and guard nothing. The
+    // defect is the missing ordering itself, so that is what is asserted.
+    assert.match(
+      stmts.matchPricing.source.replace(/\s+/g, " "),
+      /ORDER BY LENGTH\(model_pattern\) DESC\s+LIMIT 1/,
+      "matchPricing must order by pattern length so the most specific rule wins"
+    );
+  });
+
+  it("stmts.matchPricing resolves the most specific overlapping pattern", () => {
+    // Companion to the ordering assertion above: this pins the outcome callers
+    // depend on. It documents intent and catches a flipped sort direction.
+    for (const [model, expected, cacheRead] of [
+      ["claude-fable-5-1", "claude-fable-5-1%", 0.25],
+      ["claude-mythos-5-1", "claude-mythos-5-1%", 0.25],
+      ["claude-fable-5", "claude-fable-5%", 1],
+      ["claude-mythos-5", "claude-mythos-5%", 1],
+      ["claude-opus-5", "claude-opus-5%", 0.5],
+      ["claude-opus-5[1m]", "claude-opus-5%", 0.5],
+    ]) {
+      const row = stmts.matchPricing.get(model);
+      assert.ok(row, `${model} must match a pricing rule`);
+      assert.equal(row.model_pattern, expected, `${model} must use its own rule`);
+      assert.equal(row.cache_read_per_mtok, cacheRead, `${model} cache read`);
     }
   });
 

--- a/server/__tests__/model-pricing-seed.test.js
+++ b/server/__tests__/model-pricing-seed.test.js
@@ -1,9 +1,12 @@
 /**
- * @file Regression test for the model_pricing seed data. `claude-opus-5` had
- * no pricing rule at all (every opus-5 session priced at $0, "unpriced" in
- * the API response) — this pins the row so it can't silently disappear again.
- * Rates verified against Anthropic's own published pricing before writing
- * this test, not derived from the code under test.
+ * @file Regression tests for the model_pricing seed data and the Sonnet 5 rate
+ * correction. `claude-opus-5`, `claude-fable-5-1` and `claude-mythos-5-1` had no
+ * pricing rule at all (every such session priced at $0 and listed under
+ * "unpriced" in the API response), and Sonnet 5 fell back to a stale $3/$15
+ * standard once its launch promo lapsed. These pin the rows, the specificity
+ * rule the 5.1 patterns depend on, and the in-place correction that reaches
+ * databases created before the fix. Rates are transcribed from Anthropic's
+ * published rate card, not derived from the code under test.
  * @author Son Nguyen <hoangson091104@gmail.com>
  */
 
@@ -20,7 +23,8 @@ process.env.CLAUDE_HOME = path.join(TMP, "home");
 process.env.DASHBOARD_DATA_DIR = path.join(TMP, "data");
 fs.mkdirSync(TMP, { recursive: true });
 
-const { db } = require("../db");
+const { db, correctSonnet5StandardRate } = require("../db");
+const { calculateCost } = require("../routes/pricing");
 
 after(() => {
   if (db) db.close();
@@ -50,10 +54,174 @@ describe("model_pricing seed — claude-opus-5", () => {
   });
 
   it("the '%' wildcard matches both 'claude-opus-5' and the observed 'claude-opus-5[1m]' model string — same price, not a separate tier", () => {
-    const like = db
-      .prepare("SELECT model_pattern FROM model_pricing WHERE ? LIKE model_pattern")
-      .get("claude-opus-5[1m]");
-    assert.ok(like, "claude-opus-5[1m] must resolve to a pricing rule via LIKE-matching");
-    assert.equal(like.model_pattern, "claude-opus-5%");
+    // Both spellings, not just the [1m] one: a regression in bare
+    // claude-opus-5 resolution would otherwise slip through.
+    for (const model of ["claude-opus-5", "claude-opus-5[1m]"]) {
+      const like = db
+        .prepare("SELECT model_pattern FROM model_pricing WHERE ? LIKE model_pattern")
+        .get(model);
+      assert.ok(like, `${model} must resolve to a pricing rule via LIKE-matching`);
+      assert.equal(like.model_pattern, "claude-opus-5%", `${model} must use the opus-5 rule`);
+    }
+  });
+});
+
+describe("model_pricing seed — models that had no rule or a stale rate", () => {
+  // [pattern, input, output, cacheRead, cacheWrite5m, cacheWrite1h]
+  const EXPECTED = [
+    ["claude-fable-5-1%", 10, 50, 0.25, 12.5, 20],
+    ["claude-mythos-5-1%", 10, 50, 0.25, 12.5, 20],
+    ["claude-fable-5%", 10, 50, 1, 12.5, 20],
+    ["claude-mythos-5%", 10, 50, 1, 12.5, 20],
+    ["claude-opus-5%", 5, 25, 0.5, 6.25, 10],
+    ["claude-opus-4-5%", 5, 25, 0.5, 6.25, 10],
+    ["claude-sonnet-5%", 2, 10, 0.2, 2.5, 4],
+  ];
+
+  for (const [pattern, input, output, cacheRead, cacheWrite, cacheWrite1h] of EXPECTED) {
+    it(`seeds ${pattern} at the published rate card`, () => {
+      const row = db.prepare("SELECT * FROM model_pricing WHERE model_pattern = ?").get(pattern);
+      assert.ok(row, `${pattern} must have a pricing rule — without one it prices at $0`);
+      assert.equal(row.input_per_mtok, input, `${pattern} input`);
+      assert.equal(row.output_per_mtok, output, `${pattern} output`);
+      assert.equal(row.cache_read_per_mtok, cacheRead, `${pattern} cache read`);
+      assert.equal(row.cache_write_per_mtok, cacheWrite, `${pattern} 5m cache write`);
+      assert.equal(row.cache_write_1h_per_mtok, cacheWrite1h, `${pattern} 1h cache write`);
+    });
+  }
+
+  it("prices Fable/Mythos 5.1 by their own rule, not the 5 rule they also LIKE-match", () => {
+    // "claude-fable-5-1" matches BOTH claude-fable-5% and claude-fable-5-1%.
+    // calculateCost sorts by pattern length descending so the specific rule
+    // wins; without that, 5.1 would silently bill cache reads at $1 (the 5
+    // rate) instead of $0.25 — a 4x over-report on cached input.
+    const rules = db.prepare("SELECT * FROM model_pricing").all();
+    const sorted = [...rules].sort((a, b) => b.model_pattern.length - a.model_pattern.length);
+    const ruleFor = (model) =>
+      sorted.find((p) => new RegExp("^" + p.model_pattern.replace(/%/g, ".*") + "$").test(model));
+
+    for (const [model, expected, cacheRead] of [
+      ["claude-fable-5-1", "claude-fable-5-1%", 0.25],
+      ["claude-mythos-5-1", "claude-mythos-5-1%", 0.25],
+      ["claude-fable-5", "claude-fable-5%", 1],
+      ["claude-mythos-5", "claude-mythos-5%", 1],
+    ]) {
+      const rule = ruleFor(model);
+      assert.ok(rule, `${model} must resolve to a pricing rule`);
+      assert.equal(rule.model_pattern, expected, `${model} must use its own rule`);
+      assert.equal(rule.cache_read_per_mtok, cacheRead, `${model} cache read`);
+    }
+  });
+
+  it("leaves no current Claude model unpriced", () => {
+    const rules = db.prepare("SELECT * FROM model_pricing").all();
+    const sorted = [...rules].sort((a, b) => b.model_pattern.length - a.model_pattern.length);
+    const unpriced = [
+      "claude-fable-5-1",
+      "claude-mythos-5-1",
+      "claude-fable-5",
+      "claude-mythos-5",
+      "claude-opus-5",
+      "claude-opus-4-8",
+      "claude-opus-4-7",
+      "claude-opus-4-6",
+      "claude-opus-4-5",
+      "claude-sonnet-5",
+      "claude-haiku-4-5",
+    ].filter(
+      (model) =>
+        !sorted.some((p) => new RegExp("^" + p.model_pattern.replace(/%/g, ".*") + "$").test(model))
+    );
+    assert.deepEqual(unpriced, [], "every current model must match a pricing rule");
+  });
+});
+
+describe("historical usage reprices from the corrected rules", () => {
+  // Cost is computed from token_usage on every request and never stored, so
+  // fixing a rule retroactively fixes every past session. This asserts the
+  // arithmetic end to end for the three models the fix touches.
+  const MTOK = 1_000_000;
+  const bucket = (model) => ({
+    model,
+    speed: "standard",
+    inference_geo: "global",
+    service_tier: "standard",
+    context_size: "short",
+    input_tokens: MTOK,
+    output_tokens: MTOK,
+    cache_read_tokens: MTOK,
+    cache_write_tokens: 0,
+    cache_write_1h_tokens: 0,
+  });
+
+  it("prices 1M in / 1M out / 1M cache-read at the published rate for each model", () => {
+    const rules = db.prepare("SELECT * FROM model_pricing").all();
+    const rows = ["claude-opus-5", "claude-fable-5-1", "claude-sonnet-5"].map(bucket);
+    const result = calculateCost(rows, rules, null);
+
+    assert.deepEqual(result.unpriced_models ?? [], [], "no model may be unpriced");
+    const costOf = (model) => result.breakdown.find((b) => b.model === model).cost;
+
+    // opus-5:   5 + 25 + 0.50 = 30.50   (was $0 — no rule at all)
+    assert.equal(costOf("claude-opus-5"), 30.5);
+    // fable-5.1: 10 + 50 + 0.25 = 60.25 (was 61.00 at the Fable 5 cache rate)
+    assert.equal(costOf("claude-fable-5-1"), 60.25);
+    // sonnet-5:  2 + 10 + 0.20 = 12.20  (was 18.30 at the stale $3/$15)
+    assert.equal(costOf("claude-sonnet-5"), 12.2);
+  });
+});
+
+describe("Sonnet 5 rate correction on pre-existing databases", () => {
+  const setSonnet5 = (values) =>
+    db
+      .prepare(
+        `UPDATE model_pricing SET input_per_mtok = ?, output_per_mtok = ?,
+           cache_read_per_mtok = ?, cache_write_per_mtok = ?, cache_write_1h_per_mtok = ?
+         WHERE model_pattern = 'claude-sonnet-5%'`
+      )
+      .run(...values);
+  const readSonnet5 = () =>
+    db.prepare("SELECT * FROM model_pricing WHERE model_pattern = 'claude-sonnet-5%'").get();
+
+  it("rewrites a row still holding the stale $3/$15 standard", () => {
+    // The startup top-up is INSERT OR IGNORE — it never touches an existing
+    // row — so without this correction an upgraded install keeps over-reporting
+    // Sonnet 5 by 50% until someone hits "Reset Defaults".
+    setSonnet5([3, 15, 0.3, 3.75, 6]);
+
+    correctSonnet5StandardRate(db);
+
+    const row = readSonnet5();
+    assert.equal(row.input_per_mtok, 2);
+    assert.equal(row.output_per_mtok, 10);
+    assert.equal(row.cache_read_per_mtok, 0.2);
+    assert.equal(row.cache_write_per_mtok, 2.5);
+    assert.equal(row.cache_write_1h_per_mtok, 4);
+  });
+
+  it("never overwrites rates the user edited themselves", () => {
+    const custom = [7, 21, 0.7, 8.75, 14];
+    setSonnet5(custom);
+
+    correctSonnet5StandardRate(db);
+
+    const row = readSonnet5();
+    assert.deepEqual(
+      [
+        row.input_per_mtok,
+        row.output_per_mtok,
+        row.cache_read_per_mtok,
+        row.cache_write_per_mtok,
+        row.cache_write_1h_per_mtok,
+      ],
+      custom,
+      "a user-customized Sonnet 5 rate must survive the correction untouched"
+    );
+  });
+
+  it("is idempotent — re-running changes nothing", () => {
+    setSonnet5([3, 15, 0.3, 3.75, 6]);
+    assert.equal(correctSonnet5StandardRate(db).changes, 1, "first run corrects the row");
+    assert.equal(correctSonnet5StandardRate(db).changes, 0, "second run is a no-op");
   });
 });

--- a/server/db.js
+++ b/server/db.js
@@ -563,7 +563,20 @@ const DEFAULT_PRICING = [
   // Next-gen flagship
   ["claude-fable-5%", "Claude Fable 5", 10, 50, 1, 12.5, 20, 0, 0],
   ["claude-mythos-5%", "Claude Mythos 5", 10, 50, 1, 12.5, 20, 0, 0],
-  // Opus family (fast mode available on 4.6 / 4.7 / 4.8)
+  // Opus family (fast mode available on 4.6 / 4.7 / 4.8, and now 5)
+  // claude-opus-5: verified via the claude-api skill (Anthropic's own pricing
+  // reference, not guessed) — $5/$25 input/output, fast mode $10/$50 (same
+  // fast-mode price as 4.8, confirmed explicitly in that reference). Cache
+  // read/write use Anthropic's standard multipliers (0.1x/1.25x/2x of input),
+  // documented in that same skill's caching section, and cross-checked
+  // against every other row here sharing this $5 input rate (4.8/4.7/4.6) —
+  // all three already derive their cache columns the identical way.
+  // `%` covers both "claude-opus-5" and "claude-opus-5[1m]" (observed model
+  // string with the 1M-context flag) under one rule — same convention already
+  // used for every other model here, not a new pricing tier (decisions/0034
+  // in the ai-deck repo measured this: opus-5 and opus-5[1m] are the same
+  // price, only the wildcard needs to catch both spellings).
+  ["claude-opus-5%", "Claude Opus 5", 5, 25, 0.5, 6.25, 10, 10, 50],
   ["claude-opus-4-8%", "Claude Opus 4.8", 5, 25, 0.5, 6.25, 10, 10, 50],
   ["claude-opus-4-7%", "Claude Opus 4.7", 5, 25, 0.5, 6.25, 10, 30, 150],
   ["claude-opus-4-6%", "Claude Opus 4.6", 5, 25, 0.5, 6.25, 10, 30, 150],

--- a/server/db.js
+++ b/server/db.js
@@ -1845,8 +1845,16 @@ const stmts = {
     WHERE model_pattern = ?
   `),
   deletePricing: db.prepare("DELETE FROM model_pricing WHERE model_pattern = ?"),
+  // ORDER BY length DESC picks the MOST SPECIFIC matching pattern, mirroring
+  // calculateCost() in routes/pricing.js. Patterns overlap by design —
+  // "claude-fable-5-1" matches both `claude-fable-5-1%` and `claude-fable-5%`,
+  // and the two differ on cache reads ($0.25 vs $1) — so a bare LIMIT 1 with no
+  // ordering could return either row and silently bill 5.1 at the 5 rate.
   matchPricing: db.prepare(
-    "SELECT * FROM model_pricing WHERE ? LIKE REPLACE(model_pattern, '%', '%') LIMIT 1"
+    `SELECT * FROM model_pricing
+      WHERE ? LIKE REPLACE(model_pattern, '%', '%')
+      ORDER BY LENGTH(model_pattern) DESC
+      LIMIT 1`
   ),
   // GPT / Codex pricing
   listGptPricing: db.prepare("SELECT * FROM gpt_model_pricing ORDER BY display_name ASC"),

--- a/server/db.js
+++ b/server/db.js
@@ -560,22 +560,24 @@ try {
 // Each model gets its own explicit row — no catch-all grouping.
 // Rate shape mirrors Anthropic's published table: 5m write = 1.25× input, 1h write = 2× input.
 const DEFAULT_PRICING = [
-  // Next-gen flagship
+  // Next-gen flagship.
+  // The 5.1 rows need their own patterns: `claude-fable-5%` also LIKE-matches
+  // "claude-fable-5-1", and 5.1 differs from 5 on cache reads ($0.25 vs $1).
+  // calculateCost() in routes/pricing.js sorts rules by pattern length
+  // descending, so the more specific 5-1 rule wins for 5.1 while plain
+  // "claude-fable-5" still lands on the 5 rule.
+  ["claude-fable-5-1%", "Claude Fable 5.1", 10, 50, 0.25, 12.5, 20, 0, 0],
+  ["claude-mythos-5-1%", "Claude Mythos 5.1", 10, 50, 0.25, 12.5, 20, 0, 0],
   ["claude-fable-5%", "Claude Fable 5", 10, 50, 1, 12.5, 20, 0, 0],
   ["claude-mythos-5%", "Claude Mythos 5", 10, 50, 1, 12.5, 20, 0, 0],
   // Opus family (fast mode available on 4.6 / 4.7 / 4.8, and now 5)
-  // claude-opus-5: verified via the claude-api skill (Anthropic's own pricing
-  // reference, not guessed) — $5/$25 input/output, fast mode $10/$50 (same
-  // fast-mode price as 4.8, confirmed explicitly in that reference). Cache
-  // read/write use Anthropic's standard multipliers (0.1x/1.25x/2x of input),
-  // documented in that same skill's caching section, and cross-checked
-  // against every other row here sharing this $5 input rate (4.8/4.7/4.6) —
-  // all three already derive their cache columns the identical way.
+  // claude-opus-5: $5/$25 input/output, $0.50 cache read, $6.25 5m cache write,
+  // $10 1h cache write — matching Anthropic's published rate card and identical
+  // to the 4.8/4.7/4.6/4.5 rows that share the same $5 input tier. Fast mode is
+  // $10/$50 (fast mode is Opus 5 / Opus 4.8 only).
   // `%` covers both "claude-opus-5" and "claude-opus-5[1m]" (observed model
-  // string with the 1M-context flag) under one rule — same convention already
-  // used for every other model here, not a new pricing tier (decisions/0034
-  // in the ai-deck repo measured this: opus-5 and opus-5[1m] are the same
-  // price, only the wildcard needs to catch both spellings).
+  // string with the 1M-context flag) under one rule — the same convention every
+  // other model here uses, not a separate pricing tier.
   ["claude-opus-5%", "Claude Opus 5", 5, 25, 0.5, 6.25, 10, 10, 50],
   ["claude-opus-4-8%", "Claude Opus 4.8", 5, 25, 0.5, 6.25, 10, 10, 50],
   ["claude-opus-4-7%", "Claude Opus 4.7", 5, 25, 0.5, 6.25, 10, 30, 150],
@@ -584,7 +586,12 @@ const DEFAULT_PRICING = [
   ["claude-opus-4-1%", "Claude Opus 4.1", 15, 75, 1.5, 18.75, 30, 0, 0],
   ["claude-opus-4-2%", "Claude Opus 4", 15, 75, 1.5, 18.75, 30, 0, 0],
   // Sonnet family
-  ["claude-sonnet-5%", "Claude Sonnet 5", 3, 15, 0.3, 3.75, 6, 0, 0],
+  // Sonnet 5 is $2/$10 on the current rate card. The 2/3-off launch promo
+  // (DEFAULT_INTRO_PRICING below) ran through 2026-08-31 at these same
+  // numbers; once it lapsed, usage fell back to the old $3/$15 standard and
+  // over-reported by 50%. The promo row is now a no-op and is kept only so
+  // existing DBs that already stamped intro_until keep their history.
+  ["claude-sonnet-5%", "Claude Sonnet 5", 2, 10, 0.2, 2.5, 4, 0, 0],
   ["claude-sonnet-4-6%", "Claude Sonnet 4.6", 3, 15, 0.3, 3.75, 6, 0, 0],
   ["claude-sonnet-4-5%", "Claude Sonnet 4.5", 3, 15, 0.3, 3.75, 6, 0, 0],
   ["claude-sonnet-4-2%", "Claude Sonnet 4", 3, 15, 0.3, 3.75, 6, 0, 0],
@@ -714,6 +721,39 @@ repairLegacyGptPricing();
   });
   addMissing(DEFAULT_PRICING);
 }
+
+// One-time correction of Sonnet 5's standard rate on EXISTING databases.
+// The top-up above only INSERTs patterns that are missing, so a row seeded
+// before this change keeps the old $3/$15 standard forever — the user would
+// have to notice and hit "Reset Defaults" in Settings. Sonnet 5's 2/3-off
+// launch promo carried the correct $2/$10 through 2026-08-31; once it lapsed,
+// every session priced at the stale standard and over-reported by 50%.
+//
+// Guarded on the exact old defaults in every column, so a user who edited their
+// own Sonnet 5 rates is never overwritten, and re-running is a no-op. Cost is
+// computed from token_usage at request time and never stored, so correcting the
+// rule reprices all historical usage automatically — no data migration needed.
+// Exported (like applyIntroPricing) so the reset-pricing endpoint and tests can
+// apply it against a specific handle.
+function correctSonnet5StandardRate(dbHandle = db) {
+  return dbHandle
+    .prepare(
+      `UPDATE model_pricing
+          SET input_per_mtok = 2,
+              output_per_mtok = 10,
+              cache_read_per_mtok = 0.2,
+              cache_write_per_mtok = 2.5,
+              cache_write_1h_per_mtok = 4
+        WHERE model_pattern = 'claude-sonnet-5%'
+          AND input_per_mtok = 3
+          AND output_per_mtok = 15
+          AND cache_read_per_mtok = 0.3
+          AND cache_write_per_mtok = 3.75
+          AND cache_write_1h_per_mtok = 6`
+    )
+    .run();
+}
+correctSonnet5StandardRate();
 
 // Known introductory promo rates: [pattern, in, out, cacheRead, cw5m, cw1h, until].
 // Standard rates live in the DEFAULT_PRICING row; these add the time-limited
@@ -2080,6 +2120,7 @@ module.exports = {
   DEFAULT_PRICING,
   DEFAULT_GPT_PRICING,
   applyIntroPricing,
+  correctSonnet5StandardRate,
   seedGptPricing,
   repairLegacyGptPricing,
 };


### PR DESCRIPTION
## Summary

`claude-opus-5` has never had a row in `DEFAULT_PRICING` (`server/db.js`). Every session using it prices at $0 and shows up in `unpriced_models` on `GET /api/pricing/cost` — silently undercounting cost totals for anyone running Opus 5.

- Added `claude-opus-5%` with Anthropic's published rates: $5/$25 input/output per MTok, fast mode $10/$50 (same as Opus 4.8). Cache read/write use Anthropic's standard multipliers (0.1x/1.25x/2x of input) — identical derivation to the existing 4.8/4.7/4.6 rows, which all share the same $5 input rate.
- The `%` wildcard covers both the plain `claude-opus-5` and the `claude-opus-5[1m]` model string (observed when the 1M-context window is active) under one rule, same convention already used for every other model in this table.
- 2 new tests pin the seed row's values so it can't silently regress again.

## Test plan

- [x] `node --test server/__tests__/*.test.js` passes locally (537/537)
- [x] Verified against a real historical session pre-dating the fix: `GET /api/pricing/cost/:id` now returns a non-zero, correctly-priced `claude-opus-5` breakdown instead of listing it in `unpriced_models`
