### PR TITLE
perf(db): index events.tool_name so the analytics panel stops scanning

### DIFF
--- a/server/__tests__/events-tool-name-index.test.js
+++ b/server/__tests__/events-tool-name-index.test.js
@@ -1,0 +1,54 @@
+/**
+ * @file Guards the partial index behind the analytics tool-usage panel. That
+ * panel groups every event by `tool_name`; without an index on the column the
+ * group-by is a full events-table scan, and because SQLite access here is
+ * synchronous the whole server stalls while it runs — measured at 45.7s on a
+ * 3.9M-row table. This pins the query to a covering-index scan so a regression
+ * shows up as a failing plan rather than as a slow dashboard.
+ * @author Son Nguyen <hoangson091104@gmail.com>
+ */
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), `events-tool-index-${process.pid}-`));
+process.env.DASHBOARD_DB_PATH = path.join(TMP, "dashboard.db");
+
+const { db } = require("../db");
+
+describe("events.tool_name index", () => {
+  it("exists as a partial index over non-NULL tool names", () => {
+    const row = db
+      .prepare("SELECT sql FROM sqlite_master WHERE type = 'index' AND name = ?")
+      .get("idx_events_tool_name");
+    assert.ok(row, "idx_events_tool_name must exist");
+    assert.match(
+      row.sql,
+      /WHERE\s+tool_name\s+IS\s+NOT\s+NULL/i,
+      "the index must stay partial so it only covers tool events"
+    );
+  });
+
+  it("makes the analytics tool-usage group-by a covering index scan", () => {
+    const plan = db
+      .prepare(
+        `EXPLAIN QUERY PLAN
+         SELECT tool_name, COUNT(*) as count
+         FROM events
+         WHERE tool_name IS NOT NULL
+         GROUP BY tool_name
+         ORDER BY count DESC
+         LIMIT 20`
+      )
+      .all()
+      .map((step) => step.detail)
+      .join(" | ");
+    assert.ok(
+      plan.includes("COVERING INDEX idx_events_tool_name"),
+      `tool-usage counts must use idx_events_tool_name, got: ${plan}`
+    );
+  });
+});

--- a/server/db.js
+++ b/server/db.js
@@ -341,6 +341,13 @@ db.exec(`
   -- each agent/session on every list request.
   CREATE INDEX IF NOT EXISTS idx_events_agent_created ON events(agent_id, created_at);
   CREATE INDEX IF NOT EXISTS idx_events_session_created ON events(session_id, created_at);
+  -- The analytics tool-usage panel groups every event by tool_name. With no
+  -- index on that column it is a full events-table scan on every request, and
+  -- better-sqlite3 is synchronous, so the whole server stalls for its duration:
+  -- measured at 45.7s on a 3.9M-row events table. Only tool events carry a
+  -- tool_name, so a partial index stays small, and it makes the GROUP BY a
+  -- covering-index scan -- the same query then measured 0.25s.
+  CREATE INDEX IF NOT EXISTS idx_events_tool_name ON events(tool_name) WHERE tool_name IS NOT NULL;
   CREATE INDEX IF NOT EXISTS idx_agents_session_type ON agents(session_id, type);
   CREATE INDEX IF NOT EXISTS idx_dashboard_runs_started ON dashboard_runs(started_at DESC);
   CREATE INDEX IF NOT EXISTS idx_dashboard_runs_session ON dashboard_runs(session_id);


### PR DESCRIPTION
## Summary

The analytics tool-usage panel groups every row of `events` by `tool_name`, and
no index covers that column, so it is a full table scan on every request — 45.7s
on a 3.9M-row table here, with the single Node thread blocked for the duration.
A partial index over the non-NULL tool names takes the same query to 0.25s.

## Changes

- `server/db.js`: `CREATE INDEX IF NOT EXISTS idx_events_tool_name ON events(tool_name) WHERE tool_name IS NOT NULL`,
  in the existing schema block alongside the other `idx_events_*` indexes, with a
  comment in the same style explaining what it buys.
- `server/__tests__/events-tool-name-index.test.js`: asserts the index exists,
  stays partial, and that the panel's query plan is a covering-index scan.

### Measurement

On a 3,889,039-row `events` table:

```
SELECT tool_name, COUNT(*) FROM events
WHERE tool_name IS NOT NULL GROUP BY tool_name ORDER BY count DESC LIMIT 20

before : 45.75s
after  :  0.25s
```

Plan after the change:

```
SEARCH events USING COVERING INDEX idx_events_tool_name (tool_name>?)
```

Only tool events carry a `tool_name` — 156,959 of 3.9M rows on that install — so
the partial index stays a small fraction of the table. Building it on that table
took 15s, once, on the next start; `CREATE INDEX IF NOT EXISTS` means existing
databases pick it up without a migration step.

This is the same class as the composite indexes added in #320 for the agent and
session "last activity" subqueries (issue #319), whose comments make the same
argument: a scan of `events` on a synchronous connection stalls everything. That
PR covered `(agent_id, created_at)` and `(session_id, created_at)`; the
tool-usage grouping is the remaining unindexed full-table scan of `events` I
could find in the analytics path.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (no functional changes)
- [ ] Documentation update
- [x] Infrastructure / CI / DevOps
- [ ] Dependency update

## How to Test

```bash
node --test server/__tests__/events-tool-name-index.test.js
```

Both assertions fail on `master` (the index does not exist, and the plan is
`SCAN events`) and pass on this branch. The test pins the query plan rather than
a timing, so it stays meaningful on a small CI database.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/hoangsonww/Claude-Code-Agent-Monitor/blob/master/.github/CONTRIBUTING.md)
- [x] I have signed the [CLA](https://github.com/hoangsonww/Claude-Code-Agent-Monitor/blob/master/CLA.md)
- [x] My code follows the project's coding standards
- [x] I have added/updated tests that prove my fix or feature works
- [ ] The full local gate passes (`npm run verify`) — see the note below
- [x] Every source file I added or changed carries the authorship header (`npm run check:headers`)
- [x] Snapshot changes were reviewed rather than blindly regenerated
- [x] I have updated documentation where necessary
- [x] If this PR bumps the version, every release surface is synchronized (no bump)

**Note on the gate.** `npm run verify` returns exit 1 in my environment (macOS,
node 24.14.0) on unmodified `master` as well as on this branch, from one
timing-sensitive test: `server/__tests__/dev-server.test.js` → *"watches source
files created beneath a new directory"*. It passes in isolation on both, and the
failing set is identical before and after this change. `check:headers`,
`format:check` and `typecheck:client` pass.
