### PR TITLE
test(codex): cover cumulative counter regression in token deltas

### DIFF
--- a/server/__tests__/codex-ingest.test.js
+++ b/server/__tests__/codex-ingest.test.js
@@ -404,6 +404,75 @@ describe("Codex rollout ingestor", () => {
     assert.equal(stmts.getAgent.get(`codex:${SESSION_ID}`).status, "working");
   });
 
+  it("zeroes the delta when cumulative token counters regress, then resumes from the lower baseline", () => {
+    const sessionId = "019fde70-aaaa-7b71-8c90-000000000001";
+    const rollout = path.join(
+      process.env.DASHBOARD_CODEX_HOME,
+      "sessions",
+      "2026",
+      "08",
+      "06",
+      `rollout-2026-08-06T09-00-00-${sessionId}.jsonl`
+    );
+    const appendLocal = (entry) => {
+      fs.mkdirSync(path.dirname(rollout), { recursive: true });
+      fs.appendFileSync(rollout, `${JSON.stringify(entry)}\n`);
+    };
+    const tokenCount = (usage) =>
+      record("event_msg", { type: "token_count", info: { total_token_usage: usage } });
+
+    appendLocal(record("session_meta", { id: sessionId, cwd: "/workspace/regression" }));
+    appendLocal(
+      tokenCount({
+        input_tokens: 300_000,
+        cached_input_tokens: 100_000,
+        cache_write_input_tokens: 20_000,
+        output_tokens: 1_000,
+        reasoning_output_tokens: 250,
+      })
+    );
+    assert.equal(ingestCodexTranscript(rollout).changed, true);
+    const rowsAfterFirst = stmts.getTokensBySession.all(sessionId);
+    assert.equal(rowsAfterFirst.length, 1);
+    assert.equal(rowsAfterFirst[0].input_tokens, 180_000);
+    assert.equal(rowsAfterFirst[0].output_tokens, 1_250);
+
+    // A rewritten or resumed rollout can re-open with lower cumulative counters.
+    // The regressed snapshot itself must contribute nothing…
+    appendLocal(
+      tokenCount({
+        input_tokens: 50_000,
+        cached_input_tokens: 10_000,
+        cache_write_input_tokens: 0,
+        output_tokens: 200,
+        reasoning_output_tokens: 50,
+      })
+    );
+    assert.equal(ingestCodexTranscript(rollout).changed, true);
+    assert.deepEqual(
+      stmts.getTokensBySession.all(sessionId),
+      rowsAfterFirst,
+      "a regressed cumulative snapshot must not emit a token delta"
+    );
+
+    // …and growth after the regression is measured against the lower baseline.
+    appendLocal(
+      tokenCount({
+        input_tokens: 50_100,
+        cached_input_tokens: 10_000,
+        cache_write_input_tokens: 0,
+        output_tokens: 205,
+        reasoning_output_tokens: 50,
+      })
+    );
+    assert.equal(ingestCodexTranscript(rollout).changed, true);
+    const resumed = stmts.getTokensBySession
+      .all(sessionId)
+      .find((row) => row.context_size === "short");
+    assert.equal(resumed.input_tokens, 100);
+    assert.equal(resumed.output_tokens, 5);
+  });
+
   it("imports an inactive historical rollout as completed without replaying task_started", () => {
     const sessionId = "019fd086-d75c-7a91-9743-2788d849c224";
     const rollout = path.join(


### PR DESCRIPTION
## What

Adds one test to `server/__tests__/codex-ingest.test.js` covering `applyTokenSnapshot`'s counter-regression branch: when a rewritten or resumed rollout re-opens with **lower** cumulative `total_token_usage`, the regressed snapshot must contribute no token delta, and subsequent growth must be measured against the lower baseline.

## Why

`applyTokenSnapshot` already guards this (any field regression zeroes the delta and swaps the baseline), but no existing test exercises it — the suite only covers monotonically growing counters. The regression path is exactly where a rewritten rollout would otherwise double-count or go negative, so it deserves a pinned test.

## Verification

- `node --test server/__tests__/codex-ingest.test.js` → 22 pass / 0 fail with this addition (was 21)
- The repo's own pre-commit hook (Prettier + full backend suite) ran clean on this commit
- No runtime changes; test-only diff

## Notes

The fixture uses a fully synthetic session id and synthetic token counts — no real logs. Related prior art in this repo: #293/#294 handled per-record inflation on the Claude side; this pins the Codex-side cumulative guard.
