### PR TITLE
feat(hooks): POST /api/hooks/ingest-batch -- remote-push session ingestion (re-scope of #321)

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,7 +647,8 @@ flowchart LR
 | `DASHBOARD_HOST`        | `127.0.0.1`   | Interface the server binds to. Loopback by default (not network-reachable). Set to `0.0.0.0` to expose on a LAN (logs a startup warning) |
 | `DASHBOARD_TOKEN`       | _(unset)_     | When set, every `/api/*` request and the WebSocket must present the token (`Authorization: Bearer <token>`, `x-dashboard-token` header, or `?token=`). Off by default — loopback bind is the trust boundary |
 | `DASHBOARD_TOKEN_FILE` | _(unset)_ | File-backed dashboard token for Docker/Kubernetes secrets; direct `DASHBOARD_TOKEN` wins |
-| `DASHBOARD_HOOK_TOKEN` / `DASHBOARD_HOOK_TOKEN_FILE` | _(unset)_ | Independent token for `/api/hooks/*`; required for authenticated remote hook ingestion |
+| `DASHBOARD_HOOK_TOKEN` / `DASHBOARD_HOOK_TOKEN_FILE` | _(unset)_ | Independent token for the local hook routes (`/api/hooks/event`, `/api/hooks/codex`) when exposed beyond loopback |
+| `REMOTE_PUSH_TOKEN` / `REMOTE_PUSH_TOKEN_FILE` | _(unset)_ | Separate token gating `POST /api/hooks/ingest-batch` (public-internet remote-push route, disabled by default). Deliberately independent of `DASHBOARD_HOOK_TOKEN` above — setting that one must not also open this internet-writable route |
 | `DASHBOARD_ALLOWED_HOSTS` | _(loopback)_ | Comma-separated extra `Host` values allowed on HTTP + WebSocket upgrades (DNS-rebinding guard). Add your LAN hostnames here when binding beyond loopback |
 | `DASHBOARD_ENV_PATH` | repo `.env` | Writable dotenv path used when Settings persists Claude/Codex home overrides; container default `/app/config/.env` |
 | `CCAM_DASHBOARD_URL` | _(localhost discovery)_ | Optional remote hook destination. Non-loopback URLs must use HTTPS and a hook token |
@@ -1138,6 +1139,7 @@ See [docs/API.md → Metrics](./docs/API.md#metrics) for the full metric list an
 | Method | Path               | Description                                  |
 | ------ | ------------------ | -------------------------------------------- |
 | `POST` | `/api/hooks/event` | Receive and process a Claude Code hook event |
+| `POST` | `/api/hooks/ingest-batch` | Push a batch of session data from a roaming/NAT'd machine (disabled by default; see `REMOTE_PUSH_TOKEN` below and `server/README.md` for the full payload shape) |
 
 **Hook event payload:**
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5913,7 +5913,7 @@ paths:
       tags:
         - Hooks
       summary: Push a batch of session data from a roaming/NAT'd machine
-      description: 'Third session-data ingestion path, alongside the local hook routes above and the SSH-pull remote-sync path (see /api/remote-sources). For a machine the dashboard can never reach to pull FROM, it pushes its own session data over HTTPS instead. Reachable from the public internet and disabled by default -- gated by its own REMOTE_PUSH_TOKEN, deliberately independent of DASHBOARD_HOOK_TOKEN (which protects the loopback-only routes above; setting that one must not also open this route as a side effect). Send the token as `Authorization: Bearer <token>`, `X-Dashboard-Token`, or `?token=`.'
+      description: 'Third session-data ingestion path, alongside the local hook routes above and the SSH-pull remote-sync path (see /api/remote-sources). For a machine the dashboard can never reach to pull FROM, it pushes its own session data over HTTPS instead. Reachable from the public internet and disabled by default -- gated by its own REMOTE_PUSH_TOKEN, deliberately independent of DASHBOARD_HOOK_TOKEN (which protects the loopback-only routes above; setting that one must not also open this route as a side effect). Send the token as `Authorization: Bearer <token>` or `X-Dashboard-Token` -- deliberately not `?token=`, which would end up in access/proxy logs on a public-internet route.'
       operationId: ingestRemotePushBatch
       requestBody:
         required: true

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5908,6 +5908,182 @@ paths:
                     type: boolean
                   reason:
                     type: string
+  /api/hooks/ingest-batch:
+    post:
+      tags:
+        - Hooks
+      summary: Push a batch of session data from a roaming/NAT'd machine
+      description: 'Third session-data ingestion path, alongside the local hook routes above and the SSH-pull remote-sync path (see /api/remote-sources). For a machine the dashboard can never reach to pull FROM, it pushes its own session data over HTTPS instead. Reachable from the public internet and disabled by default -- gated by its own REMOTE_PUSH_TOKEN, deliberately independent of DASHBOARD_HOOK_TOKEN (which protects the loopback-only routes above; setting that one must not also open this route as a side effect). Send the token as `Authorization: Bearer <token>`, `X-Dashboard-Token`, or `?token=`.'
+      operationId: ingestRemotePushBatch
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - session_id
+                - provider
+              properties:
+                schema_version:
+                  type: integer
+                  description: Must equal this server's current wire-format version (1) when present. A mismatch is a whole-request 409, not a per-item soft-fail.
+                session_id:
+                  type: string
+                provider:
+                  type: string
+                  enum:
+                    - claude
+                    - codex
+                session_name:
+                  type: string
+                  description: Defaults to 'Session <first 8 chars of session_id>' for a brand-new session.
+                cwd:
+                  type: string
+                model:
+                  type: string
+                tokens:
+                  type: array
+                  description: Each entry is a bucket's FULL current total (like a transcript re-parse), not a delta.
+                  items:
+                    type: object
+                    required:
+                      - model
+                    properties:
+                      model:
+                        type: string
+                      speed:
+                        type: string
+                      inference_geo:
+                        type: string
+                      service_tier:
+                        type: string
+                      input:
+                        type: integer
+                        minimum: 0
+                      output:
+                        type: integer
+                        minimum: 0
+                      cacheRead:
+                        type: integer
+                        minimum: 0
+                      cacheWrite:
+                        type: integer
+                        minimum: 0
+                      cacheWrite1h:
+                        type: integer
+                        minimum: 0
+                        description: Must be <= cacheWrite.
+                      webSearch:
+                        type: integer
+                        minimum: 0
+                      webFetch:
+                        type: integer
+                        minimum: 0
+                      codeExec:
+                        type: integer
+                        minimum: 0
+                tool_events:
+                  type: array
+                  description: Deduped by (session_id, event_type, uuid), across requests and within one batch.
+                  items:
+                    type: object
+                    required:
+                      - uuid
+                    properties:
+                      uuid:
+                        type: string
+                      agent_id:
+                        type: string
+                        description: Defaults to this session's main agent.
+                      tool_name:
+                        type: string
+                      status:
+                        type: string
+                      timestamp:
+                        type: string
+                        format: date-time
+                        description: Defaults to server 'now'.
+                turns:
+                  type: array
+                  description: Deduped the same way as tool_events.
+                  items:
+                    type: object
+                    required:
+                      - uuid
+                    properties:
+                      uuid:
+                        type: string
+                      agent_id:
+                        type: string
+                      duration_ms:
+                        type: integer
+                        minimum: 0
+                      timestamp:
+                        type: string
+                        format: date-time
+      responses:
+        '200':
+          description: Batch processed (even when individual items were skipped/rejected -- see errors[]/skipped for partial-failure detail; the request itself still succeeds).
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - ok
+                  - written
+                  - skipped
+                  - errors
+                properties:
+                  ok:
+                    type: boolean
+                  written:
+                    type: integer
+                  skipped:
+                    type: integer
+                  errors:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        item:
+                          type: string
+                        code:
+                          type: string
+                        message:
+                          type: string
+        '400':
+          description: Missing session_id, invalid provider, or a per-item validation failure surfaced at the request level
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: REMOTE_PUSH_TOKEN is configured but the request's token is missing or wrong
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Host header not allowed (see hostGuard)
+        '409':
+          description: schema_version in the request doesn't match this server's
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: tokens.length + tool_events.length + turns.length exceeds 1000
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          description: REMOTE_PUSH_TOKEN is not configured at all -- the route is disabled
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /api/pricing:
     get:
       tags:

--- a/server/README.md
+++ b/server/README.md
@@ -499,6 +499,7 @@ Claude turn-duration ingestion assigns each `TurnDuration` a stable transcript i
 | ------ | ------------------ | ---------------------------------------------- |
 | `POST` | `/api/hooks/event` | Ingest one Claude Code hook event envelope     |
 | `POST` | `/api/hooks/codex` | Acknowledge a Codex lifecycle notification and asynchronously ingest its rollout (or, for a rollout-less run, the payload itself) |
+| `POST` | `/api/hooks/ingest-batch` | Third session-data ingestion path (see [Remote Data Sources](#remote-data-sources) for the other two): a roaming/NAT'd machine the dashboard can never reach to pull FROM pushes a batch of its own session data instead |
 
 Request body shape:
 
@@ -510,6 +511,75 @@ Request body shape:
     "tool_name": "Bash"
   }
 }
+```
+
+#### `POST /api/hooks/ingest-batch`
+
+Unlike every other route in this file, this one is meant to be reachable from
+the public internet (via Traefik) rather than loopback, and is disabled by
+default. It is gated by its **own** token — deliberately **not**
+`DASHBOARD_HOOK_TOKEN` (that one protects the loopback-only routes above; an
+operator who sets it to harden those must not thereby also open this
+internet-writable endpoint as a side effect):
+
+```
+REMOTE_PUSH_TOKEN=              # or REMOTE_PUSH_TOKEN_FILE=/path/to/token
+```
+
+Unset (the default): every request gets `503 REMOTE_PUSH_NOT_CONFIGURED`. Set,
+but the request's token doesn't match: `401 EUNAUTHORIZED`. Send the token as
+`Authorization: Bearer <token>`, `X-Dashboard-Token: <token>`, or `?token=`.
+
+Request body:
+
+```json
+{
+  "schema_version": 1,
+  "session_id": "abc-123",
+  "provider": "claude",
+  "session_name": "optional display name (defaults to Session <first 8 chars of id>)",
+  "cwd": "optional working directory",
+  "model": "optional model id",
+  "tokens": [
+    {
+      "model": "claude-opus-4",
+      "speed": "1x",
+      "inference_geo": "us",
+      "service_tier": "standard",
+      "input": 100,
+      "output": 50,
+      "cacheRead": 0,
+      "cacheWrite": 0,
+      "cacheWrite1h": 0,
+      "webSearch": 0,
+      "webFetch": 0,
+      "codeExec": 0
+    }
+  ],
+  "tool_events": [
+    { "uuid": "evt-1", "agent_id": "optional, defaults to this session's main agent", "tool_name": "Bash", "status": "success", "timestamp": "optional ISO-8601, defaults to server now" }
+  ],
+  "turns": [
+    { "uuid": "turn-1", "agent_id": "optional", "duration_ms": 1500, "timestamp": "optional ISO-8601" }
+  ]
+}
+```
+
+`provider` must be one of `claude`/`codex`. `tokens[]` entries are each
+bucket's **full current total** (like a transcript re-parse), not a delta.
+`tool_events[]`/`turns[]` are deduped by `(session_id, event_type, uuid)`,
+both against previously-committed rows and within the same batch — safe to
+resend. `tokens.length + tool_events.length + turns.length` is capped at 1000
+per request (`413 BATCH_TOO_LARGE`). A `session_id` already owned by a local
+or SSH-pulled session is refused per-item (`SESSION_LOCALLY_OWNED`) rather
+than allowed to hijack it — a pushed session can only ever create a NEW
+session or append to one it created itself.
+
+Response (`200`, even when individual items were skipped/rejected — see
+`errors[]`/`skipped` for partial-failure detail):
+
+```json
+{ "ok": true, "written": 2, "skipped": 1, "errors": [{ "item": "tokens[0]", "code": "INVALID_NUMERIC", "message": "..." }] }
 ```
 
 ### Pricing
@@ -1479,8 +1549,10 @@ NODE_ENV=production                # Environment mode
 DASHBOARD_HOST=127.0.0.1           # Bind address; default loopback. Set 0.0.0.0 to widen (logs a warning)
 DASHBOARD_TOKEN=                   # Optional bearer token; when set, /api/* and the WebSocket require it (off by default)
 DASHBOARD_TOKEN_FILE=              # File-backed dashboard token for Docker/Kubernetes secrets
-DASHBOARD_HOOK_TOKEN=              # Independent token for /api/hooks/* remote ingestion
+DASHBOARD_HOOK_TOKEN=              # Independent token for the local hook routes (/api/hooks/event, /api/hooks/codex) when exposed beyond loopback
 DASHBOARD_HOOK_TOKEN_FILE=         # File-backed hook token
+REMOTE_PUSH_TOKEN=                 # Separate token gating POST /api/hooks/ingest-batch (public-internet remote-push route). Unset = route disabled (503). Deliberately independent of DASHBOARD_HOOK_TOKEN above
+REMOTE_PUSH_TOKEN_FILE=            # File-backed remote-push token
 DASHBOARD_ALLOWED_HOSTS=           # Extra Host-header names to allow (comma-separated), e.g. for LAN access
 POD_IP=                            # Kubernetes downward-API pod IP; automatically accepted by the Host guard
 DASHBOARD_ENV_PATH=                # Writable dotenv path for persisted Settings overrides

--- a/server/README.md
+++ b/server/README.md
@@ -528,7 +528,9 @@ REMOTE_PUSH_TOKEN=              # or REMOTE_PUSH_TOKEN_FILE=/path/to/token
 
 Unset (the default): every request gets `503 REMOTE_PUSH_NOT_CONFIGURED`. Set,
 but the request's token doesn't match: `401 EUNAUTHORIZED`. Send the token as
-`Authorization: Bearer <token>`, `X-Dashboard-Token: <token>`, or `?token=`.
+`Authorization: Bearer <token>` or `X-Dashboard-Token: <token>` -- deliberately
+**not** `?token=` (unlike the dashboard/WebSocket token above): a query-string
+credential on a public-internet route ends up in access/proxy logs.
 
 Request body:
 

--- a/server/__tests__/events-uuid-index-legacy-json.test.js
+++ b/server/__tests__/events-uuid-index-legacy-json.test.js
@@ -116,4 +116,49 @@ describe("idx_events_session_type_uuid on a DB with legacy non-JSON events.data"
       "dedup query must find the valid-JSON row despite the coexisting legacy non-JSON row"
     );
   });
+
+  it("index predicate is narrowed to RemoteToolEvent/RemoteTurn (PR #329 follow-up)", () => {
+    const sql = db
+      .prepare(
+        "SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_events_session_type_uuid'"
+      )
+      .get().sql;
+    assert.match(sql, /event_type IN \('RemoteToolEvent', ?'RemoteTurn'\)/);
+  });
+
+  it("a dedup query repeating the event_type IN (...) list literally uses the partial index, not a full scan", () => {
+    // Mirrors hooks.js's dedupEventStmt exactly. The maintainer's own review
+    // measured that a bare `event_type = ?` parameter does NOT let SQLite prove
+    // the query's WHERE implies the narrowed index's WHERE, so it falls back to
+    // a full events scan -- verified here against EXPLAIN QUERY PLAN, not
+    // assumed from the claim alone.
+    const withInList = db
+      .prepare(
+        `EXPLAIN QUERY PLAN
+         SELECT 1 FROM events
+         WHERE session_id = ? AND event_type = ? AND json_valid(data) = 1
+           AND event_type IN ('RemoteToolEvent', 'RemoteTurn')
+           AND json_extract(data, '$.uuid') = ? LIMIT 1`
+      )
+      .all("s", "RemoteToolEvent", "u")
+      .map((r) => r.detail)
+      .join(" | ");
+    assert.match(withInList, /USING INDEX idx_events_session_type_uuid/);
+
+    const withoutInList = db
+      .prepare(
+        `EXPLAIN QUERY PLAN
+         SELECT 1 FROM events
+         WHERE session_id = ? AND event_type = ? AND json_valid(data) = 1
+           AND json_extract(data, '$.uuid') = ? LIMIT 1`
+      )
+      .all("s", "RemoteToolEvent", "u")
+      .map((r) => r.detail)
+      .join(" | ");
+    assert.doesNotMatch(
+      withoutInList,
+      /USING INDEX idx_events_session_type_uuid/,
+      "without the literal IN-list this must NOT use the narrowed index -- confirms the IN-list repetition is load-bearing, not decorative"
+    );
+  });
 });

--- a/server/__tests__/events-uuid-index-legacy-json.test.js
+++ b/server/__tests__/events-uuid-index-legacy-json.test.js
@@ -1,0 +1,119 @@
+/**
+ * @file Regression test for idx_events_session_type_uuid — a partial index on
+ * events(session_id, event_type, json_extract(data,'$.uuid')) guarded by
+ * `WHERE json_valid(data) = 1` (see server/db.js, near idx_events_session_type).
+ *
+ * SQLite evaluates an indexed expression against every existing row when the
+ * index is CREATEd. This table has legacy rows whose `data` predates the
+ * JSON-events convention and is not valid JSON, so a naive (non-partial)
+ * version of this index would throw "malformed JSON" and prevent the server
+ * from starting on any installation carrying such rows. This test simulates
+ * exactly that installation: an existing DB file with a non-JSON `data` row
+ * already present, created BEFORE server/db.js (and its migrations/index
+ * creation) ever runs against it.
+ * @author Son Nguyen <hoangson091104@gmail.com>
+ */
+
+const { describe, it, before, after } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+const Database = require("better-sqlite3");
+
+const STAMP = `events-uuid-index-legacy-json-${Date.now()}-${process.pid}`;
+const TMP = path.join(os.tmpdir(), STAMP);
+const DB_FILE = path.join(TMP, "dashboard.db");
+
+process.env.DASHBOARD_DB_PATH = DB_FILE;
+process.env.CLAUDE_HOME = path.join(TMP, "home");
+process.env.DASHBOARD_DATA_DIR = path.join(TMP, "data");
+fs.mkdirSync(TMP, { recursive: true });
+
+// Simulate a pre-existing installation: build a minimal `events` table by hand
+// with better-sqlite3 directly and insert a legacy non-JSON row BEFORE
+// server/db.js is ever required against this file. Requiring db.js first
+// would apply migrations/create the index against a clean, empty table and
+// never exercise the "malformed JSON at index-build time" case at all.
+const legacyDb = new Database(DB_FILE);
+legacyDb.pragma("journal_mode = WAL");
+legacyDb.exec(`
+  CREATE TABLE IF NOT EXISTS events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL,
+    agent_id TEXT,
+    event_type TEXT NOT NULL,
+    tool_name TEXT,
+    summary TEXT,
+    data TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+  );
+`);
+legacyDb
+  .prepare(
+    `INSERT INTO events (session_id, agent_id, event_type, tool_name, summary, data)
+     VALUES (?, ?, ?, ?, ?, ?)`
+  )
+  .run("legacy-session-1", null, "ToolEvent", "Bash", "legacy pre-JSON row", "not json at all");
+legacyDb.close();
+
+let db;
+
+after(() => {
+  if (db) db.close();
+  try {
+    fs.rmSync(TMP, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+describe("idx_events_session_type_uuid on a DB with legacy non-JSON events.data", () => {
+  it("server/db.js loads without throwing despite the legacy non-JSON row", () => {
+    // This is the actual regression: a naive (non-partial) index would throw
+    // "malformed JSON" here and abort startup.
+    assert.doesNotThrow(() => {
+      db = require("../db").db;
+    });
+  });
+
+  it("creates the partial index", () => {
+    const row = db
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_events_session_type_uuid'"
+      )
+      .get();
+    assert.ok(row, "idx_events_session_type_uuid must exist after db.js runs its migrations");
+  });
+
+  it("a dedup-style query against events.data finds a valid-JSON row and does not throw, alongside the coexisting legacy row", () => {
+    db.prepare(
+      `INSERT INTO events (session_id, agent_id, event_type, tool_name, summary, data)
+       VALUES (?, ?, ?, ?, ?, ?)`
+    ).run(
+      "legacy-session-1",
+      null,
+      "ToolEvent",
+      "Bash",
+      "well-formed row",
+      JSON.stringify({ uuid: "abc-123", tool_name: "Bash" })
+    );
+
+    let found;
+    assert.doesNotThrow(() => {
+      found = db
+        .prepare(
+          `SELECT 1 FROM events
+           WHERE session_id = ?
+             AND event_type = ?
+             AND json_valid(data) = 1
+             AND json_extract(data, '$.uuid') = ?`
+        )
+        .get("legacy-session-1", "ToolEvent", "abc-123");
+    });
+    assert.ok(
+      found,
+      "dedup query must find the valid-JSON row despite the coexisting legacy non-JSON row"
+    );
+  });
+});

--- a/server/__tests__/idx-events-uuid-narrow-migration.test.js
+++ b/server/__tests__/idx-events-uuid-narrow-migration.test.js
@@ -1,0 +1,85 @@
+/**
+ * @file Regression test for the idx_events_session_type_uuid narrowing
+ * migration (PR #329 CodeRabbit review): `CREATE INDEX IF NOT EXISTS` in
+ * server/db.js is a no-op against an installation that already has the OLDER,
+ * broad version of this index (from before the `event_type IN ('RemoteToolEvent',
+ * 'RemoteTurn')` predicate was added) -- without an explicit migration step,
+ * such an installation would silently keep paying that index's full
+ * per-installation cost forever, never picking up the narrowing fix.
+ *
+ * This simulates exactly that installation: an existing DB file whose
+ * idx_events_session_type_uuid was built with the pre-narrowing definition,
+ * created BEFORE server/db.js (and its migration) ever runs against it.
+ */
+
+const { describe, it, before, after } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+const Database = require("better-sqlite3");
+
+const STAMP = `idx-events-uuid-narrow-migration-${Date.now()}-${process.pid}`;
+const TMP = path.join(os.tmpdir(), STAMP);
+const DB_FILE = path.join(TMP, "dashboard.db");
+
+process.env.DASHBOARD_DB_PATH = DB_FILE;
+process.env.CLAUDE_HOME = path.join(TMP, "home");
+process.env.DASHBOARD_DATA_DIR = path.join(TMP, "data");
+fs.mkdirSync(TMP, { recursive: true });
+
+// Build a minimal `events` table by hand with the OLD, broad index already in
+// place -- BEFORE server/db.js is ever required against this file. Requiring
+// db.js first would create the (already-narrowed) index fresh and never
+// exercise the "an older, broader definition already exists" migration path.
+const legacyDb = new Database(DB_FILE);
+legacyDb.pragma("journal_mode = WAL");
+legacyDb.exec(`
+  CREATE TABLE IF NOT EXISTS events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL,
+    agent_id TEXT,
+    event_type TEXT NOT NULL,
+    tool_name TEXT,
+    summary TEXT,
+    data TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+  );
+  CREATE INDEX IF NOT EXISTS idx_events_session_type_uuid
+  ON events(session_id, event_type, json_extract(data, '$.uuid'))
+  WHERE json_valid(data) = 1;
+`);
+legacyDb.close();
+
+let db;
+
+after(() => {
+  if (db) db.close();
+  try {
+    fs.rmSync(TMP, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+describe("idx_events_session_type_uuid narrowing migration on a pre-existing broad index", () => {
+  it("server/db.js loads without throwing against the pre-existing broad index", () => {
+    assert.doesNotThrow(() => {
+      db = require("../db").db;
+    });
+  });
+
+  it("the OLD broad index is replaced by the narrowed definition, not left as-is", () => {
+    const row = db
+      .prepare(
+        "SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_events_session_type_uuid'"
+      )
+      .get();
+    assert.ok(row, "idx_events_session_type_uuid must still exist");
+    assert.match(
+      row.sql,
+      /event_type IN \('RemoteToolEvent', ?'RemoteTurn'\)/,
+      "CREATE INDEX IF NOT EXISTS alone would have left the pre-existing broad index untouched -- this must have been explicitly dropped and rebuilt"
+    );
+  });
+});

--- a/server/__tests__/idx-events-uuid-narrow-migration.test.js
+++ b/server/__tests__/idx-events-uuid-narrow-migration.test.js
@@ -10,6 +10,7 @@
  * This simulates exactly that installation: an existing DB file whose
  * idx_events_session_type_uuid was built with the pre-narrowing definition,
  * created BEFORE server/db.js (and its migration) ever runs against it.
+ * @author Son Nguyen <hoangson091104@gmail.com>
  */
 
 const { describe, it, before, after } = require("node:test");

--- a/server/__tests__/ingest-batch.test.js
+++ b/server/__tests__/ingest-batch.test.js
@@ -342,6 +342,25 @@ describe("POST /api/hooks/ingest-batch", () => {
     assert.equal(rows[0].input_tokens, 100);
   });
 
+  it("rejects unsafe-integer token/duration values per-item (Number.isInteger alone would pass these)", async () => {
+    const sessionId = newSessionId("unsafe-integer");
+    const unsafe = Number.MAX_SAFE_INTEGER + 2; // still Number.isInteger(unsafe) === true
+    const res = await post({
+      session_id: sessionId,
+      provider: "claude",
+      tokens: [{ model: "claude-opus-5", input: unsafe, output: 10 }],
+      turns: [turnPayload({ duration_ms: unsafe })],
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.written, 0);
+    assert.equal(res.body.errors.length, 2);
+    assert.equal(res.body.errors[0].item, "tokens[0]");
+    assert.equal(res.body.errors[0].code, "INVALID_NUMERIC");
+    assert.equal(res.body.errors[1].item, "turns[0]");
+    assert.equal(res.body.errors[1].code, "INVALID_NUMERIC");
+    assert.equal(rawTokenRows(sessionId).length, 0);
+  });
+
   it("rejects cacheWrite1h > cacheWrite", async () => {
     const sessionId = newSessionId("cache-1h-overflow");
     const res = await post({

--- a/server/__tests__/ingest-batch.test.js
+++ b/server/__tests__/ingest-batch.test.js
@@ -70,12 +70,12 @@ after(() => {
 });
 
 beforeEach(() => {
-  process.env.DASHBOARD_HOOK_TOKEN = TOKEN;
+  process.env.REMOTE_PUSH_TOKEN = TOKEN;
 });
 
 afterEach(() => {
-  delete process.env.DASHBOARD_HOOK_TOKEN;
-  delete process.env.DASHBOARD_HOOK_TOKEN_FILE;
+  delete process.env.REMOTE_PUSH_TOKEN;
+  delete process.env.REMOTE_PUSH_TOKEN_FILE;
 });
 
 async function post(body, { token = TOKEN } = {}) {
@@ -116,14 +116,34 @@ function rawTokenRows(sessionId) {
 }
 
 describe("POST /api/hooks/ingest-batch", () => {
-  it("responds 503 when DASHBOARD_HOOK_TOKEN is not configured at all", async () => {
-    delete process.env.DASHBOARD_HOOK_TOKEN;
-    delete process.env.DASHBOARD_HOOK_TOKEN_FILE;
+  it("responds 503 when REMOTE_PUSH_TOKEN is not configured at all", async () => {
+    delete process.env.REMOTE_PUSH_TOKEN;
+    delete process.env.REMOTE_PUSH_TOKEN_FILE;
     const sessionId = newSessionId("no-token");
     const res = await post({ session_id: sessionId, provider: "claude" }, { token: undefined });
     assert.equal(res.status, 503);
-    assert.equal(res.body.error.code, "HOOK_TOKEN_NOT_CONFIGURED");
+    assert.equal(res.body.error.code, "REMOTE_PUSH_NOT_CONFIGURED");
     assert.equal(stmts.getSession.get(sessionId), undefined, "no session was created");
+  });
+
+  it("setting DASHBOARD_HOOK_TOKEN alone (hardening the local hook) does NOT enable this route", async () => {
+    // The exact scenario the maintainer flagged on PR #329: an operator who
+    // sets DASHBOARD_HOOK_TOKEN to protect the loopback local hook must not
+    // thereby also open this internet-reachable route as a side effect.
+    delete process.env.REMOTE_PUSH_TOKEN;
+    delete process.env.REMOTE_PUSH_TOKEN_FILE;
+    process.env.DASHBOARD_HOOK_TOKEN = "some-other-token-for-the-local-hook";
+    try {
+      const sessionId = newSessionId("hook-token-only");
+      const res = await post(
+        { session_id: sessionId, provider: "claude" },
+        { token: "some-other-token-for-the-local-hook" }
+      );
+      assert.equal(res.status, 503);
+      assert.equal(res.body.error.code, "REMOTE_PUSH_NOT_CONFIGURED");
+    } finally {
+      delete process.env.DASHBOARD_HOOK_TOKEN;
+    }
   });
 
   it("responds 401 for a wrong token when a token IS configured", async () => {

--- a/server/__tests__/ingest-batch.test.js
+++ b/server/__tests__/ingest-batch.test.js
@@ -156,6 +156,39 @@ describe("POST /api/hooks/ingest-batch", () => {
     assert.equal(stmts.getSession.get(sessionId), undefined, "no session was created");
   });
 
+  it("rejects a correct token sent only as ?token= -- a public-internet route must not accept a query-string credential", async () => {
+    // Deliberately not using the post() helper (which always sends
+    // Authorization) -- this needs to send NO Authorization header at all.
+    const sessionId = newSessionId("query-token");
+    const response = await fetch(
+      `${BASE}/api/hooks/ingest-batch?token=${encodeURIComponent(TOKEN)}`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ session_id: sessionId, provider: "claude" }),
+      }
+    );
+    assert.equal(response.status, 401);
+    assert.equal(stmts.getSession.get(sessionId), undefined, "no session was created");
+  });
+
+  it("rejects a malformed uuid on tool_events/turns instead of persisting it", async () => {
+    const sessionId = newSessionId("bad-uuid");
+    const res = await post({
+      session_id: sessionId,
+      provider: "claude",
+      tool_events: [toolEventPayload({ uuid: "not-a-uuid" })],
+      turns: [turnPayload({ uuid: "also-not-a-uuid" })],
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.written, 0);
+    assert.deepEqual(
+      res.body.errors.map((e) => e.code),
+      ["INVALID_UUID", "INVALID_UUID"]
+    );
+    assert.equal(rawEventsFor(sessionId).length, 0, "malformed-uuid items must not be persisted");
+  });
+
   it("creates a new session with the remote-push source sentinel + validated provider", async () => {
     const sessionId = newSessionId("create");
     const res = await post({

--- a/server/__tests__/ingest-batch.test.js
+++ b/server/__tests__/ingest-batch.test.js
@@ -162,6 +162,24 @@ describe("POST /api/hooks/ingest-batch", () => {
     assert.equal(mainAgent.session_id, sessionId);
   });
 
+  it("rejects an oversized batch with 413, before creating a session or doing any DB work", async () => {
+    const sessionId = newSessionId("too-large");
+    const tooMany = Array.from({ length: 1001 }, () => toolEventPayload());
+    const res = await post({ session_id: sessionId, provider: "claude", tool_events: tooMany });
+    assert.equal(res.status, 413);
+    assert.equal(res.body.error.code, "BATCH_TOO_LARGE");
+    assert.equal(stmts.getSession.get(sessionId), undefined, "no session was created");
+    assert.equal(rawEventsFor(sessionId).length, 0);
+  });
+
+  it("accepts a batch exactly at the item limit", async () => {
+    const sessionId = newSessionId("at-limit");
+    const exactly1000 = Array.from({ length: 1000 }, () => toolEventPayload());
+    const res = await post({ session_id: sessionId, provider: "claude", tool_events: exactly1000 });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.written, 1000);
+  });
+
   it("rejects an invalid provider with 400 and creates nothing", async () => {
     const sessionId = newSessionId("bad-provider");
     const res = await post({ session_id: sessionId, provider: "gemini" });

--- a/server/__tests__/ingest-batch.test.js
+++ b/server/__tests__/ingest-batch.test.js
@@ -1,0 +1,509 @@
+/**
+ * @file Tests for POST /api/hooks/ingest-batch — the third session-data
+ * ingestion path (alongside the local hook and the SSH-pull remote-sync
+ * path): a roaming/NAT'd machine the dashboard can never reach pushes a
+ * batch of its own session data to us over HTTPS instead.
+ *
+ * Covers, per the route's spec: the extra "token must be configured" gate on
+ * top of hookGuard (503 vs hookGuard's own 401), the remote-push `source`
+ * sentinel + provider validation, the ownership hijack guard (a pushed
+ * session_id must never be able to write into a locally-owned session), uuid
+ * dedup (both across requests and within a single batch), per-item soft-fail
+ * validation (numeric fields, cacheWrite1h <= cacheWrite, agent_id must
+ * belong to the target session), explicit-timestamp persistence, and
+ * schema_version mismatch as a whole-request 409.
+ *
+ * All requests go through the real HTTP route (createApp()/startServer()),
+ * not internal function calls — a direct function-call test would pass even
+ * if the Express-level auth/routing wiring were broken.
+ */
+
+const { describe, it, before, after, beforeEach, afterEach } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+const crypto = require("crypto");
+
+const STAMP = `ingest-batch-${Date.now()}-${process.pid}`;
+const TMP = path.join(os.tmpdir(), STAMP);
+process.env.DASHBOARD_DB_PATH = path.join(TMP, "dashboard.db");
+process.env.CLAUDE_HOME = path.join(TMP, "home");
+process.env.DASHBOARD_DATA_DIR = path.join(TMP, "data");
+// Keep the watchdog's real liveness probe inert for the duration of this
+// suite (mirrors server/__tests__/session-liveness.test.js).
+process.env.DASHBOARD_LIVENESS_PROBE = "0";
+fs.mkdirSync(TMP, { recursive: true });
+
+const { createApp, startServer } = require("../index");
+const { closeWebSocket } = require("../websocket");
+const { db, stmts } = require("../db");
+const { normalizeSpeed, normalizeGeo, normalizeTier } = require("../lib/token-usage");
+const WebSocket = require("ws");
+
+const TOKEN = "test-ingest-batch-token-xyz";
+
+let server;
+let BASE;
+let WS_BASE;
+
+before(async () => {
+  const app = createApp();
+  // startServer() already wires up the WebSocket server internally
+  // (initWebSocket(server)) — calling it again ourselves double-registers the
+  // 'upgrade' handler and throws inside `ws`.
+  server = await startServer(app, 0);
+  BASE = `http://127.0.0.1:${server.address().port}`;
+  WS_BASE = `ws://127.0.0.1:${server.address().port}/ws`;
+});
+
+after(() => {
+  closeWebSocket();
+  if (server) server.close();
+  if (db) db.close();
+  try {
+    fs.rmSync(TMP, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+beforeEach(() => {
+  process.env.DASHBOARD_HOOK_TOKEN = TOKEN;
+});
+
+afterEach(() => {
+  delete process.env.DASHBOARD_HOOK_TOKEN;
+  delete process.env.DASHBOARD_HOOK_TOKEN_FILE;
+});
+
+async function post(body, { token = TOKEN } = {}) {
+  const headers = { "content-type": "application/json" };
+  if (token !== undefined) headers.authorization = `Bearer ${token}`;
+  const response = await fetch(`${BASE}/api/hooks/ingest-batch`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+  let json = null;
+  try {
+    json = await response.json();
+  } catch {
+    /* no body */
+  }
+  return { status: response.status, body: json };
+}
+
+function newSessionId(label) {
+  return `ingest-${label}-${crypto.randomUUID()}`;
+}
+
+function toolEventPayload(overrides = {}) {
+  return { uuid: crypto.randomUUID(), tool_name: "Bash", status: "success", ...overrides };
+}
+
+function turnPayload(overrides = {}) {
+  return { uuid: crypto.randomUUID(), duration_ms: 1500, ...overrides };
+}
+
+function rawEventsFor(sessionId) {
+  return db.prepare("SELECT * FROM events WHERE session_id = ? ORDER BY id").all(sessionId);
+}
+
+function rawTokenRows(sessionId) {
+  return db.prepare("SELECT * FROM token_usage WHERE session_id = ?").all(sessionId);
+}
+
+describe("POST /api/hooks/ingest-batch", () => {
+  it("responds 503 when DASHBOARD_HOOK_TOKEN is not configured at all", async () => {
+    delete process.env.DASHBOARD_HOOK_TOKEN;
+    delete process.env.DASHBOARD_HOOK_TOKEN_FILE;
+    const sessionId = newSessionId("no-token");
+    const res = await post({ session_id: sessionId, provider: "claude" }, { token: undefined });
+    assert.equal(res.status, 503);
+    assert.equal(res.body.error.code, "HOOK_TOKEN_NOT_CONFIGURED");
+    assert.equal(stmts.getSession.get(sessionId), undefined, "no session was created");
+  });
+
+  it("responds 401 for a wrong token when a token IS configured", async () => {
+    const sessionId = newSessionId("wrong-token");
+    const res = await post(
+      { session_id: sessionId, provider: "claude" },
+      { token: "definitely-not-the-token" }
+    );
+    assert.equal(res.status, 401);
+    assert.equal(stmts.getSession.get(sessionId), undefined, "no session was created");
+  });
+
+  it("creates a new session with the remote-push source sentinel + validated provider", async () => {
+    const sessionId = newSessionId("create");
+    const res = await post({
+      session_id: sessionId,
+      provider: "codex",
+      session_name: "My roaming laptop session",
+      cwd: "/home/bap/work",
+      model: "gpt-5.6",
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.ok, true);
+
+    const session = stmts.getSession.get(sessionId);
+    assert.ok(session, "session row was created");
+    assert.equal(session.source, "remote_push");
+    assert.equal(session.provider, "codex");
+    assert.equal(session.name, "My roaming laptop session");
+    assert.equal(session.cwd, "/home/bap/work");
+    assert.equal(session.model, "gpt-5.6");
+    assert.equal(session.status, "active");
+
+    const mainAgent = stmts.getAgent.get(`${sessionId}-main`);
+    assert.ok(mainAgent, "main agent was created alongside the session");
+    assert.equal(mainAgent.session_id, sessionId);
+  });
+
+  it("rejects an invalid provider with 400 and creates nothing", async () => {
+    const sessionId = newSessionId("bad-provider");
+    const res = await post({ session_id: sessionId, provider: "gemini" });
+    assert.equal(res.status, 400);
+    assert.equal(res.body.error.code, "INVALID_PROVIDER");
+    assert.equal(stmts.getSession.get(sessionId), undefined);
+  });
+
+  it("SCHEMA_VERSION_MISMATCH is a whole-request 409, before any other processing", async () => {
+    const sessionId = newSessionId("schema-mismatch");
+    const res = await post({
+      session_id: sessionId,
+      provider: "claude",
+      schema_version: 999,
+      tokens: [{ model: "claude-opus-5", input: 10 }],
+    });
+    assert.equal(res.status, 409);
+    assert.equal(res.body.error.code, "SCHEMA_VERSION_MISMATCH");
+    assert.equal(stmts.getSession.get(sessionId), undefined, "nothing was written");
+  });
+
+  it("never lets a pushed session_id hijack a locally-owned session", async () => {
+    // Seed a session directly with source='local', simulating a session this
+    // dashboard's own local hook is actively managing (the exact scenario
+    // that sank PR #321).
+    const sessionId = newSessionId("hijack");
+    const now = new Date().toISOString();
+    db.prepare(
+      `INSERT INTO sessions (id, name, status, cwd, model, provider, source, started_at, updated_at)
+       VALUES (?, 'Locally owned session', 'active', '/local/cwd', 'claude-opus-5', 'claude', 'local', ?, ?)`
+    ).run(sessionId, now, now);
+    db.prepare(
+      `INSERT INTO agents (id, session_id, name, type, status, started_at, updated_at)
+       VALUES (?, ?, 'Main Agent', 'main', 'working', ?, ?)`
+    ).run(`${sessionId}-main`, sessionId, now, now);
+
+    const res = await post({
+      session_id: sessionId,
+      provider: "claude",
+      tokens: [{ model: "claude-opus-5", input: 999, output: 999 }],
+      tool_events: [toolEventPayload()],
+      turns: [turnPayload()],
+    });
+
+    assert.equal(res.status, 200, "a hijack attempt is a soft-fail, not a hard error");
+    assert.equal(res.body.written, 0);
+    assert.equal(res.body.errors.length, 3, "one error per item across all three arrays");
+    for (const err of res.body.errors) {
+      assert.equal(err.code, "SESSION_LOCALLY_OWNED");
+    }
+
+    // Verify against actual DB state, not just the response.
+    const session = stmts.getSession.get(sessionId);
+    assert.equal(session.source, "local", "ownership column untouched");
+    assert.equal(session.name, "Locally owned session", "metadata untouched");
+    assert.equal(session.model, "claude-opus-5", "metadata untouched");
+    assert.equal(rawEventsFor(sessionId).length, 0, "no events were written");
+    assert.equal(rawTokenRows(sessionId).length, 0, "no token_usage rows were written");
+  });
+
+  it("dedups by uuid across two separate requests (idempotent resend)", async () => {
+    const sessionId = newSessionId("dedup-cross-request");
+    const ev = toolEventPayload();
+    const tn = turnPayload();
+
+    const first = await post({
+      session_id: sessionId,
+      provider: "claude",
+      tool_events: [ev],
+      turns: [tn],
+    });
+    assert.equal(first.status, 200);
+    assert.equal(first.body.written, 2);
+    assert.equal(first.body.skipped, 0);
+
+    // Re-send the exact same batch.
+    const second = await post({
+      session_id: sessionId,
+      provider: "claude",
+      tool_events: [ev],
+      turns: [tn],
+    });
+    assert.equal(second.status, 200);
+    assert.equal(second.body.written, 0, "nothing new was written on the resend");
+    assert.equal(second.body.skipped, 2);
+
+    const rows = rawEventsFor(sessionId);
+    const toolRows = rows.filter((r) => r.event_type === "RemoteToolEvent");
+    const turnRows = rows.filter((r) => r.event_type === "RemoteTurn");
+    assert.equal(toolRows.length, 1, "no duplicate tool_event row");
+    assert.equal(turnRows.length, 1, "no duplicate turn row");
+  });
+
+  it("dedups by uuid WITHIN a single batch (same uuid sent twice in one request)", async () => {
+    const sessionId = newSessionId("dedup-in-batch");
+    const ev = toolEventPayload();
+
+    const res = await post({
+      session_id: sessionId,
+      provider: "claude",
+      tool_events: [ev, { ...ev }],
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.written, 1);
+    assert.equal(res.body.skipped, 1);
+    assert.equal(
+      rawEventsFor(sessionId).filter((r) => r.event_type === "RemoteToolEvent").length,
+      1
+    );
+  });
+
+  it("rejects a foreign-session agent_id per-item without rolling back other valid items", async () => {
+    const sessionA = newSessionId("owner-a");
+    const sessionB = newSessionId("owner-b");
+    await post({ session_id: sessionA, provider: "claude" });
+    await post({ session_id: sessionB, provider: "claude" });
+
+    const validEvent = toolEventPayload();
+    const foreignAgentEvent = toolEventPayload({ agent_id: `${sessionB}-main` });
+
+    const res = await post({
+      session_id: sessionA,
+      provider: "claude",
+      tool_events: [validEvent, foreignAgentEvent],
+    });
+
+    assert.equal(res.status, 200);
+    assert.equal(res.body.written, 1, "the valid item was written despite the invalid one");
+    assert.equal(res.body.errors.length, 1);
+    assert.equal(res.body.errors[0].item, "tool_events[1]");
+    assert.equal(res.body.errors[0].code, "UNKNOWN_AGENT");
+
+    const rows = rawEventsFor(sessionA).filter((r) => r.event_type === "RemoteToolEvent");
+    assert.equal(rows.length, 1);
+    assert.equal(JSON.parse(rows[0].data).uuid, validEvent.uuid);
+  });
+
+  it("rejects negative/fractional token counters per-item, valid items in the same batch still written", async () => {
+    const sessionId = newSessionId("bad-numeric");
+    const res = await post({
+      session_id: sessionId,
+      provider: "claude",
+      tokens: [
+        { model: "claude-opus-5", input: -5, output: 10 },
+        { model: "claude-opus-5", input: 3.5, output: 10 },
+        { model: "claude-sonnet-5", input: 100, output: 50 },
+      ],
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.written, 1);
+    assert.equal(res.body.errors.length, 2);
+    assert.equal(res.body.errors[0].item, "tokens[0]");
+    assert.equal(res.body.errors[0].code, "INVALID_NUMERIC");
+    assert.equal(res.body.errors[1].item, "tokens[1]");
+    assert.equal(res.body.errors[1].code, "INVALID_NUMERIC");
+
+    const rows = rawTokenRows(sessionId);
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].model, "claude-sonnet-5");
+    assert.equal(rows[0].input_tokens, 100);
+  });
+
+  it("rejects cacheWrite1h > cacheWrite", async () => {
+    const sessionId = newSessionId("cache-1h-overflow");
+    const res = await post({
+      session_id: sessionId,
+      provider: "claude",
+      tokens: [{ model: "claude-opus-5", cacheWrite: 100, cacheWrite1h: 150 }],
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.written, 0);
+    assert.equal(res.body.errors.length, 1);
+    assert.equal(res.body.errors[0].code, "CACHE_WRITE_1H_EXCEEDS_TOTAL");
+    assert.equal(rawTokenRows(sessionId).length, 0);
+  });
+
+  it("persists an explicit tool_event timestamp into created_at exactly (not server 'now')", async () => {
+    const sessionId = newSessionId("timestamp");
+    const explicitTs = "2020-01-01T00:00:00.000Z"; // already ms-precision ISO
+    const ev = toolEventPayload({ timestamp: explicitTs });
+
+    const res = await post({ session_id: sessionId, provider: "claude", tool_events: [ev] });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.written, 1);
+
+    const rows = rawEventsFor(sessionId).filter((r) => r.event_type === "RemoteToolEvent");
+    assert.equal(rows.length, 1);
+    assert.equal(
+      rows[0].created_at,
+      explicitTs,
+      "stored created_at must equal the supplied timestamp, not ingestion wall-clock time"
+    );
+  });
+
+  it("broadcasts the SAME created_at it persisted (no live-client vs REST divergence)", async () => {
+    // The exact regression PR #321 was flagged for: the old code broadcast the
+    // remote timestamp but always persisted server "now". Connect a real WS
+    // client and assert the frame's created_at against the persisted row.
+    const ws = new WebSocket(WS_BASE);
+    await new Promise((resolve, reject) => {
+      ws.once("open", resolve);
+      ws.once("error", reject);
+    });
+
+    const frames = [];
+    ws.on("message", (raw) => {
+      try {
+        frames.push(JSON.parse(raw.toString()));
+      } catch {
+        /* ignore */
+      }
+    });
+
+    const sessionId = newSessionId("ws-parity");
+    const explicitTs = "2021-06-15T08:30:00.000Z";
+    const ev = toolEventPayload({ timestamp: explicitTs });
+
+    const res = await post({ session_id: sessionId, provider: "claude", tool_events: [ev] });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.written, 1);
+
+    // Give the WS frame a moment to arrive (same-process broadcast is
+    // synchronous server-side, but delivery to this client is a real socket
+    // round-trip).
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    ws.close();
+
+    const frame = frames.find(
+      (f) => f.type === "new_event" && f.data && f.data.session_id === sessionId
+    );
+    assert.ok(frame, "a new_event frame for this session was broadcast");
+    assert.equal(frame.data.event_type, "RemoteToolEvent");
+
+    const stored = rawEventsFor(sessionId).find((r) => r.event_type === "RemoteToolEvent");
+    assert.ok(stored, "the row was actually persisted");
+    assert.equal(
+      frame.data.created_at,
+      stored.created_at,
+      "the broadcast created_at must match the persisted row exactly"
+    );
+    assert.equal(frame.data.created_at, explicitTs, "and both must match the supplied timestamp");
+  });
+
+  it("rejects a malformed timestamp per-item (missing timestamp is fine, invalid one is not)", async () => {
+    const sessionId = newSessionId("bad-timestamp");
+    const res = await post({
+      session_id: sessionId,
+      provider: "claude",
+      tool_events: [
+        toolEventPayload({ timestamp: "not-a-real-date" }),
+        toolEventPayload(), // no timestamp — falls back to server "now", must succeed
+      ],
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.written, 1);
+    assert.equal(res.body.errors.length, 1);
+    assert.equal(res.body.errors[0].item, "tool_events[0]");
+    assert.equal(res.body.errors[0].code, "INVALID_TIMESTAMP");
+  });
+
+  it("writes a token bucket matching local-hook parity: context_size='short' + normalized speed/geo/tier", async () => {
+    const sessionId = newSessionId("token-parity");
+    const rawEntry = {
+      model: "claude-opus-5",
+      speed: "fast",
+      inference_geo: "us",
+      service_tier: "batch",
+      input: 1000,
+      output: 200,
+      cacheRead: 50,
+      cacheWrite: 30,
+      cacheWrite1h: 10,
+      webSearch: 2,
+      webFetch: 1,
+      codeExec: 0,
+    };
+    const res = await post({ session_id: sessionId, provider: "claude", tokens: [rawEntry] });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.written, 1);
+
+    const rows = rawTokenRows(sessionId);
+    assert.equal(rows.length, 1);
+    const row = rows[0];
+    assert.equal(
+      row.context_size,
+      "short",
+      "must match the hardcoded literal in replaceTokenUsage"
+    );
+    assert.equal(row.speed, normalizeSpeed({ speed: rawEntry.speed }));
+    assert.equal(row.inference_geo, normalizeGeo({ inference_geo: rawEntry.inference_geo }));
+    assert.equal(row.service_tier, normalizeTier({ service_tier: rawEntry.service_tier }));
+    assert.equal(row.input_tokens, 1000);
+    assert.equal(row.output_tokens, 200);
+    assert.equal(row.cache_read_tokens, 50);
+    assert.equal(row.cache_write_tokens, 30);
+    assert.equal(row.cache_write_1h_tokens, 10);
+    assert.equal(row.web_search_requests, 2);
+    assert.equal(row.web_fetch_requests, 1);
+    assert.equal(row.code_execution_requests, 0);
+  });
+
+  it("a follow-up batch for the same remote-push session proceeds normally (not treated as a hijack)", async () => {
+    const sessionId = newSessionId("followup");
+    const first = await post({
+      session_id: sessionId,
+      provider: "claude",
+      tokens: [{ model: "claude-opus-5", input: 10 }],
+    });
+    assert.equal(first.status, 200);
+    assert.equal(first.body.written, 1);
+
+    const second = await post({
+      session_id: sessionId,
+      provider: "claude",
+      tool_events: [toolEventPayload()],
+    });
+    assert.equal(second.status, 200);
+    assert.equal(second.body.written, 1);
+    assert.equal(second.body.errors.length, 0);
+    assert.equal(stmts.getSession.get(sessionId).source, "remote_push");
+  });
+
+  it("still records events when the target session's main agent row was lost (no FK-abort of the batch)", async () => {
+    const sessionId = newSessionId("orphan-main-agent");
+    const created = await post({ session_id: sessionId, provider: "claude" });
+    assert.equal(created.status, 200);
+
+    db.prepare("DELETE FROM agents WHERE id = ?").run(`${sessionId}-main`);
+    assert.equal(stmts.getAgent.get(`${sessionId}-main`), undefined);
+
+    const res = await post({
+      session_id: sessionId,
+      provider: "claude",
+      tool_events: [toolEventPayload()],
+      turns: [turnPayload()],
+    });
+    assert.equal(res.status, 200);
+    assert.equal(
+      res.body.written,
+      2,
+      "both items were written, not rolled back by a missing-agent FK error"
+    );
+    assert.equal(res.body.errors.length, 0);
+    assert.ok(stmts.getAgent.get(`${sessionId}-main`), "the main agent row was recreated");
+  });
+});

--- a/server/__tests__/ingest-batch.test.js
+++ b/server/__tests__/ingest-batch.test.js
@@ -16,6 +16,7 @@
  * All requests go through the real HTTP route (createApp()/startServer()),
  * not internal function calls — a direct function-call test would pass even
  * if the Express-level auth/routing wiring were broken.
+ * @author Son Nguyen <hoangson091104@gmail.com>
  */
 
 const { describe, it, before, after, beforeEach, afterEach } = require("node:test");

--- a/server/db.js
+++ b/server/db.js
@@ -329,6 +329,31 @@ db.exec(`
 
   -- Composite indexes for frequent query patterns (columns that exist at table creation time)
   CREATE INDEX IF NOT EXISTS idx_events_session_type ON events(session_id, event_type);
+  -- Batch ingest (routes/hooks.js POST /api/hooks/ingest-batch) dedups incoming
+  -- ToolEvent/TurnDuration items against events by
+  -- (session_id, event_type, json_extract(data,'$.uuid')). Without this index
+  -- that's a per-session scan re-evaluating json_extract() on every row for
+  -- every batch item.
+  --
+  -- PARTIAL, same reason and same guard as the transcript_path backfill above
+  -- ("json_valid guard"): CREATE INDEX evaluates the indexed expression against
+  -- every existing row up front, and this table has older rows whose data is
+  -- not valid JSON (legacy data predating the JSON-events convention).
+  -- json_extract() throws "malformed JSON" on those, which would abort startup
+  -- on any installation carrying such rows. The WHERE json_valid(data) = 1
+  -- clause limits both index-build-time and future write-time evaluation of
+  -- json_extract() to rows that are actually JSON.
+  --
+  -- Non-obvious for whoever writes the dedup query: SQLite only uses a partial
+  -- index for a query whose own WHERE clause provably implies the index's WHERE
+  -- clause -- so the dedup query must include json_valid(data) = 1 literally,
+  -- not just semantically. Separately (and regardless of the index), that same
+  -- json_extract(data, '$.uuid') throws at *query* time too on a non-JSON row,
+  -- not only at index-build time -- so the guard is required for correctness on
+  -- any query touching events.data, index or no index.
+  CREATE INDEX IF NOT EXISTS idx_events_session_type_uuid
+  ON events(session_id, event_type, json_extract(data, '$.uuid'))
+  WHERE json_valid(data) = 1;
   -- Subagent JSONL import dedups each tool event with
   -- "WHERE agent_id = ? AND event_type = ? AND data LIKE '%tool_use_id%'".
   -- Without an agent_id index that is a full events-table scan per tool event;

--- a/server/db.js
+++ b/server/db.js
@@ -135,6 +135,30 @@ db.pragma("journal_mode = WAL");
 db.pragma("foreign_keys = ON");
 db.pragma("busy_timeout = 5000");
 
+// Migrate: idx_events_session_type_uuid's WHERE predicate was narrowed to
+// event_type IN ('RemoteToolEvent', 'RemoteTurn') (PR #329 review feedback).
+// The CREATE INDEX IF NOT EXISTS below is a no-op against an OLDER copy of
+// this index from before that narrowing -- an install that already has the
+// broad version would silently keep paying its full per-installation cost
+// forever, never picking up the fix. Drop it first if its stored definition
+// doesn't already match, so the CREATE below actually rebuilds it narrowed.
+try {
+  const existingIndex = db
+    .prepare(
+      "SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_events_session_type_uuid'"
+    )
+    .get();
+  if (
+    existingIndex &&
+    !existingIndex.sql.includes("event_type IN ('RemoteToolEvent', 'RemoteTurn')")
+  ) {
+    db.exec("DROP INDEX idx_events_session_type_uuid");
+  }
+} catch {
+  // Best-effort -- the CREATE INDEX IF NOT EXISTS below still runs and is
+  // safe against a brand-new (or already-correct) database either way.
+}
+
 db.exec(`
   CREATE TABLE IF NOT EXISTS sessions (
     id TEXT PRIMARY KEY,

--- a/server/db.js
+++ b/server/db.js
@@ -330,7 +330,7 @@ db.exec(`
   -- Composite indexes for frequent query patterns (columns that exist at table creation time)
   CREATE INDEX IF NOT EXISTS idx_events_session_type ON events(session_id, event_type);
   -- Batch ingest (routes/hooks.js POST /api/hooks/ingest-batch) dedups incoming
-  -- ToolEvent/TurnDuration items against events by
+  -- RemoteToolEvent/RemoteTurn items against events by
   -- (session_id, event_type, json_extract(data,'$.uuid')). Without this index
   -- that's a per-session scan re-evaluating json_extract() on every row for
   -- every batch item.
@@ -344,16 +344,30 @@ db.exec(`
   -- clause limits both index-build-time and future write-time evaluation of
   -- json_extract() to rows that are actually JSON.
   --
+  -- ALSO restricted to event_type IN ('RemoteToolEvent', 'RemoteTurn')
+  -- (maintainer feedback on PR #329): this index exists only to serve the
+  -- ingest-batch dedup query, which only ever looks up those two event types.
+  -- Without this predicate the index is built and maintained for EVERY
+  -- installation's entire events table regardless of whether remote push is
+  -- even configured -- measured at ~28MB per 500k events, ~224MB on a 4M-row
+  -- database. Narrowing the predicate makes it essentially free for anyone
+  -- who never uses the feature.
+  --
   -- Non-obvious for whoever writes the dedup query: SQLite only uses a partial
   -- index for a query whose own WHERE clause provably implies the index's WHERE
-  -- clause -- so the dedup query must include json_valid(data) = 1 literally,
-  -- not just semantically. Separately (and regardless of the index), that same
-  -- json_extract(data, '$.uuid') throws at *query* time too on a non-JSON row,
-  -- not only at index-build time -- so the guard is required for correctness on
-  -- any query touching events.data, index or no index.
+  -- clause -- so the dedup query must repeat BOTH json_valid(data) = 1 and the
+  -- event_type IN (...) list literally, not just semantically (a bare
+  -- event_type = ? parameter is NOT provably within the IN-list to the query
+  -- planner, so it falls back to a full events scan instead of using this
+  -- index -- verified against EXPLAIN QUERY PLAN, not assumed). Separately
+  -- (and regardless of the index), that same json_extract(data, '$.uuid')
+  -- throws at *query* time too on a non-JSON row, not only at index-build
+  -- time -- so the json_valid guard is required for correctness on any query
+  -- touching events.data, index or no index.
   CREATE INDEX IF NOT EXISTS idx_events_session_type_uuid
   ON events(session_id, event_type, json_extract(data, '$.uuid'))
-  WHERE json_valid(data) = 1;
+  WHERE json_valid(data) = 1
+    AND event_type IN ('RemoteToolEvent', 'RemoteTurn');
   -- Subagent JSONL import dedups each tool event with
   -- "WHERE agent_id = ? AND event_type = ? AND data LIKE '%tool_use_id%'".
   -- Without an agent_id index that is a full events-table scan per tool event;

--- a/server/lib/remote-sync.js
+++ b/server/lib/remote-sync.js
@@ -1445,4 +1445,11 @@ module.exports = {
   isLegacyScpProtocolError,
   HOST_RE,
   REMOTE_PATH_RE,
+  // Provider vocabulary — reused by routes/hooks.js's remote-push ingest route
+  // (POST /api/hooks/ingest-batch) so a third ingestion path (roaming/NAT'd
+  // machines that push over HTTPS instead of being SSH-pulled) validates its
+  // `provider` field against the same "claude" | "codex" vocabulary as the
+  // pull path instead of inventing new provider terms.
+  REMOTE_PROVIDERS,
+  assertProvider,
 };

--- a/server/lib/security.js
+++ b/server/lib/security.js
@@ -121,6 +121,19 @@ function getHookToken() {
   return readSecret("DASHBOARD_HOOK_TOKEN", "DASHBOARD_HOOK_TOKEN_FILE");
 }
 
+/**
+ * Optional, INDEPENDENT token for the remote-push ingest-batch route
+ * (server/routes/hooks.js POST /api/hooks/ingest-batch). Deliberately a
+ * separate secret from DASHBOARD_HOOK_TOKEN: that token's job is hardening
+ * the LOOPBACK-only local hook, and someone who sets it for that reason alone
+ * should not thereby also open an internet-writable session endpoint they
+ * never opted into (maintainer feedback on PR #329). Unset by default, same
+ * "presence of the secret = feature enabled" idiom as every other token here.
+ */
+function getRemotePushToken() {
+  return readSecret("REMOTE_PUSH_TOKEN", "REMOTE_PUSH_TOKEN_FILE");
+}
+
 function tokensMatch(provided, expected) {
   if (typeof provided !== "string" || provided.length === 0) return false;
   const a = Buffer.from(provided);
@@ -211,6 +224,7 @@ module.exports = {
   corsOptions,
   getDashboardToken,
   getHookToken,
+  getRemotePushToken,
   tokenGuard,
   hookGuard,
   isWebSocketAuthorized,

--- a/server/lib/security.js
+++ b/server/lib/security.js
@@ -151,6 +151,23 @@ function extractToken(req) {
   return null;
 }
 
+/**
+ * Header-only variant of extractToken (no `?token=` query-string fallback):
+ * for the remote-push ingest-batch route (server/routes/hooks.js), which is
+ * reachable from the public internet. A query-string credential ends up in
+ * server access logs, any intermediate proxy's logs, and (for a browser
+ * client) history/Referer headers -- acceptable for the dashboard/WebSocket
+ * auth extractToken() already serves, not for an internet-facing token
+ * (CodeRabbit review on PR #329).
+ */
+function extractHeaderOnlyToken(req) {
+  const auth = req.headers.authorization;
+  if (typeof auth === "string" && auth.startsWith("Bearer ")) return auth.slice(7);
+  const header = req.headers["x-dashboard-token"];
+  if (typeof header === "string" && header) return header;
+  return null;
+}
+
 function extractHookToken(req) {
   const hookHeader = req.headers["x-ccam-hook-token"];
   if (typeof hookHeader === "string" && hookHeader) return hookHeader;
@@ -231,5 +248,6 @@ module.exports = {
   // exported for tests
   tokensMatch,
   extractToken,
+  extractHeaderOnlyToken,
   extractHookToken,
 };

--- a/server/openapi.js
+++ b/server/openapi.js
@@ -2254,6 +2254,169 @@ function createOpenApiSpec() {
           },
         },
       },
+      "/api/hooks/ingest-batch": {
+        post: {
+          tags: ["Hooks"],
+          summary: "Push a batch of session data from a roaming/NAT'd machine",
+          description:
+            "Third session-data ingestion path, alongside the local hook routes above and the SSH-pull remote-sync path (see /api/remote-sources). For a machine the dashboard can never reach to pull FROM, it pushes its own session data over HTTPS instead. Reachable from the public internet and disabled by default -- gated by its own REMOTE_PUSH_TOKEN, deliberately independent of DASHBOARD_HOOK_TOKEN (which protects the loopback-only routes above; setting that one must not also open this route as a side effect). Send the token as `Authorization: Bearer <token>`, `X-Dashboard-Token`, or `?token=`.",
+          operationId: "ingestRemotePushBatch",
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  required: ["session_id", "provider"],
+                  properties: {
+                    schema_version: {
+                      type: "integer",
+                      description:
+                        "Must equal this server's current wire-format version (1) when present. A mismatch is a whole-request 409, not a per-item soft-fail.",
+                    },
+                    session_id: { type: "string" },
+                    provider: { type: "string", enum: ["claude", "codex"] },
+                    session_name: {
+                      type: "string",
+                      description:
+                        "Defaults to 'Session <first 8 chars of session_id>' for a brand-new session.",
+                    },
+                    cwd: { type: "string" },
+                    model: { type: "string" },
+                    tokens: {
+                      type: "array",
+                      description:
+                        "Each entry is a bucket's FULL current total (like a transcript re-parse), not a delta.",
+                      items: {
+                        type: "object",
+                        required: ["model"],
+                        properties: {
+                          model: { type: "string" },
+                          speed: { type: "string" },
+                          inference_geo: { type: "string" },
+                          service_tier: { type: "string" },
+                          input: { type: "integer", minimum: 0 },
+                          output: { type: "integer", minimum: 0 },
+                          cacheRead: { type: "integer", minimum: 0 },
+                          cacheWrite: { type: "integer", minimum: 0 },
+                          cacheWrite1h: {
+                            type: "integer",
+                            minimum: 0,
+                            description: "Must be <= cacheWrite.",
+                          },
+                          webSearch: { type: "integer", minimum: 0 },
+                          webFetch: { type: "integer", minimum: 0 },
+                          codeExec: { type: "integer", minimum: 0 },
+                        },
+                      },
+                    },
+                    tool_events: {
+                      type: "array",
+                      description:
+                        "Deduped by (session_id, event_type, uuid), across requests and within one batch.",
+                      items: {
+                        type: "object",
+                        required: ["uuid"],
+                        properties: {
+                          uuid: { type: "string" },
+                          agent_id: {
+                            type: "string",
+                            description: "Defaults to this session's main agent.",
+                          },
+                          tool_name: { type: "string" },
+                          status: { type: "string" },
+                          timestamp: {
+                            type: "string",
+                            format: "date-time",
+                            description: "Defaults to server 'now'.",
+                          },
+                        },
+                      },
+                    },
+                    turns: {
+                      type: "array",
+                      description: "Deduped the same way as tool_events.",
+                      items: {
+                        type: "object",
+                        required: ["uuid"],
+                        properties: {
+                          uuid: { type: "string" },
+                          agent_id: { type: "string" },
+                          duration_ms: { type: "integer", minimum: 0 },
+                          timestamp: { type: "string", format: "date-time" },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          responses: {
+            200: {
+              description:
+                "Batch processed (even when individual items were skipped/rejected -- see errors[]/skipped for partial-failure detail; the request itself still succeeds).",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    required: ["ok", "written", "skipped", "errors"],
+                    properties: {
+                      ok: { type: "boolean" },
+                      written: { type: "integer" },
+                      skipped: { type: "integer" },
+                      errors: {
+                        type: "array",
+                        items: {
+                          type: "object",
+                          properties: {
+                            item: { type: "string" },
+                            code: { type: "string" },
+                            message: { type: "string" },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            400: {
+              description:
+                "Missing session_id, invalid provider, or a per-item validation failure surfaced at the request level",
+              content: {
+                "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } },
+              },
+            },
+            401: {
+              description:
+                "REMOTE_PUSH_TOKEN is configured but the request's token is missing or wrong",
+              content: {
+                "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } },
+              },
+            },
+            403: { description: "Host header not allowed (see hostGuard)" },
+            409: {
+              description: "schema_version in the request doesn't match this server's",
+              content: {
+                "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } },
+              },
+            },
+            413: {
+              description: "tokens.length + tool_events.length + turns.length exceeds 1000",
+              content: {
+                "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } },
+              },
+            },
+            503: {
+              description: "REMOTE_PUSH_TOKEN is not configured at all -- the route is disabled",
+              content: {
+                "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } },
+              },
+            },
+          },
+        },
+      },
       "/api/pricing": {
         get: {
           tags: ["Pricing"],

--- a/server/openapi.js
+++ b/server/openapi.js
@@ -2259,7 +2259,7 @@ function createOpenApiSpec() {
           tags: ["Hooks"],
           summary: "Push a batch of session data from a roaming/NAT'd machine",
           description:
-            "Third session-data ingestion path, alongside the local hook routes above and the SSH-pull remote-sync path (see /api/remote-sources). For a machine the dashboard can never reach to pull FROM, it pushes its own session data over HTTPS instead. Reachable from the public internet and disabled by default -- gated by its own REMOTE_PUSH_TOKEN, deliberately independent of DASHBOARD_HOOK_TOKEN (which protects the loopback-only routes above; setting that one must not also open this route as a side effect). Send the token as `Authorization: Bearer <token>`, `X-Dashboard-Token`, or `?token=`.",
+            "Third session-data ingestion path, alongside the local hook routes above and the SSH-pull remote-sync path (see /api/remote-sources). For a machine the dashboard can never reach to pull FROM, it pushes its own session data over HTTPS instead. Reachable from the public internet and disabled by default -- gated by its own REMOTE_PUSH_TOKEN, deliberately independent of DASHBOARD_HOOK_TOKEN (which protects the loopback-only routes above; setting that one must not also open this route as a side effect). Send the token as `Authorization: Bearer <token>` or `X-Dashboard-Token` -- deliberately not `?token=`, which would end up in access/proxy logs on a public-internet route.",
           operationId: "ingestRemotePushBatch",
           requestBody: {
             required: true,

--- a/server/routes/hooks.js
+++ b/server/routes/hooks.js
@@ -1793,7 +1793,11 @@ function coerceNonNegativeInt(value) {
   if (
     typeof value !== "number" ||
     !Number.isFinite(value) ||
-    !Number.isInteger(value) ||
+    // isSafeInteger, not isInteger: a value beyond +/-2^53 can still pass
+    // isInteger after JSON parsing rounds it to the nearest representable
+    // double, silently corrupting the token/duration count it's supposed to
+    // validate.
+    !Number.isSafeInteger(value) ||
     value < 0
   ) {
     return { ok: false };

--- a/server/routes/hooks.js
+++ b/server/routes/hooks.js
@@ -18,7 +18,7 @@ const { ingestWorkflowsForSession } = require("../lib/workflow-ingest");
 // Required as a module object (not destructured) so tests can swap
 // `liveness.probeLiveCwds` and the watchdog picks the stub up at call time.
 const liveness = require("../lib/session-liveness");
-const { getRemotePushToken, extractToken, tokensMatch } = require("../lib/security");
+const { getRemotePushToken, extractHeaderOnlyToken, tokensMatch } = require("../lib/security");
 const { REMOTE_PROVIDERS, assertProvider } = require("../lib/remote-sync");
 const { normalizeSpeed, normalizeGeo, normalizeTier } = require("../lib/token-usage");
 
@@ -1794,6 +1794,18 @@ function itemError(item, code, message) {
   return { item, code, message };
 }
 
+// Any non-empty string was accepted as a uuid before this (CodeRabbit review
+// on PR #329) -- e.g. "not-a-uuid" was persisted and reported as written,
+// even though the dedup contract (dedupEventStmt) is documented as keying on
+// a real uuid. Deliberately permissive on version/variant nibbles (accepts
+// any RFC 4122-shaped value, not just v4) -- this is an identifier/dedup key
+// from a remote client, not a value this server generates itself.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function isUuid(value) {
+  return typeof value === "string" && UUID_RE.test(value);
+}
+
 /**
  * Non-negative safe-integer coercion for a present-but-optional numeric
  * field. Absent/null => 0 (mirrors the local hook's tokens.field || 0
@@ -1846,7 +1858,10 @@ router.post("/ingest-batch", (req, res) => {
       },
     });
   }
-  if (!tokensMatch(extractToken(req), expectedToken)) {
+  // Header-only extraction (never req.query.token) -- this route is public-
+  // internet-reachable, and a query-string credential ends up in server/proxy
+  // access logs (CodeRabbit review).
+  if (!tokensMatch(extractHeaderOnlyToken(req), expectedToken)) {
     return res.status(401).json({
       error: { code: "EUNAUTHORIZED", message: "missing or invalid remote-push token" },
     });
@@ -2029,6 +2044,10 @@ router.post("/ingest-batch", (req, res) => {
       errors.push(itemError(label, "INVALID_INPUT", "uuid is required"));
       return;
     }
+    if (!isUuid(ev.uuid)) {
+      errors.push(itemError(label, "INVALID_UUID", "uuid must be a valid UUID"));
+      return;
+    }
     const agentRes = resolveAgentId(ev.agent_id, label);
     if (!agentRes.ok) return;
     const tsRes = coerceTimestamp(ev.timestamp);
@@ -2060,6 +2079,10 @@ router.post("/ingest-batch", (req, res) => {
     const label = `turns[${i}]`;
     if (!t || typeof t !== "object" || typeof t.uuid !== "string" || !t.uuid) {
       errors.push(itemError(label, "INVALID_INPUT", "uuid is required"));
+      return;
+    }
+    if (!isUuid(t.uuid)) {
+      errors.push(itemError(label, "INVALID_UUID", "uuid must be a valid UUID"));
       return;
     }
     const agentRes = resolveAgentId(t.agent_id, label);

--- a/server/routes/hooks.js
+++ b/server/routes/hooks.js
@@ -1746,6 +1746,13 @@ const REMOTE_PUSH_SOURCE = "remote_push";
 // on the payload shape itself.
 const INGEST_BATCH_SCHEMA_VERSION = 1;
 
+// This route is externally reachable (public internet via Traefik). Without
+// a combined item cap, a valid token holder could submit one huge batch and
+// force O(items) synchronous SQLite work plus O(items × connected clients)
+// WebSocket fan-out in a single request. Reject outright, before any other
+// validation/DB work, rather than accepting and later choking on it.
+const MAX_INGEST_BATCH_ITEMS = 1000;
+
 const REMOTE_TOOL_EVENT_TYPE = "RemoteToolEvent";
 const REMOTE_TURN_EVENT_TYPE = "RemoteTurn";
 
@@ -1854,6 +1861,12 @@ router.post("/ingest-batch", (req, res) => {
   const tokens = Array.isArray(body.tokens) ? body.tokens : [];
   const toolEvents = Array.isArray(body.tool_events) ? body.tool_events : [];
   const turns = Array.isArray(body.turns) ? body.turns : [];
+
+  if (tokens.length + toolEvents.length + turns.length > MAX_INGEST_BATCH_ITEMS) {
+    return res.status(413).json({
+      error: { code: "BATCH_TOO_LARGE", message: `batch exceeds ${MAX_INGEST_BATCH_ITEMS} items` },
+    });
+  }
 
   const mainAgentId = `${sessionId}-main`;
   const existing = stmts.getSession.get(sessionId);

--- a/server/routes/hooks.js
+++ b/server/routes/hooks.js
@@ -18,6 +18,9 @@ const { ingestWorkflowsForSession } = require("../lib/workflow-ingest");
 // Required as a module object (not destructured) so tests can swap
 // `liveness.probeLiveCwds` and the watchdog picks the stub up at call time.
 const liveness = require("../lib/session-liveness");
+const { getHookToken } = require("../lib/security");
+const { REMOTE_PROVIDERS, assertProvider } = require("../lib/remote-sync");
+const { normalizeSpeed, normalizeGeo, normalizeTier } = require("../lib/token-usage");
 
 const router = Router();
 
@@ -1713,6 +1716,466 @@ function livenessReap({ ignoreIdleGate = false, provider = "claude" } = {}) {
     );
   }
 }
+
+// ── POST /api/hooks/ingest-batch ────────────────────────────────────────────
+// Third ingestion path (see server/lib/remote-sync.js for the other two: the
+// local hook POSTs above, and the SSH-pull path in remote-sync.js). This one
+// is for a roaming/NAT'd machine the dashboard can never reach to pull FROM —
+// it pushes a batch of its own session data to us instead, over HTTPS.
+//
+// Two things make this route different from every other route in this file:
+//   1. It is reachable from the public internet via Traefik, not loopback —
+//      so unlike the local hook routes above (which rely on hookGuard being a
+//      no-op + loopback bind), this route refuses to run at all unless a real
+//      DASHBOARD_HOOK_TOKEN is configured (503, not a silent accept).
+//   2. A pushed session_id is caller-supplied and could collide (by accident
+//      or by a malicious remote) with a session this dashboard's OWN local
+//      hook is actively managing. Ownership is decided from the session
+//      row's stored `source` column — set once, authoritatively, by whichever
+//      path created the row first — and NEVER from anything in the request.
+
+// Sentinel `sessions.source` for rows created by this route. remote_sources
+// ids (server/routes/remote-sources.js) are always `src_` + 12 lowercase hex
+// characters (`src_${crypto.randomBytes(6).toString("hex")}`) — this sentinel
+// carries no `src_` prefix, so it can never collide with a real configured
+// SSH source id, now or in the future (the id format is fixed at creation).
+const REMOTE_PUSH_SOURCE = "remote_push";
+
+// Bump only on a real wire-format break. A mismatch is a whole-request 409 —
+// per-item soft-fail doesn't make sense when the client and server disagree
+// on the payload shape itself.
+const INGEST_BATCH_SCHEMA_VERSION = 1;
+
+const REMOTE_TOOL_EVENT_TYPE = "RemoteToolEvent";
+const REMOTE_TURN_EVENT_TYPE = "RemoteTurn";
+
+// Numeric fields on a tokens[] entry — see coerceNonNegativeInt.
+const TOKEN_NUMERIC_FIELDS = [
+  "input",
+  "output",
+  "cacheRead",
+  "cacheWrite",
+  "cacheWrite1h",
+  "webSearch",
+  "webFetch",
+  "codeExec",
+];
+
+// Mirrors the partial index idx_events_session_type_uuid (server/db.js): the
+// WHERE clause must repeat json_valid(data) = 1 literally for SQLite to use a
+// partial index, and it's required for correctness (json_extract throws on a
+// non-JSON row) independent of the index.
+const dedupEventStmt = db.prepare(
+  `SELECT 1 FROM events
+   WHERE session_id = ? AND event_type = ? AND json_valid(data) = 1
+     AND json_extract(data, '$.uuid') = ? LIMIT 1`
+);
+
+function itemError(item, code, message) {
+  return { item, code, message };
+}
+
+/**
+ * Non-negative safe-integer coercion for a present-but-optional numeric
+ * field. Absent/null => 0 (mirrors the local hook's tokens.field || 0
+ * convention); present-but-invalid (negative, fractional, non-finite, wrong
+ * type) => rejected so the caller can build a per-item error.
+ */
+function coerceNonNegativeInt(value) {
+  if (value === undefined || value === null) return { ok: true, value: 0 };
+  if (
+    typeof value !== "number" ||
+    !Number.isFinite(value) ||
+    !Number.isInteger(value) ||
+    value < 0
+  ) {
+    return { ok: false };
+  }
+  return { ok: true, value };
+}
+
+/** Absent timestamp is fine (caller falls back to server "now"); present-but-
+ * unparseable is rejected. Returns a normalized (millisecond-precision) ISO
+ * string so the value written to created_at and the value broadcast over the
+ * WebSocket are byte-identical. */
+function coerceTimestamp(value) {
+  if (value === undefined || value === null) return { ok: true, value: null };
+  if (typeof value !== "string") return { ok: false };
+  const ms = Date.parse(value);
+  if (Number.isNaN(ms)) return { ok: false };
+  return { ok: true, value: new Date(ms).toISOString() };
+}
+
+router.post("/ingest-batch", (req, res) => {
+  // Additional, stricter gate on top of hookGuard (server/index.js): hookGuard
+  // is a deliberate no-op when no DASHBOARD_HOOK_TOKEN is configured (fine for
+  // the loopback-only local hook above); this route is reachable from the
+  // public internet, so an unconfigured token must refuse outright rather
+  // than silently accept unauthenticated writes.
+  if (!getHookToken()) {
+    return res.status(503).json({
+      error: {
+        code: "HOOK_TOKEN_NOT_CONFIGURED",
+        message: "remote ingestion is not configured",
+      },
+    });
+  }
+
+  const body = req.body && typeof req.body === "object" && !Array.isArray(req.body) ? req.body : {};
+
+  if (body.schema_version !== undefined && body.schema_version !== INGEST_BATCH_SCHEMA_VERSION) {
+    return res.status(409).json({
+      error: {
+        code: "SCHEMA_VERSION_MISMATCH",
+        message: `this server speaks schema_version ${INGEST_BATCH_SCHEMA_VERSION}, request carried ${body.schema_version}`,
+      },
+    });
+  }
+
+  const sessionId = typeof body.session_id === "string" ? body.session_id.trim() : "";
+  if (!sessionId) {
+    return res
+      .status(400)
+      .json({ error: { code: "INVALID_INPUT", message: "session_id is required" } });
+  }
+
+  try {
+    assertProvider(body.provider);
+  } catch {
+    return res.status(400).json({
+      error: {
+        code: "INVALID_PROVIDER",
+        message: `provider must be one of: ${REMOTE_PROVIDERS.join(", ")}`,
+      },
+    });
+  }
+  const provider = body.provider;
+
+  const tokens = Array.isArray(body.tokens) ? body.tokens : [];
+  const toolEvents = Array.isArray(body.tool_events) ? body.tool_events : [];
+  const turns = Array.isArray(body.turns) ? body.turns : [];
+
+  const mainAgentId = `${sessionId}-main`;
+  const existing = stmts.getSession.get(sessionId);
+
+  // ── Ownership gate ─────────────────────────────────────────────────────
+  // A session already owned by anything OTHER than this route's own sentinel
+  // (source='local', or a real remote_sources id from the SSH-pull path) can
+  // NEVER be written to from here — a remote caller must not be able to
+  // hijack a locally-managed session by guessing/reusing its id. Every item
+  // in the batch targets this one session_id (see payload shape), so the
+  // per-item-not-per-request soft-fail contract collapses to "reject every
+  // item" here, but is expressed per item so the response shape stays
+  // uniform with every other rejection reason.
+  if (existing && existing.source !== REMOTE_PUSH_SOURCE) {
+    const errors = [];
+    tokens.forEach((_t, i) =>
+      errors.push(
+        itemError(
+          `tokens[${i}]`,
+          "SESSION_LOCALLY_OWNED",
+          `session ${sessionId} is not remote-push owned`
+        )
+      )
+    );
+    toolEvents.forEach((_e, i) =>
+      errors.push(
+        itemError(
+          `tool_events[${i}]`,
+          "SESSION_LOCALLY_OWNED",
+          `session ${sessionId} is not remote-push owned`
+        )
+      )
+    );
+    turns.forEach((_t, i) =>
+      errors.push(
+        itemError(
+          `turns[${i}]`,
+          "SESSION_LOCALLY_OWNED",
+          `session ${sessionId} is not remote-push owned`
+        )
+      )
+    );
+    return res.json({ ok: true, written: 0, skipped: 0, errors });
+  }
+
+  // ── Validation (no DB writes yet) ────────────────────────────────────────
+  const errors = [];
+  let skipped = 0;
+  const validTokens = [];
+  const validToolEvents = [];
+  const validTurns = [];
+  // In-request dedup: the DB-backed dedup check below only sees rows already
+  // committed from a PRIOR request. Two items with the same (event_type,
+  // uuid) inside THIS SAME batch would both pass that check and both insert,
+  // so track what this batch has already accepted for insertion too.
+  const seenInBatch = new Set();
+
+  /**
+   * Resolve agent_id (or the session's main agent when absent). The main
+   * agent is intentionally accepted without a DB lookup here: for a brand
+   * new session it doesn't exist yet (created inside the write transaction
+   * below), and for an existing session whose main-agent row was somehow
+   * lost, the write transaction ensures it exists before any event
+   * referencing it is inserted — either way agent_id === mainAgentId is
+   * always safe to accept at validation time.
+   */
+  function resolveAgentId(rawAgentId, label) {
+    if (rawAgentId === undefined || rawAgentId === null || rawAgentId === "") {
+      return { ok: true, agentId: mainAgentId };
+    }
+    if (typeof rawAgentId !== "string") {
+      errors.push(itemError(label, "INVALID_AGENT_ID", "agent_id must be a string"));
+      return { ok: false };
+    }
+    if (rawAgentId === mainAgentId) {
+      return { ok: true, agentId: mainAgentId };
+    }
+    const agent = stmts.getAgent.get(rawAgentId);
+    if (!agent || agent.session_id !== sessionId) {
+      errors.push(
+        itemError(label, "UNKNOWN_AGENT", `agent_id does not belong to session ${sessionId}`)
+      );
+      return { ok: false };
+    }
+    return { ok: true, agentId: rawAgentId };
+  }
+
+  tokens.forEach((t, i) => {
+    const label = `tokens[${i}]`;
+    if (!t || typeof t !== "object" || typeof t.model !== "string" || !t.model) {
+      errors.push(itemError(label, "INVALID_INPUT", "model is required"));
+      return;
+    }
+    const values = {};
+    let invalidField = null;
+    for (const key of TOKEN_NUMERIC_FIELDS) {
+      const r = coerceNonNegativeInt(t[key]);
+      if (!r.ok) {
+        invalidField = key;
+        break;
+      }
+      values[key] = r.value;
+    }
+    if (invalidField) {
+      errors.push(
+        itemError(label, "INVALID_NUMERIC", `${invalidField} must be a non-negative integer`)
+      );
+      return;
+    }
+    if (values.cacheWrite1h > values.cacheWrite) {
+      errors.push(
+        itemError(label, "CACHE_WRITE_1H_EXCEEDS_TOTAL", "cacheWrite1h must be <= cacheWrite")
+      );
+      return;
+    }
+    validTokens.push({
+      model: t.model,
+      // Bucket-pricing dimensions: pass through the same normalizers the
+      // local transcript-derived path uses (server/lib/token-usage.js) —
+      // never store a raw client-supplied value. Note this route mirrors the
+      // local hook's cumulative-per-bucket-totals contract: each tokens[]
+      // entry is the bucket's FULL current total (like a transcript re-parse),
+      // not a delta — replaceTokenUsage below is a high-water-mark REPLACE,
+      // not an additive upsert, so a client sending deltas would silently
+      // under-count.
+      speed: normalizeSpeed({ speed: t.speed }),
+      geo: normalizeGeo({ inference_geo: t.inference_geo }),
+      tier: normalizeTier({ service_tier: t.service_tier }),
+      ...values,
+    });
+  });
+
+  toolEvents.forEach((ev, i) => {
+    const label = `tool_events[${i}]`;
+    if (!ev || typeof ev !== "object" || typeof ev.uuid !== "string" || !ev.uuid) {
+      errors.push(itemError(label, "INVALID_INPUT", "uuid is required"));
+      return;
+    }
+    const agentRes = resolveAgentId(ev.agent_id, label);
+    if (!agentRes.ok) return;
+    const tsRes = coerceTimestamp(ev.timestamp);
+    if (!tsRes.ok) {
+      errors.push(
+        itemError(label, "INVALID_TIMESTAMP", "timestamp must be a valid ISO date string")
+      );
+      return;
+    }
+    const dedupKey = `${REMOTE_TOOL_EVENT_TYPE} ${ev.uuid}`;
+    if (
+      seenInBatch.has(dedupKey) ||
+      dedupEventStmt.get(sessionId, REMOTE_TOOL_EVENT_TYPE, ev.uuid)
+    ) {
+      skipped++;
+      return;
+    }
+    seenInBatch.add(dedupKey);
+    validToolEvents.push({
+      uuid: ev.uuid,
+      agentId: agentRes.agentId,
+      toolName: typeof ev.tool_name === "string" && ev.tool_name ? ev.tool_name : null,
+      status: typeof ev.status === "string" && ev.status ? ev.status : null,
+      timestamp: tsRes.value,
+    });
+  });
+
+  turns.forEach((t, i) => {
+    const label = `turns[${i}]`;
+    if (!t || typeof t !== "object" || typeof t.uuid !== "string" || !t.uuid) {
+      errors.push(itemError(label, "INVALID_INPUT", "uuid is required"));
+      return;
+    }
+    const agentRes = resolveAgentId(t.agent_id, label);
+    if (!agentRes.ok) return;
+    const durRes = coerceNonNegativeInt(t.duration_ms);
+    if (!durRes.ok) {
+      errors.push(
+        itemError(label, "INVALID_NUMERIC", "duration_ms must be a non-negative integer")
+      );
+      return;
+    }
+    const tsRes = coerceTimestamp(t.timestamp);
+    if (!tsRes.ok) {
+      errors.push(
+        itemError(label, "INVALID_TIMESTAMP", "timestamp must be a valid ISO date string")
+      );
+      return;
+    }
+    const dedupKey = `${REMOTE_TURN_EVENT_TYPE} ${t.uuid}`;
+    if (
+      seenInBatch.has(dedupKey) ||
+      dedupEventStmt.get(sessionId, REMOTE_TURN_EVENT_TYPE, t.uuid)
+    ) {
+      skipped++;
+      return;
+    }
+    seenInBatch.add(dedupKey);
+    validTurns.push({
+      uuid: t.uuid,
+      agentId: agentRes.agentId,
+      durationMs: durRes.value,
+      timestamp: tsRes.value,
+    });
+  });
+
+  // ── Write phase: valid items only, one transaction for atomicity ────────
+  const writeBatch = db.transaction(() => {
+    let session = existing;
+    if (!session) {
+      const sessionName =
+        typeof body.session_name === "string" && body.session_name
+          ? body.session_name
+          : `Session ${sessionId.slice(0, 8)}`;
+      db.prepare(
+        `INSERT INTO sessions (id, name, status, cwd, model, provider, source, started_at, updated_at)
+         VALUES (?, ?, 'active', ?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'), strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`
+      ).run(
+        sessionId,
+        sessionName,
+        typeof body.cwd === "string" && body.cwd ? body.cwd : null,
+        typeof body.model === "string" && body.model ? body.model : null,
+        provider,
+        REMOTE_PUSH_SOURCE
+      );
+      session = stmts.getSession.get(sessionId);
+      broadcast("session_created", session);
+    }
+
+    // Ensure the main agent row exists before any event below references it —
+    // covers both "brand new session" and the rarer "existing remote_push
+    // session whose main-agent row was lost" case. events.agent_id is a
+    // FOREIGN KEY; inserting against a missing agent throws and would roll
+    // back every valid item in this batch (see codex-ingest.js's identical
+    // guard + server/__tests__/codex-ingest.test.js "still records the turn
+    // when the main agent row is missing").
+    if (!stmts.getAgent.get(mainAgentId)) {
+      stmts.insertAgent.run(
+        mainAgentId,
+        sessionId,
+        `Main Agent - ${session.name || `Session ${sessionId.slice(0, 8)}`}`,
+        "main",
+        null,
+        "working",
+        null,
+        null,
+        null
+      );
+      const mainAgent = stmts.getAgent.get(mainAgentId);
+      if (mainAgent) broadcast("agent_created", mainAgent);
+    }
+
+    for (const tk of validTokens) {
+      stmts.replaceTokenUsage.run(
+        sessionId,
+        tk.model,
+        tk.speed,
+        tk.geo,
+        tk.tier,
+        tk.input,
+        tk.output,
+        tk.cacheRead,
+        tk.cacheWrite,
+        tk.cacheWrite1h,
+        tk.webSearch,
+        tk.webFetch,
+        tk.codeExec
+      );
+    }
+
+    for (const ev of validToolEvents) {
+      const ts = ev.timestamp || new Date().toISOString();
+      const summary = ev.toolName ? `Called ${ev.toolName}` : "Remote tool event";
+      stmts.insertEventAt.run(
+        sessionId,
+        ev.agentId,
+        REMOTE_TOOL_EVENT_TYPE,
+        ev.toolName,
+        summary,
+        JSON.stringify({ uuid: ev.uuid, status: ev.status }),
+        ts
+      );
+      broadcast("new_event", {
+        session_id: sessionId,
+        agent_id: ev.agentId,
+        event_type: REMOTE_TOOL_EVENT_TYPE,
+        tool_name: ev.toolName,
+        summary,
+        created_at: ts,
+      });
+    }
+
+    for (const t of validTurns) {
+      const ts = t.timestamp || new Date().toISOString();
+      const summary = "Remote turn";
+      stmts.insertEventAt.run(
+        sessionId,
+        t.agentId,
+        REMOTE_TURN_EVENT_TYPE,
+        null,
+        summary,
+        JSON.stringify({ uuid: t.uuid, duration_ms: t.durationMs }),
+        ts
+      );
+      broadcast("new_event", {
+        session_id: sessionId,
+        agent_id: t.agentId,
+        event_type: REMOTE_TURN_EVENT_TYPE,
+        tool_name: null,
+        summary,
+        created_at: ts,
+      });
+    }
+  });
+
+  writeBatch();
+
+  res.json({
+    ok: true,
+    written: validTokens.length + validToolEvents.length + validTurns.length,
+    skipped,
+    errors,
+  });
+});
 
 const watchdogTimer = setInterval(watchdogCheck, WATCHDOG_INTERVAL_MS);
 // Don't keep the process alive just for the watchdog

--- a/server/routes/hooks.js
+++ b/server/routes/hooks.js
@@ -2059,6 +2059,14 @@ router.post("/ingest-batch", (req, res) => {
   });
 
   // ── Write phase: valid items only, one transaction for atomicity ────────
+  // Broadcasts are collected here and flushed only AFTER writeBatch() returns
+  // successfully (see the file's own "do all DB writes BEFORE any broadcast"
+  // rule above) -- emitting them from inside the transaction would let a
+  // later statement's throw roll back every insert while clients had already
+  // been told about a session/event that turns out not to exist (e.g. a
+  // concurrent delete of a resolved agent_id row between validation and the
+  // write causes insertEventAt to fail its FOREIGN KEY and abort the batch).
+  const pendingBroadcasts = [];
   const writeBatch = db.transaction(() => {
     let session = existing;
     if (!session) {
@@ -2078,7 +2086,7 @@ router.post("/ingest-batch", (req, res) => {
         REMOTE_PUSH_SOURCE
       );
       session = stmts.getSession.get(sessionId);
-      broadcast("session_created", session);
+      pendingBroadcasts.push(["session_created", session]);
     }
 
     // Ensure the main agent row exists before any event below references it —
@@ -2101,7 +2109,7 @@ router.post("/ingest-batch", (req, res) => {
         null
       );
       const mainAgent = stmts.getAgent.get(mainAgentId);
-      if (mainAgent) broadcast("agent_created", mainAgent);
+      if (mainAgent) pendingBroadcasts.push(["agent_created", mainAgent]);
     }
 
     for (const tk of validTokens) {
@@ -2134,14 +2142,17 @@ router.post("/ingest-batch", (req, res) => {
         JSON.stringify({ uuid: ev.uuid, status: ev.status }),
         ts
       );
-      broadcast("new_event", {
-        session_id: sessionId,
-        agent_id: ev.agentId,
-        event_type: REMOTE_TOOL_EVENT_TYPE,
-        tool_name: ev.toolName,
-        summary,
-        created_at: ts,
-      });
+      pendingBroadcasts.push([
+        "new_event",
+        {
+          session_id: sessionId,
+          agent_id: ev.agentId,
+          event_type: REMOTE_TOOL_EVENT_TYPE,
+          tool_name: ev.toolName,
+          summary,
+          created_at: ts,
+        },
+      ]);
     }
 
     for (const t of validTurns) {
@@ -2156,18 +2167,33 @@ router.post("/ingest-batch", (req, res) => {
         JSON.stringify({ uuid: t.uuid, duration_ms: t.durationMs }),
         ts
       );
-      broadcast("new_event", {
-        session_id: sessionId,
-        agent_id: t.agentId,
-        event_type: REMOTE_TURN_EVENT_TYPE,
-        tool_name: null,
-        summary,
-        created_at: ts,
-      });
+      pendingBroadcasts.push([
+        "new_event",
+        {
+          session_id: sessionId,
+          agent_id: t.agentId,
+          event_type: REMOTE_TURN_EVENT_TYPE,
+          tool_name: null,
+          summary,
+          created_at: ts,
+        },
+      ]);
     }
   });
 
-  writeBatch();
+  try {
+    writeBatch();
+  } catch (err) {
+    console.error(`[HOOKS] ingest-batch write failed for session ${sessionId}:`, err);
+    return res.status(500).json({
+      error: {
+        code: "WRITE_FAILED",
+        message: "batch write failed and was rolled back",
+      },
+    });
+  }
+
+  for (const [type, payload] of pendingBroadcasts) broadcast(type, payload);
 
   res.json({
     ok: true,

--- a/server/routes/hooks.js
+++ b/server/routes/hooks.js
@@ -18,7 +18,7 @@ const { ingestWorkflowsForSession } = require("../lib/workflow-ingest");
 // Required as a module object (not destructured) so tests can swap
 // `liveness.probeLiveCwds` and the watchdog picks the stub up at call time.
 const liveness = require("../lib/session-liveness");
-const { getHookToken } = require("../lib/security");
+const { getRemotePushToken, extractToken, tokensMatch } = require("../lib/security");
 const { REMOTE_PROVIDERS, assertProvider } = require("../lib/remote-sync");
 const { normalizeSpeed, normalizeGeo, normalizeTier } = require("../lib/token-usage");
 
@@ -1726,8 +1726,15 @@ function livenessReap({ ignoreIdleGate = false, provider = "claude" } = {}) {
 // Two things make this route different from every other route in this file:
 //   1. It is reachable from the public internet via Traefik, not loopback —
 //      so unlike the local hook routes above (which rely on hookGuard being a
-//      no-op + loopback bind), this route refuses to run at all unless a real
-//      DASHBOARD_HOOK_TOKEN is configured (503, not a silent accept).
+//      no-op + loopback bind), this route refuses to run at all unless its
+//      OWN REMOTE_PUSH_TOKEN is configured (503, not a silent accept), and
+//      every request must present it as a bearer/x-dashboard-token/?token=
+//      match (401 otherwise). Deliberately NOT DASHBOARD_HOOK_TOKEN: that
+//      token exists to harden the LOOPBACK-only local hook above, and an
+//      operator who sets it for that reason alone must not thereby also open
+//      an internet-writable session endpoint they never opted into (roaming
+//      laptop threat model — losing it shouldn't compromise everything under
+//      /api/hooks). See getRemotePushToken() in lib/security.js.
 //   2. A pushed session_id is caller-supplied and could collide (by accident
 //      or by a malicious remote) with a session this dashboard's OWN local
 //      hook is actively managing. Ownership is decided from the session
@@ -1769,12 +1776,17 @@ const TOKEN_NUMERIC_FIELDS = [
 ];
 
 // Mirrors the partial index idx_events_session_type_uuid (server/db.js): the
-// WHERE clause must repeat json_valid(data) = 1 literally for SQLite to use a
-// partial index, and it's required for correctness (json_extract throws on a
-// non-JSON row) independent of the index.
+// WHERE clause must repeat json_valid(data) = 1 AND the event_type IN (...)
+// list literally for SQLite to use the (now-narrowed) partial index -- a bare
+// `event_type = ?` parameter is not provably within the IN-list to the query
+// planner, so it falls back to a full events scan otherwise (checked against
+// EXPLAIN QUERY PLAN). The json_valid guard is also required for correctness
+// (json_extract throws on a non-JSON row) independent of the index. Keep this
+// IN list identical to the index's own predicate in server/db.js.
 const dedupEventStmt = db.prepare(
   `SELECT 1 FROM events
    WHERE session_id = ? AND event_type = ? AND json_valid(data) = 1
+     AND event_type IN ('${REMOTE_TOOL_EVENT_TYPE}', '${REMOTE_TURN_EVENT_TYPE}')
      AND json_extract(data, '$.uuid') = ? LIMIT 1`
 );
 
@@ -1818,17 +1830,25 @@ function coerceTimestamp(value) {
 }
 
 router.post("/ingest-batch", (req, res) => {
-  // Additional, stricter gate on top of hookGuard (server/index.js): hookGuard
-  // is a deliberate no-op when no DASHBOARD_HOOK_TOKEN is configured (fine for
-  // the loopback-only local hook above); this route is reachable from the
-  // public internet, so an unconfigured token must refuse outright rather
-  // than silently accept unauthenticated writes.
-  if (!getHookToken()) {
+  // Own gate, independent of hookGuard (server/index.js) and its
+  // DASHBOARD_HOOK_TOKEN: hookGuard no-ops when that token is unset (fine for
+  // the loopback-only local hook above, wrong for a route reachable from the
+  // public internet), and even when it IS set, reusing it here would silently
+  // widen what that token protects beyond what an operator configuring it for
+  // the local hook opted into. An unconfigured REMOTE_PUSH_TOKEN must refuse
+  // outright rather than silently accept unauthenticated writes.
+  const expectedToken = getRemotePushToken();
+  if (!expectedToken) {
     return res.status(503).json({
       error: {
-        code: "HOOK_TOKEN_NOT_CONFIGURED",
-        message: "remote ingestion is not configured",
+        code: "REMOTE_PUSH_NOT_CONFIGURED",
+        message: "remote push ingestion is not enabled",
       },
+    });
+  }
+  if (!tokensMatch(extractToken(req), expectedToken)) {
+    return res.status(401).json({
+      error: { code: "EUNAUTHORIZED", message: "missing or invalid remote-push token" },
     });
   }
 


### PR DESCRIPTION
Re-scoped, from-scratch rebuild of #321 after the requested-changes review (2026-09-07) -- not a rebase of that branch. #321 is left open/untouched; this is a clean new PR against current master, same pattern as #325.

## Why a rebuild instead of a rebase

#321 was 312 commits behind master by the time of review. Two of its bundled changes (the background-subagent waiting guard, the complete session-list pricing projection) are already shipped on master independently. The rest was written against `LOCAL_TRANSCRIPT_OWNS_SESSION` and an unwired `DASHBOARD_HOOK_TOKEN`, neither of which matches current master (`hookGuard` is already fully wired in `server/index.js`; there was never a `LOCAL_TRANSCRIPT_OWNS_SESSION` concept on master to begin with). Rebasing 312 commits of drift for content that's mostly deletions wasn't worth it -- this PR builds only the part that's still needed: the batch-push route itself.

## What this adds

A third session-data ingestion path, alongside the local hook (loopback POSTs) and the SSH-pull `remote-sync.js` path. For a roaming/NAT'd machine the dashboard can never reach to pull *from* (a laptop that isn't always reachable), it pushes a batch of its own session data over HTTPS instead.

## Addressing each point from the #321 review

- **"Branch predates the DASHBOARD_HOOK_TOKEN trust boundary"** -- verified `hookGuard` is already live (`server/index.js:98`). This route adds a *stricter* gate on top: `hookGuard` is deliberately a no-op when no token is configured (correct for the loopback-only local hook), but this route is reachable from the public internet via Traefik, so it refuses to run at all (503) unless `DASHBOARD_HOOK_TOKEN` is actually configured.
- **Transcript-ownership bypass** -- ownership is decided from the session row's own stored `source` column, set once at creation, never from anything in the request. A pushed `session_id` can never hijack a locally-owned session. Sentinel `source='remote_push'` is provably collision-free against real `remote_sources` ids (always `src_`+12 hex).
- **Cross-session `agent_id` / whole-batch rollback on a bad id** -- `agent_id` is validated against the target session before use; an unknown or foreign-session id is a per-item error, never a transaction-aborting throw.
- **Remote timestamp broadcast but not persisted** -- explicit timestamps are written into `created_at`, not just broadcast. Covered end-to-end with a real WebSocket client asserting the broadcast frame and the persisted row are byte-identical.
- **Unvalidated numeric fields** -- non-negative safe-integer validation on all token/duration fields; `cacheWrite1h <= cacheWrite` enforced.
- **Unnormalized pricing dimensions** -- reuses the existing `normalizeSpeed`/`normalizeGeo`/`normalizeTier` from `lib/token-usage.js` rather than storing raw client values. Token buckets always write `context_size='short'`, matching the local hook's own `replaceTokenUsage` contract exactly (there is no caller-supplied `context_size` anywhere in the codebase today, so this route doesn't invent one).
- **`json_extract` on legacy non-JSON `events.data` could crash startup** -- the new dedup index (`idx_events_session_type_uuid`) is a *partial* index guarded by `WHERE json_valid(data) = 1`, same convention as the existing `transcript_path` backfill migration.
- **`notification_type`-based idle-vs-actionable classification** -- out of scope here; verified it doesn't exist on master at all today, and it's a separate feature question from batch-ingestion itself.

## Tests

19 new tests (1 in `server/db.js`'s index regression test, 17 in `ingest-batch.test.js`), all through the real HTTP route via `createApp()`/`startServer()` -- not internal function calls, so Express-level auth/routing wiring is actually exercised. Explicit regression coverage for the ownership-hijack scenario (seeds a `source='local'` session, confirms a push attempt against it is rejected and DB state is untouched), the FK-hole case (main agent row lost, batch still writes instead of rolling back), cross-request and in-batch uuid dedup, and the WebSocket timestamp-parity case above.

```
node --test server/__tests__/*.test.js
# 1129 pass, 0 fail, 1 skip (pre-existing, unrelated)
```