### PR TITLE
fix: make setup script cross-platform (cmd cwd leak)

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "dev:client": "cd client && npm run dev",
     "build": "cd client && npm run build",
     "start": "node server/index.js",
-    "setup": "npm install && (cd client && npm install) && (cd vscode-extension && npm install) && npm run mcp:install && npm run mcp:build && npm run link-cli",
+    "setup": "npm install && npm --prefix client install && npm --prefix vscode-extension install && npm run mcp:install && npm run mcp:build && npm run link-cli",
     "update:pull-setup": "git pull --ff-only && npm run setup",
     "mcp:install": "npm --prefix mcp install",
     "mcp:build": "npm --prefix mcp run build",


### PR DESCRIPTION
## Problem

`npm run setup` fails on Windows at the third step with `The system cannot find the path specified` (cmd codepage output; exit code 1):

```json
"setup": "npm install && (cd client && npm install) && (cd vscode-extension && npm install) && npm run mcp:install && npm run mcp:build && npm run link-cli"
```

On POSIX shells, the parentheses spawn subshells, so each `cd` only affects its own subshell. On Windows, npm runs scripts through `cmd.exe`, where `( ... )` is **not** a subshell — `cd` permanently changes the working directory of the process. After the second step the cwd is still `client/`, so the third step resolves `vscode-extension` relative to `client/`, which does not exist.

## Fix

Replace both parenthesized steps with `npm --prefix <dir> install`, which is shell-agnostic and consistent with the existing `mcp:install` / `mcp:build` scripts that already use `--prefix`:

```json
"setup": "npm install && npm --prefix client install && npm --prefix vscode-extension install && npm run mcp:install && npm run mcp:build && npm run link-cli"
```

## Verification

Windows 11:

- **Before**: `npm run setup` exits 1 at the `vscode-extension` step on every run.
- **After**: all six steps complete, exit code 0.

## Note (pre-existing, unrelated)

Two server tests fail on Windows even on `master`, so a local `pre-commit` run reports unrelated failures:

- `codex-sweep-perf.test.js` — the `after()` cleanup `fs.rmSync(TMP_ROOT, { recursive: true })` hits `EBUSY` while SQLite handles are still open (Windows enforces file locks; POSIX does not).
- `remote-sources.test.js` → `allows hyphens inside an identity_file path` — a POSIX-style path (`/home/u/.ssh/id-ed25519`) comes back rewritten with backslashes on Windows and fails the strict-equality assertion.

Happy to file separate issues for those if useful.
